### PR TITLE
fix(maimai): 完成表 PR #37 后续 4 个小修补

### DIFF
--- a/Marisa.Frontend/src/assets/css/maimai/summary.pcss
+++ b/Marisa.Frontend/src/assets/css/maimai/summary.pcss
@@ -26,15 +26,16 @@
     max-width: none;
 }
 
-/* title-row / group-title 宽度等于 grid 内容宽 (8 cell × 120 + 7 gap × 40 = 1240px)，
-   stats-bar 永远靠右贴 grid 右边界，标题靠左 + flex shrink 处理过长情况。
-   不再让 stats-bar 跟着标题走，避免标题长就把统计条推出 grid 右边界。 */
+/* title-row / group-title 宽度 = grid 内容宽 + border-overflow (8 cell × 120 + 7 gap × 40 + 10 = 1250px)，
+   让 stats-bar 右沿对齐"带边框"的 grid 右边界 (cell 8 的 .border-img 比 cell 右沿外突出 10px)；
+   左沿仍贴 padding 内沿，因为标题靠左对齐看起来比 -10 偏移自然。
+   stats-bar 永远靠右贴这条带边框右边界，标题靠左 + flex shrink 处理过长情况。 */
 .title-row {
     display: flex;
     align-items: center;
     gap: 30px;
     margin-bottom: 20px;
-    width: calc(var(--col-count) * var(--cell-size) + (var(--col-count) - 1) * var(--cell-gap));
+    width: calc(var(--col-count) * var(--cell-size) + (var(--col-count) - 1) * var(--cell-gap) + var(--border-overflow));
 }
 
 .title {
@@ -70,7 +71,8 @@
     display: flex;
     align-items: center;
     gap: 6px;
-    width: calc(var(--col-count) * var(--cell-size) + (var(--col-count) - 1) * var(--cell-gap));
+    /* +border-overflow 与 .title-row 同理，让 group-stats 右沿对齐带边框 grid 右边界 */
+    width: calc(var(--col-count) * var(--cell-size) + (var(--col-count) - 1) * var(--cell-gap) + var(--border-overflow));
     position: relative;       /* 给 .min-rank-center 提供 absolute 锚点 */
 }
 

--- a/Marisa.Frontend/src/assets/css/maimai/summary.pcss
+++ b/Marisa.Frontend/src/assets/css/maimai/summary.pcss
@@ -167,7 +167,6 @@
     justify-content: center;
     padding-bottom: 5px;
     font-weight: bold;
-    font-style: italic;
     font-family: 'Consolas', 'Segoe UI', 'Arial Unicode MS Font', monospace;
     line-height: 1;
 }

--- a/Marisa.Frontend/src/components/maimai/Summary.vue
+++ b/Marisa.Frontend/src/components/maimai/Summary.vue
@@ -40,7 +40,7 @@ axios.all([
 const allCharts = computed(() => grouped.value.flatMap(g => g.x))
 
 // 标题字号按字符数自适应 — 防止长标题被 stats-bar 挤出而截断
-// grid 总宽 1240px - stats-bar 720px - gap 30px = 490px 给 title
+// title-row 总宽 1250px (grid 1240 + border-overflow 10) - stats-bar 720px - gap 30px = 500px 给 title
 const titleFontSize = computed(() => {
     const n = title.value?.length ?? 0
     if (n <= 5)  return '72px'   // 5×72=360

--- a/Marisa.Frontend/src/components/maimai/Summary.vue
+++ b/Marisa.Frontend/src/components/maimai/Summary.vue
@@ -150,11 +150,13 @@ function groupKeyColor(g: GroupedSong): string {
 }
 
 function groupMinRank(g: GroupedSong): string | null {
-    // 该组已打的歌中最低 ach 对应的 rank icon；跳过未打的歌
+    // 该组所有歌中最低 ach 对应的 rank icon。
+    // 任何一首未打过 (np / scores 字典里没条目) → 整组不显示 min-rank（朋友诉求：组内必须全打过才有意义）。
+    // 打过但 ach=0 仍算入（其 rank=d，min 会落到 d）。
     let minA = Infinity
     for (const s of g.x) {
         const sc = getScore(s.Item3.Id, s.Item2)
-        if (!sc) continue
+        if (!sc) return null
         if (sc.achievements < minA) minA = sc.achievements
     }
     if (!isFinite(minA)) return null

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiMaiDraw.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiMaiDraw.cs
@@ -176,7 +176,7 @@ public static class MaiMaiDraw
         ctx.Put("GroupedSongs", groupedSong.Select(g => new { g.Key, x = g.ToArray() }).ToArray());
         ctx.Put("Scores", scores);
         ctx.Put("Title", title);
-        ctx.Put("Plate", null as object);
+        ctx.Put("Plate", null);
         return await WebApi.MaiMaiSummary(ctx.Id);
     }
 

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiMaiDraw.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiMaiDraw.cs
@@ -190,11 +190,27 @@ public static class MaiMaiDraw
         IReadOnlyDictionary<(long SongId, int LevelIdx), SongScore> scores,
         string title)
     {
-        // 按 Level 字符串分组（"15+"/"15"/"14+"...），跨度内按定数降序。
+        // 分组策略：
+        // - Level selector (输入 "14" / "14+")：按定数 F1 字符串分组（"14.6" / "14.5" / ... / "14.0"），
+        //   因为整张表都是同一 lv label，再按 label 分组等于一个大 group，没有可读性。
+        // - 其他 selector（版本/谱师/类别/作曲家/定数等）：按 lv label 分组（"15+" / "15" / "14+" / ...），
+        //   跨多 lv label 时分块呈现。
+        var isLevelSelector = query.Selector is PlateData.Selector.Level;
+
+        string GroupKey((double Constant, int LevelIdx, MaiMaiSong Song) t) =>
+            isLevelSelector
+                ? t.Constant.ToString("F1", System.Globalization.CultureInfo.InvariantCulture)
+                : t.Song.Levels[t.LevelIdx];
+
+        int GroupSortKey(string key) =>
+            isLevelSelector
+                ? (int)Math.Round(double.Parse(key, System.Globalization.CultureInfo.InvariantCulture) * 10)
+                : LevelSortKey(key);
+
         var grouped = pairs
             .OrderByDescending(t => t.Constant)
-            .GroupBy(t => t.Song.Levels[t.LevelIdx])
-            .OrderByDescending(g => LevelSortKey(g.Key))
+            .GroupBy(GroupKey)
+            .OrderByDescending(g => GroupSortKey(g.Key))
             .Select(g => new { Key = g.Key, x = g.ToArray() })
             .ToArray();
 

--- a/Marisa.Plugin.Shared/Util/SongGuessMaker/SongGuessMaker.cs
+++ b/Marisa.Plugin.Shared/Util/SongGuessMaker/SongGuessMaker.cs
@@ -12,7 +12,7 @@ public class SongGuessMaker<TSong, TSongGuess>(SongDb<TSong> songDb)
     where TSong : Song
     where TSongGuess : class, IHaveId, ISongGuess, IRealmObject, new()
 {
-    private async Task<MarisaPluginTaskState> ProcSongGuessResult(Message message, TSong song, TSong? guess)
+    private Task<MarisaPluginTaskState> ProcSongGuessResult(Message message, TSong song, TSong? guess)
     {
         var senderId   = message.Sender.Id;
         var senderName = message.Sender.Name;
@@ -25,7 +25,7 @@ public class SongGuessMaker<TSong, TSongGuess>(SongDb<TSong> songDb)
         if (guess == null)
         {
             message.Reply("没找到你说的这首歌");
-            return MarisaPluginTaskState.ToBeContinued;
+            return Task.FromResult(MarisaPluginTaskState.ToBeContinued);
         }
 
         // 猜对了
@@ -43,7 +43,7 @@ public class SongGuessMaker<TSong, TSongGuess>(SongDb<TSong> songDb)
                 MessageDataImage.FromBase64(song.GetImage())
             );
 
-            return MarisaPluginTaskState.CompletedTask;
+            return Task.FromResult(MarisaPluginTaskState.CompletedTask);
         }
 
         // 猜错了
@@ -55,7 +55,7 @@ public class SongGuessMaker<TSong, TSongGuess>(SongDb<TSong> songDb)
         });
 
         message.Reply("不对不对！");
-        return MarisaPluginTaskState.ToBeContinued;
+        return Task.FromResult(MarisaPluginTaskState.ToBeContinued);
     }
 
     private Dialog.Dialog.MessageHandler GenGuessDialogHandler(TSong song, DateTime startTime, long qq)

--- a/Marisa.Plugin.Shared/Util/WebContext.cs
+++ b/Marisa.Plugin.Shared/Util/WebContext.cs
@@ -37,16 +37,17 @@ public class WebContext
         ContextPool.TryAdd(Id, new ConcurrentDictionary<string, object>());
     }
 
-    public void Put(string name, object obj)
+    public void Put(string name, object? obj)
     {
         if (ContextPool.TryGetValue(Id, out var context))
         {
-            context.TryAdd(name, obj);
+            // 允许显式存 null（前端 axios.get 用统一管线取值，"该字段为空" 的语义需要存条目而不是不存）
+            context.TryAdd(name, obj!);
         }
 
         if (!DumpOnPut) return;
 
-        Dump(Id, name, obj);
+        Dump(Id, name, obj!);
         Console.WriteLine($"Dump context {Id} to {Path.Join(GetHistoryPath(), $"{name}.{Id}")}");
     }
 

--- a/Marisa.Plugin/BlackList.cs
+++ b/Marisa.Plugin/BlackList.cs
@@ -13,7 +13,7 @@ public class BlackList : MarisaPluginBase
     private static bool _cacheInitialized;
 
     [MarisaPluginTrigger(nameof(MarisaPluginTrigger.AlwaysTrueTrigger))]
-    private static async Task<MarisaPluginTaskState> Handler(Message message)
+    private static Task<MarisaPluginTaskState> Handler(Message message)
     {
         var u = message.Sender.Id;
 
@@ -28,9 +28,9 @@ public class BlackList : MarisaPluginBase
             }
         }
 
-        if (Cache.Contains(u)) return MarisaPluginTaskState.CompletedTask;
+        if (Cache.Contains(u)) return Task.FromResult(MarisaPluginTaskState.CompletedTask);
 
-        return MarisaPluginTaskState.NoResponse; // 插件不处理这条消息，等于不ban
+        return Task.FromResult(MarisaPluginTaskState.NoResponse); // 插件不处理这条消息，等于不ban
     }
 
     [MarisaPluginCommand(":ban")]

--- a/Marisa.Plugin/Chunithm/Chunithm.Utils.cs
+++ b/Marisa.Plugin/Chunithm/Chunithm.Utils.cs
@@ -35,13 +35,13 @@ public partial class Chunithm
         }
     }
 
-    private async Task<DataFetcher> GetDataFetcher(Message message, bool allowUsername = false)
+    private Task<DataFetcher> GetDataFetcher(Message message, bool allowUsername = false)
     {
         // Command不为空的话，就是用用户名查。只有DivingFish能使用用户名查。
         // NOTE Louis也能用用户名查，但现在还是默认水鱼吧
         if (allowUsername && !message.Command.IsWhiteSpace())
         {
-            return GetDataFetcher("DivingFish", null);
+            return Task.FromResult(GetDataFetcher("DivingFish", null));
         }
 
         var qq = message.Sender.Id;
@@ -56,9 +56,9 @@ public partial class Chunithm
 
         var bind = realm.All<ChunithmBind>().FirstOrDefault(x => x.UId == qq);
 
-        return bind == null
+        return Task.FromResult(bind == null
             ? GetDataFetcher("DivingFish", null)
-            : GetDataFetcher(bind.ServerName, bind.AccessCode);
+            : GetDataFetcher(bind.ServerName, bind.AccessCode));
     }
 
     private async Task<ChunithmRating> GetRating(Message message, bool b50 = false)

--- a/Marisa.Plugin/Osu/Osu.cs
+++ b/Marisa.Plugin/Osu/Osu.cs
@@ -146,11 +146,11 @@ public partial class Osu : MarisaPluginBase, IMarisaPluginWithHelp, IHandleCommo
         return id.Id;
     }
 
-    public override async Task BackgroundService(CancellationToken cancellationToken)
+    public override Task BackgroundService(CancellationToken cancellationToken)
     {
         // 1200/minute, with burst capability of up to 200 beyond that
         // > 60/minute, you should probably give peppy a yell
-        return;
+        return Task.CompletedTask;
         /*
         try
         {

--- a/Marisa.StartUp/config.yaml
+++ b/Marisa.StartUp/config.yaml
@@ -12,10 +12,10 @@ napCat:
   token:
   selfId:
 
- divingFish:
+divingFish:
   devToken:
 
- lxns:
+lxns:
   devToken:
 
 arcaea:


### PR DESCRIPTION
PR #37 (mai 完成表) 已 merge。这里是朋友 review 后陆续提的 4 个小修补，分 4 个独立 commit。

## Commits

### 1. ` 497ed0a` fix(maimai): summary 统计条右沿对齐带边框 grid 右边界

`.title-row` / `.group-title` 宽度从 1240px (8 cell + 7 gap) 改为 **1250px** (+border-overflow 10px)，让靠右贴边的 stats-bar 右沿对齐 cell 8 `.border-img` 的右沿，而不是停在 cell-box 内沿。

### 2. ` 5b4dc88` fix: 清理编译警告 (CS1998 + CS8604)

- `WebContext.Put` 形参改 `object?` 接受 null（sum/plate 统一管线下 `Plate` 字段为空的合法语义）
- 4 处 async-without-await: `BlackList.Handler` / `Osu.BackgroundService` / `Chunithm.GetDataFetcher` / `SongGuessMaker.ProcSongGuessResult` 改成同步 `Task.FromResult` / `Task.CompletedTask`

`dotnet build` 从 5 warning 降到 0。

### 3. ` 3e2616f` fix(maimai): 组内有未打过的歌时不显示 group-min-rank

`min-rank` 表示"这个组保底分"——组内只要有一首没打过 (np / scores 字典里没条目) 就不该展示。当前 v5 起改成 "continue 跳过 np 继续算其余"，跟语义相反。

恢复 v3 时的逻辑：`!sc → return null`（彻底隐藏）；保留 `sc.achievements===0`（打过但 0 分，仍算入 min，落到 rank=d）。

### 4. ` b79205d` feat(maimai): Level 完成表按定数 (F1) 分组而非 lv label

`14将完成表` 整张表都是 lv `14`，原 `GroupBy(Levels[i])` 等价单 group，分组失去意义。改成 Level selector 时按 `t.Constant.ToString("F1")` 分组：`14.6` / `14.5` / ... / `14.0` 多 group。其他 selector (版本/谱师/类别/作曲家/定数) 保持 lv label 分组 (v6 行为不变)。

## Test plan

- [x] `dotnet build` clean (0 warning)
- [x] `MaiMaiDxPlateDataTest` 96/96 通过
- [x] 视觉验证（fixture-gen + puppeteer 截图）— 截图会随后单独 comment 附上