### PR TITLE
feat(maimai): 完成表支持多 selector AND + stats-bar 完成率按阈值动态算

### DIFF
--- a/Marisa.Frontend/src/components/maimai/Summary.vue
+++ b/Marisa.Frontend/src/components/maimai/Summary.vue
@@ -4,6 +4,7 @@ import {ref, computed} from 'vue'
 import axios from 'axios'
 import {context_get} from '@/GlobalVars'
 import type {GroupedSong, Score, PlateInfo} from '@/components/maimai/utils/summary_t'
+import {achievementOrdinal, fcOrdinal, fsOrdinal} from '@/components/maimai/utils/ordinal'
 import StatsBar from '@/components/maimai/partial/StatsBar.vue'
 
 const route          = useRoute()
@@ -52,30 +53,6 @@ const titleFontSize = computed(() => {
 
 function getScore(songId: number, levelIdx: number): Score | undefined {
     return scores.value[`(${songId}, ${levelIdx})`]
-}
-
-function achievementOrdinal(a: number): number {
-    if (a >= 100.5) return 13
-    if (a >= 100)   return 12
-    if (a >= 99.5)  return 11
-    if (a >= 99)    return 10
-    if (a >= 98)    return 9
-    if (a >= 97)    return 8
-    if (a >= 94)    return 7
-    if (a >= 90)    return 6
-    if (a >= 80)    return 5
-    if (a >= 75)    return 4
-    if (a >= 70)    return 3
-    if (a >= 60)    return 2
-    if (a >= 50)    return 1
-    return 0
-}
-function fcOrdinal(fc: string): number {
-    return ({fc: 1, fcp: 2, ap: 3, app: 4} as Record<string, number>)[fc] ?? 0
-}
-function fsOrdinal(fs: string): number {
-    // diving-fish 用 fsd/fsdp (FDX/FDX+)；fdx/fdxp 是旧别名，并存接受
-    return ({sync: 1, fs: 2, fsp: 3, fsd: 4, fdx: 4, fsdp: 5, fdxp: 5} as Record<string, number>)[fs] ?? 0
 }
 
 function isPassed(songId: number, levelIdx: number): boolean {
@@ -176,14 +153,14 @@ function formatAch(a: number): {intPart: string, fracPart: string} {
     <div class="mai-summary" v-if="data_fetched">
         <div class="title-row">
             <span class="title" :style="{fontSize: titleFontSize}">{{ title }}</span>
-            <StatsBar :charts="allCharts" :scores="scores" :detail="true" class="title-stats"/>
+            <StatsBar :charts="allCharts" :scores="scores" :detail="true" :plate="plate" class="title-stats"/>
         </div>
         <div class="groups">
             <div class="group" v-for="g in grouped" :key="g.Key">
                 <div class="group-title" :style="{color: groupKeyColor(g)}">
                     <span>{{ g.Key }}</span>
                     <img v-if="groupMinRank(g)" :src="groupMinRank(g)!" class="min-rank" alt=""/>
-                    <StatsBar :charts="g.x" :scores="scores" :detail="false" class="group-stats"/>
+                    <StatsBar :charts="g.x" :scores="scores" :detail="false" :plate="plate" class="group-stats"/>
                 </div>
                 <div class="row">
                     <template v-for="s in g.x" :key="`${s.Item3.Id}-${s.Item2}`">

--- a/Marisa.Frontend/src/components/maimai/partial/StatsBar.vue
+++ b/Marisa.Frontend/src/components/maimai/partial/StatsBar.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
 import {computed} from 'vue'
-import type {Score, GroupedSong} from '@/components/maimai/utils/summary_t'
+import type {Score, GroupedSong, PlateInfo} from '@/components/maimai/utils/summary_t'
+import {achievementOrdinal, fcOrdinal, fsOrdinal} from '@/components/maimai/utils/ordinal'
 
 const props = defineProps({
     charts: { type: Array as () => GroupedSong['x'], required: true },
     scores: { type: Object as () => Record<string, Score>, required: true },
     detail: { type: Boolean, default: false },
+    // plate 模式时传入；中央 overlay 完成率按 plate.Dim + plate.Level 动态算。
+    // sum 模式 (null) 时按 SSS 阈值兜底 (与 PR #38 行为一致)。
+    plate:  { type: Object as () => PlateInfo | null, default: null },
 })
 
 // rank 顶档加 'app'（fc=='app' 等价 ach 满分 101 — 与下层 fc 顶档对齐，amber-200 同色，
@@ -62,10 +66,26 @@ function pct(n: number, total: number): string {
 }
 
 const overallPct = computed(() => {
-    const r = rankStat.value
-    // 完成率 = SSS 及以上 (含 app/sssp/sss)；SS+ 以下不算
-    const done = r.app + r.sssp + r.sss
-    return r.total ? (done / r.total * 100).toFixed(2) + '%' : '0.00%'
+    // 中央完成率按命令的阈值维度动态算：
+    // - plate.Dim = Achievement → 按达成率 (achievementOrdinal)
+    // - plate.Dim = Fc          → 按 fc 字段 (fcOrdinal)
+    // - plate.Dim = Fs          → 按 fs 字段 (fsOrdinal)
+    // - sum 模式 (plate = null) → 按 SSS (与 PR #38 兜底一致)
+    const dim       = props.plate?.Dim   ?? 'Achievement'
+    const threshold = props.plate?.Level ?? 12   // 12 = SSS
+    const total = props.charts.length
+    if (!total) return '0.00%'
+
+    let done = 0
+    for (const c of props.charts) {
+        const sc = props.scores[`(${c.Item3.Id}, ${c.Item2})`]
+        if (!sc) continue
+        const lv = dim === 'Achievement' ? achievementOrdinal(sc.achievements)
+                : dim === 'Fc'           ? fcOrdinal(sc.fc)
+                :                          fsOrdinal(sc.fs)
+        if (lv >= threshold) done++
+    }
+    return (done / total * 100).toFixed(2) + '%'
 })
 </script>
 

--- a/Marisa.Frontend/src/components/maimai/utils/ordinal.ts
+++ b/Marisa.Frontend/src/components/maimai/utils/ordinal.ts
@@ -1,0 +1,28 @@
+// Achievement / Fc / Fs 字段值 → 有序整数（用于阈值比较 / 段位排序）。
+// 跟 PlateData.cs 的 AchievementLevel / FcLevel / FsLevel 三个 C# helper 同语义；
+// diving-fish fs 字段返回 fsd/fsdp (FDX/FDX+) 命名，fdx/fdxp 是旧别名也接受。
+
+export function achievementOrdinal(a: number): number {
+    if (a >= 100.5) return 13
+    if (a >= 100)   return 12
+    if (a >= 99.5)  return 11
+    if (a >= 99)    return 10
+    if (a >= 98)    return 9
+    if (a >= 97)    return 8
+    if (a >= 94)    return 7
+    if (a >= 90)    return 6
+    if (a >= 80)    return 5
+    if (a >= 75)    return 4
+    if (a >= 70)    return 3
+    if (a >= 60)    return 2
+    if (a >= 50)    return 1
+    return 0
+}
+
+export function fcOrdinal(fc: string): number {
+    return ({fc: 1, fcp: 2, ap: 3, app: 4} as Record<string, number>)[fc] ?? 0
+}
+
+export function fsOrdinal(fs: string): number {
+    return ({sync: 1, fs: 2, fsp: 3, fsd: 4, fdx: 4, fsdp: 5, fdxp: 5} as Record<string, number>)[fs] ?? 0
+}

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiMaiDraw.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiMaiDraw.cs
@@ -195,7 +195,8 @@ public static class MaiMaiDraw
         //   因为整张表都是同一 lv label，再按 label 分组等于一个大 group，没有可读性。
         // - 其他 selector（版本/谱师/类别/作曲家/定数等）：按 lv label 分组（"15+" / "15" / "14+" / ...），
         //   跨多 lv label 时分块呈现。
-        var isLevelSelector = query.Selector is PlateData.Selector.Level;
+        // 任一 selector 是 Level（如 "镜代13+" 含 Level("13+")）就按定数分组。
+        var isLevelSelector = query.Selectors.Any(s => s is PlateData.Selector.Level);
 
         string GroupKey((double Constant, int LevelIdx, MaiMaiSong Song) t) =>
             isLevelSelector

--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -427,6 +427,14 @@ public static class PlateData
             return false;
         }
 
+        // 宴会場 special-case：宴谱（id > 100000）只有 1-2 个低 idx 谱面（没有 MASTER+Re:MASTER），
+        // 用 DefaultLevelIdxes=[3,4] 会把所有 宴会場 songs 过滤光。
+        // 用户未显式指定难度 (diffAt < 0) 且 selector 命中 Genre("宴会場") 时，扩展到全难度。
+        if (diffAt < 0 && selectors.OfType<Selector.Genre>().Any(g => g.FullName == "宴会場"))
+        {
+            levelIdxes = [0, 1, 2, 3, 4];
+        }
+
         query = new Query(selectors, threshold, levelIdxes);
         return true;
     }

--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -47,7 +47,12 @@ public static class PlateData
         public sealed record Constant(double Value) : Selector(Value.ToString("F1"));
     }
 
-    public sealed record Query(Selector Selector, Threshold Threshold, IReadOnlyList<int> LevelIdxes);
+    /// <summary>
+    ///     完整查询：一组 Selectors（AND 合取——所有 selector 都命中的 chart 才入选）+ 阈值 + 难度。
+    ///     当前 TryParse 阶段返回 Selectors.Count == 1（与历史单 selector 行为等价）；
+    ///     multi-selector 解析在后续 commit 启用。
+    /// </summary>
+    public sealed record Query(IReadOnlyList<Selector> Selectors, Threshold Threshold, IReadOnlyList<int> LevelIdxes);
 
     /// <summary>默认难度：未指定时同时查 MASTER + Re:MASTER。</summary>
     public static readonly IReadOnlyList<int> DefaultLevelIdxes = [3, 4];
@@ -325,7 +330,7 @@ public static class PlateData
         //    Charter catch-all 殿后保留"乱输入也接受 + handler 报 0 首"语义。
         if (TryResolvePlate(selectorPart, out var plateSel, out var plateErr))
         {
-            query = new Query(plateSel!, threshold, levelIdxes);
+            query = new Query([plateSel!], threshold, levelIdxes);
             return true;
         }
         if (plateErr != null)
@@ -336,19 +341,19 @@ public static class PlateData
 
         if (TryResolveGenre(selectorPart, out var genreSel))
         {
-            query = new Query(genreSel!, threshold, levelIdxes);
+            query = new Query([genreSel!], threshold, levelIdxes);
             return true;
         }
 
         if (TryResolveLevel(selectorPart, out var levelSel))
         {
-            query = new Query(levelSel!, threshold, levelIdxes);
+            query = new Query([levelSel!], threshold, levelIdxes);
             return true;
         }
 
         if (TryResolveConstant(selectorPart, out var constantSel))
         {
-            query = new Query(constantSel!, threshold, levelIdxes);
+            query = new Query([constantSel!], threshold, levelIdxes);
             return true;
         }
 
@@ -357,22 +362,22 @@ public static class PlateData
 
         if (charterHit && artistHit)
         {
-            query = new Query(new Selector.CharterOrArtist(selectorPart), threshold, levelIdxes);
+            query = new Query([new Selector.CharterOrArtist(selectorPart)], threshold, levelIdxes);
             return true;
         }
         if (charterHit)
         {
-            query = new Query(charterPreciseSel!, threshold, levelIdxes);
+            query = new Query([charterPreciseSel!], threshold, levelIdxes);
             return true;
         }
         if (artistHit)
         {
-            query = new Query(artistSel!, threshold, levelIdxes);
+            query = new Query([artistSel!], threshold, levelIdxes);
             return true;
         }
 
         // catch-all：把 selector 当作 charter 接收，由 handler 在筛选时报 0 首。
-        query = new Query(new Selector.Charter(selectorPart), threshold, levelIdxes);
+        query = new Query([new Selector.Charter(selectorPart)], threshold, levelIdxes);
         return true;
     }
 

--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -60,7 +60,7 @@ public static class PlateData
     /// <summary>默认阈值（"将"=SSS）。用户未指定阈值时自动应用。</summary>
     public static readonly Threshold DefaultThreshold = new(Dimension.Achievement, 12, "SSS");
 
-    public enum ErrorKind { NotPlateCommand, EmptyQuery, UnsupportedPlate, UnknownSelector }
+    public enum ErrorKind { NotPlateCommand, EmptyQuery, UnsupportedPlate, UnknownSelector, ConflictingSelector }
 
     public sealed record ParseError(ErrorKind Kind, string? Detail = null);
 
@@ -324,60 +324,110 @@ public static class PlateData
             return false;
         }
 
-        // 3. 解析 selector：Plate → Genre → Level → Constant → (Charter precise + Artist precise 同时查) → Charter catch-all。
-        //    Level/Constant 是纯数字格式（"13" / "13+" / "13.5"），跟 charter / artist 名不冲突，放靠前优先级。
-        //    Charter / Artist 同时命中时合并为 CharterOrArtist（处理 "rintaro soma" 这种身兼谱师+作曲家的人）。
-        //    Charter catch-all 殿后保留"乱输入也接受 + handler 报 0 首"语义。
-        if (TryResolvePlate(selectorPart, out var plateSel, out var plateErr))
+        // 3. 多 selector 解析：每轮在 workingPart 内找一个"硬" token（Plate / Genre / Constant / Level）
+        //    的 rightmost-longest match，剥掉，加入 selectors 列表。重复直到无新匹配。
+        //    剩下的连续片段当作 Charter / Artist（substring precise → CharterOrArtist union → catch-all）。
+        //    AND 语义：handler 端对每首 chart 用 selectors.All(MatchSelector) 求交集。
+        //
+        //    冲突规则：同类 selector 出现两次（含 Level + Constant 互斥，因为 Constant 隐含确定 Level）
+        //    → ConflictingSelector 错误。
+        var selectors = new List<Selector>();
+        var workingPart = selectorPart;
+
+        while (true)
         {
-            query = new Query([plateSel!], threshold, levelIdxes);
-            return true;
+            // 同一轮内收集 4 种 token 候选，按 (length DESC, start DESC) 取最优。
+            // longest-first 是为了处理像 "宴会场" 的歧义 — "宴" 是 Plate kanji（BUDDiES）
+            // 但 "宴会场" 是 Genre 别名；明确选最长（Genre）。
+            int matchStart = -1, matchLen = 0;
+            Selector? matched = null;
+
+            if (TryFindRightmostPlateInString(workingPart, out var pStart, out var pLen, out var pSel, out var pErr))
+            {
+                if (pLen > matchLen || (pLen == matchLen && pStart > matchStart))
+                { matchStart = pStart; matchLen = pLen; matched = pSel; }
+            }
+            else if (pErr != null)
+            {
+                error = pErr;       // 丸/彩 这种已知不支持，立刻返回
+                return false;
+            }
+
+            if (TryFindRightmostGenreInString(workingPart, out var gStart, out var gLen, out var gSel))
+            {
+                if (gLen > matchLen || (gLen == matchLen && gStart > matchStart))
+                { matchStart = gStart; matchLen = gLen; matched = gSel; }
+            }
+
+            if (TryFindRightmostConstantInString(workingPart, out var cStart, out var cLen, out var cSel))
+            {
+                if (cLen > matchLen || (cLen == matchLen && cStart > matchStart))
+                { matchStart = cStart; matchLen = cLen; matched = cSel; }
+            }
+
+            if (TryFindRightmostLevelInString(workingPart, out var lStart, out var lLen, out var lSel))
+            {
+                if (lLen > matchLen || (lLen == matchLen && lStart > matchStart))
+                { matchStart = lStart; matchLen = lLen; matched = lSel; }
+            }
+
+            if (matchStart < 0) break;
+
+            // 同类冲突检查（Level + Constant 视为同类——Constant 隐含 Level，二者只能给一个）
+            if (matched is Selector.Plate && selectors.OfType<Selector.Plate>().Any())
+            {
+                error = new(ErrorKind.ConflictingSelector, "版本");
+                return false;
+            }
+            if (matched is Selector.Genre && selectors.OfType<Selector.Genre>().Any())
+            {
+                error = new(ErrorKind.ConflictingSelector, "类别");
+                return false;
+            }
+            if (matched is Selector.Level or Selector.Constant
+                && selectors.Any(s => s is Selector.Level or Selector.Constant))
+            {
+                error = new(ErrorKind.ConflictingSelector, "难度或定数");
+                return false;
+            }
+
+            selectors.Add(matched!);
+            workingPart = (workingPart[..matchStart] + workingPart[(matchStart + matchLen)..]).Trim();
         }
-        if (plateErr != null)
+
+        // 剩余连续片段当 Charter / Artist
+        if (workingPart.Length > 0)
         {
-            error = plateErr;  // 丸/彩 这种已知不支持，立刻返回
+            var charterHit = TryResolveCharterPrecise(workingPart, knownCharters, out var charterPreciseSel);
+            var artistHit  = TryResolveArtist(workingPart, knownArtists, out var artistSel);
+
+            if (charterHit && artistHit)
+            {
+                selectors.Add(new Selector.CharterOrArtist(workingPart));
+            }
+            else if (charterHit)
+            {
+                selectors.Add(charterPreciseSel!);
+            }
+            else if (artistHit)
+            {
+                selectors.Add(artistSel!);
+            }
+            else
+            {
+                // catch-all：把剩余部分当 charter 接收，由 handler 在筛选时报 0 首。
+                selectors.Add(new Selector.Charter(workingPart));
+            }
+        }
+
+        if (selectors.Count == 0)
+        {
+            // 理论上不会走到（EmptyQuery 在更早被挡），保险兜底
+            error = new(ErrorKind.UnknownSelector, inner);
             return false;
         }
 
-        if (TryResolveGenre(selectorPart, out var genreSel))
-        {
-            query = new Query([genreSel!], threshold, levelIdxes);
-            return true;
-        }
-
-        if (TryResolveLevel(selectorPart, out var levelSel))
-        {
-            query = new Query([levelSel!], threshold, levelIdxes);
-            return true;
-        }
-
-        if (TryResolveConstant(selectorPart, out var constantSel))
-        {
-            query = new Query([constantSel!], threshold, levelIdxes);
-            return true;
-        }
-
-        var charterHit = TryResolveCharterPrecise(selectorPart, knownCharters, out var charterPreciseSel);
-        var artistHit  = TryResolveArtist(selectorPart, knownArtists, out var artistSel);
-
-        if (charterHit && artistHit)
-        {
-            query = new Query([new Selector.CharterOrArtist(selectorPart)], threshold, levelIdxes);
-            return true;
-        }
-        if (charterHit)
-        {
-            query = new Query([charterPreciseSel!], threshold, levelIdxes);
-            return true;
-        }
-        if (artistHit)
-        {
-            query = new Query([artistSel!], threshold, levelIdxes);
-            return true;
-        }
-
-        // catch-all：把 selector 当作 charter 接收，由 handler 在筛选时报 0 首。
-        query = new Query([new Selector.Charter(selectorPart)], threshold, levelIdxes);
+        query = new Query(selectors, threshold, levelIdxes);
         return true;
     }
 
@@ -531,4 +581,154 @@ public static class PlateData
 
         return false;
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // multi-selector: 在 workingPart 内"任意位置"找一个 token 的 rightmost-longest match。
+    // Plate / Genre 直接走表；Level / Constant 走 regex，并要求两侧不是 ASCII 字母
+    // （避免吃到 charter / artist 名里的偶然数字，如假想 charter "k14"）。
+    // ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    ///     找 workingPart 内"最佳"Plate kanji 匹配。优先级 (length DESC, rightmost) —
+    ///     即更长的匹配（带"代"后缀的双字版本）优先；同长度时取靠右的位置。
+    ///     BlockedPlateKanji 命中且比有效 kanji 更靠右时报错。
+    /// </summary>
+    private static bool TryFindRightmostPlateInString(
+        string s, out int start, out int length, out Selector? selector, out ParseError? plateErr)
+    {
+        start = -1; length = 0; selector = null; plateErr = null;
+
+        int bestStart = -1, bestLen = 0;
+        string? bestKanji = null;
+        string[]? bestVersions = null;
+
+        foreach (var (kanji, versions) in PlateVersionMap)
+        {
+            var idx = s.LastIndexOf(kanji, StringComparison.Ordinal);
+            if (idx < 0) continue;
+            // 同位置时优先 "kanji+代"（更长）
+            var withDai = idx + kanji.Length < s.Length && s[idx + kanji.Length] == '代';
+            var len = withDai ? kanji.Length + 1 : kanji.Length;
+            if (len > bestLen || (len == bestLen && idx > bestStart))
+            {
+                bestStart = idx; bestLen = len; bestKanji = kanji; bestVersions = versions;
+            }
+        }
+
+        int blockedStart = -1;
+        string? blockedKanji = null;
+        foreach (var bk in BlockedPlateKanji)
+        {
+            var idx = s.LastIndexOf(bk, StringComparison.Ordinal);
+            if (idx > blockedStart) { blockedStart = idx; blockedKanji = bk; }
+        }
+
+        // 若被屏蔽 kanji 出现得比任何有效 kanji 更右 → 立即报错（避免悄悄走 catch-all）
+        if (blockedStart > bestStart)
+        {
+            plateErr = new(ErrorKind.UnsupportedPlate, blockedKanji!);
+            return false;
+        }
+
+        if (bestStart < 0) return false;
+        start = bestStart; length = bestLen;
+        selector = new Selector.Plate(bestKanji!, bestVersions!);
+        return true;
+    }
+
+    /// <summary>
+    ///     找 workingPart 内"最佳"Genre alias 或全名匹配。优先级 (length DESC, rightmost) —
+    ///     避免 "流行动漫" 被更短的 "动漫" 抢掉位置。
+    /// </summary>
+    private static bool TryFindRightmostGenreInString(
+        string s, out int start, out int length, out Selector? selector)
+    {
+        start = -1; length = 0; selector = null;
+
+        int bestStart = -1, bestLen = 0;
+        Selector? bestSel = null;
+
+        foreach (var (alias, fullName) in GenreAliasMap)
+        {
+            var idx = s.LastIndexOf(alias, StringComparison.Ordinal);
+            if (idx < 0) continue;
+            if (alias.Length > bestLen || (alias.Length == bestLen && idx > bestStart))
+            {
+                bestStart = idx; bestLen = alias.Length;
+                bestSel = new Selector.Genre(fullName, alias);
+            }
+        }
+        foreach (var fullName in GenreAliasMap.Values.Distinct(StringComparer.Ordinal))
+        {
+            var idx = s.LastIndexOf(fullName, StringComparison.Ordinal);
+            if (idx < 0) continue;
+            if (fullName.Length > bestLen || (fullName.Length == bestLen && idx > bestStart))
+            {
+                bestStart = idx; bestLen = fullName.Length;
+                bestSel = new Selector.Genre(fullName, fullName);
+            }
+        }
+
+        if (bestStart < 0) return false;
+        start = bestStart; length = bestLen; selector = bestSel;
+        return true;
+    }
+
+    /// <summary>
+    ///     找 workingPart 内 rightmost Constant（X.Y 格式，1-15.x 范围）。
+    ///     两侧不能是 ASCII 字母 / 数字 / 点号，避免吃到 charter/artist 名里的偶然数字（如 "DECO*27"）。
+    ///     正则 alternation 顺序 (1[0-5]|[1-9]) 优先匹更长以保证 "14" 不被 "1" 吃。
+    /// </summary>
+    private static bool TryFindRightmostConstantInString(
+        string s, out int start, out int length, out Selector? selector)
+    {
+        start = -1; length = 0; selector = null;
+        var matches = System.Text.RegularExpressions.Regex.Matches(s, @"(1[0-5]|[1-9])\.\d");
+        for (var i = matches.Count - 1; i >= 0; i--)
+        {
+            var m = matches[i];
+            if (!IsCompleteNumberToken(s, m.Index, m.Length)) continue;
+            if (!double.TryParse(m.Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v)) continue;
+            start = m.Index; length = m.Length;
+            selector = new Selector.Constant(v);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    ///     找 workingPart 内 rightmost Level（X 或 X+ 格式，1-15）。
+    ///     1）两侧不能是 ASCII 字母 / 数字 / 点号；2）右边不能是 ".X"（避免吃 Constant 前缀）。
+    /// </summary>
+    private static bool TryFindRightmostLevelInString(
+        string s, out int start, out int length, out Selector? selector)
+    {
+        start = -1; length = 0; selector = null;
+        var matches = System.Text.RegularExpressions.Regex.Matches(s, @"(1[0-5]|[1-9])\+?");
+        for (var i = matches.Count - 1; i >= 0; i--)
+        {
+            var m = matches[i];
+            if (m.Length == 0) continue;
+            // 不能是 Constant 前缀（紧跟 ".d"），由 IsCompleteNumberToken 的 dot 检查覆盖。
+            if (!IsCompleteNumberToken(s, m.Index, m.Length)) continue;
+            start = m.Index; length = m.Length;
+            selector = new Selector.Level(m.Value);
+            return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    ///     match 两侧（前一个 char、后一个 char）都不是 ASCII 字母、数字或点号 —
+    ///     即整个数字 token 完整呈现于该匹配位置，没被更长的数字串截断。
+    /// </summary>
+    private static bool IsCompleteNumberToken(string s, int idx, int len)
+    {
+        var before = idx > 0 ? s[idx - 1] : '\0';
+        var after  = idx + len < s.Length ? s[idx + len] : '\0';
+        return !IsAsciiLetterOrDigitOrDot(before) && !IsAsciiLetterOrDigitOrDot(after);
+    }
+
+    private static bool IsAsciiLetterOrDigitOrDot(char c)
+        => IsAsciiLetter(c) || (c >= '0' && c <= '9') || c == '.';
 }

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using Marisa.Plugin.Shared.MaiMaiDx;
 using NUnit.Framework;
 
@@ -42,8 +43,8 @@ public class MaiMaiDxPlateDataTest
     public void ParsesPlateAchievement(string raw, string kanji, int level)
     {
         var query = MustParse(raw);
-        Assert.That(query.Selector, Is.InstanceOf<PlateData.Selector.Plate>());
-        var plate = (PlateData.Selector.Plate)query.Selector;
+        Assert.That(query.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Plate>());
+        var plate = (PlateData.Selector.Plate)query.Selectors.Single();
         Assert.That(plate.Kanji, Is.EqualTo(kanji));
         Assert.That(query.Threshold.Dim, Is.EqualTo(PlateData.Dimension.Achievement));
         Assert.That(query.Threshold.Level, Is.EqualTo(level));
@@ -60,7 +61,7 @@ public class MaiMaiDxPlateDataTest
     public void PlateMapsToCorrectVersions(string raw, string[] expected)
     {
         var query = MustParse(raw);
-        var plate = (PlateData.Selector.Plate)query.Selector;
+        var plate = (PlateData.Selector.Plate)query.Selectors.Single();
         Assert.That(plate.Versions, Is.EquivalentTo(expected));
     }
 
@@ -71,8 +72,8 @@ public class MaiMaiDxPlateDataTest
     public void ParsesCharter(string raw, string charter, int level)
     {
         var query = MustParse(raw);
-        Assert.That(query.Selector, Is.InstanceOf<PlateData.Selector.Charter>());
-        var c = (PlateData.Selector.Charter)query.Selector;
+        Assert.That(query.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        var c = (PlateData.Selector.Charter)query.Selectors.Single();
         Assert.That(c.Name, Is.EqualTo(charter));
         Assert.That(query.Threshold.Level, Is.EqualTo(level));
     }
@@ -91,8 +92,8 @@ public class MaiMaiDxPlateDataTest
     public void ParsesGenre(string raw, string fullName)
     {
         var query = MustParse(raw);
-        Assert.That(query.Selector, Is.InstanceOf<PlateData.Selector.Genre>());
-        var g = (PlateData.Selector.Genre)query.Selector;
+        Assert.That(query.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Genre>());
+        var g = (PlateData.Selector.Genre)query.Selectors.Single();
         Assert.That(g.FullName, Is.EqualTo(fullName));
     }
 
@@ -114,8 +115,8 @@ public class MaiMaiDxPlateDataTest
         // SelectChartsForQuery 里 substring 找不到任何含"翠楼屋代"的真 charter 名，
         // 报 "没有找到歌曲"。这里只验证解析层。
         var query = MustParse("翠楼屋代将完成表");
-        Assert.That(query.Selector, Is.InstanceOf<PlateData.Selector.Charter>());
-        Assert.That(((PlateData.Selector.Charter)query.Selector).Name, Is.EqualTo("翠楼屋代"));
+        Assert.That(query.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(((PlateData.Selector.Charter)query.Selectors.Single()).Name, Is.EqualTo("翠楼屋代"));
     }
 
     [Test]
@@ -124,8 +125,8 @@ public class MaiMaiDxPlateDataTest
         // "张顺飞" 不存在 — 但因为不是代字也不是 genre alias，按规则当 charter 接受。
         // 真不真存在由 SelectChartsForQuery 里的 substring 匹配决定（找不到时 handler 报 0 首）。
         var query = MustParse("张顺飞将完成表");
-        Assert.That(query.Selector, Is.InstanceOf<PlateData.Selector.Charter>());
-        Assert.That(((PlateData.Selector.Charter)query.Selector).Name, Is.EqualTo("张顺飞"));
+        Assert.That(query.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(((PlateData.Selector.Charter)query.Selectors.Single()).Name, Is.EqualTo("张顺飞"));
     }
 
     [Test]
@@ -152,8 +153,8 @@ public class MaiMaiDxPlateDataTest
     public void DefaultsToSssWhenThresholdMissingForPlate(string raw, string kanji, int level)
     {
         var q = MustParse(raw);
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Plate>());
-        Assert.That(((PlateData.Selector.Plate)q.Selector).Kanji, Is.EqualTo(kanji));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Plate>());
+        Assert.That(((PlateData.Selector.Plate)q.Selectors.Single()).Kanji, Is.EqualTo(kanji));
         Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.Achievement));
         Assert.That(q.Threshold.Level, Is.EqualTo(level));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
@@ -164,8 +165,8 @@ public class MaiMaiDxPlateDataTest
     public void DefaultsToSssWhenThresholdMissingForCharter()
     {
         var q = MustParse("翠楼屋完成表");
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Charter>());
-        Assert.That(((PlateData.Selector.Charter)q.Selector).Name, Is.EqualTo("翠楼屋"));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(((PlateData.Selector.Charter)q.Selectors.Single()).Name, Is.EqualTo("翠楼屋"));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
         // 难度未指定 → 默认 MASTER + Re:MASTER
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
@@ -176,7 +177,7 @@ public class MaiMaiDxPlateDataTest
     {
         // 阈值缺省 + 难度显式给：threshold=SSS / LevelIdxes=[EXPERT]
         var q = MustParse("翠楼屋红谱完成表");
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {2}));
     }
@@ -263,7 +264,7 @@ public class MaiMaiDxPlateDataTest
         var q = MustParse("真代SSS+红完成表");
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}), "single '红' must not be parsed as difficulty");
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS+"));
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
     }
 
     [TestCase("真代神白谱完成表", 4)]
@@ -288,8 +289,8 @@ public class MaiMaiDxPlateDataTest
     public void FieldOrderIsCommutative_PlateExpertJiang(string raw)
     {
         var q = MustParse(raw);
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Plate>(), "should resolve to Plate(真)");
-        Assert.That(((PlateData.Selector.Plate)q.Selector).Kanji, Is.EqualTo("真"));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Plate>(), "should resolve to Plate(真)");
+        Assert.That(((PlateData.Selector.Plate)q.Selectors.Single()).Kanji, Is.EqualTo("真"));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {2}));    // EXPERT
     }
@@ -301,7 +302,7 @@ public class MaiMaiDxPlateDataTest
     public void FieldOrderIsCommutative_PlateShinWhitePu(string raw)
     {
         var q = MustParse(raw);
-        Assert.That(((PlateData.Selector.Plate)q.Selector).Kanji, Is.EqualTo("真"));
+        Assert.That(((PlateData.Selector.Plate)q.Selectors.Single()).Kanji, Is.EqualTo("真"));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));  // 神
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {4}));     // 白谱 = Re:MASTER
     }
@@ -316,8 +317,8 @@ public class MaiMaiDxPlateDataTest
     public void ParsesArtistWhenOnlyArtistMatches(string raw, string artist, int level)
     {
         var q = MustParse(raw);
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Artist>(), $"expected Artist for '{raw}'");
-        Assert.That(((PlateData.Selector.Artist)q.Selector).Name, Is.EqualTo(artist));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Artist>(), $"expected Artist for '{raw}'");
+        Assert.That(((PlateData.Selector.Artist)q.Selectors.Single()).Name, Is.EqualTo(artist));
         Assert.That(q.Threshold.Level, Is.EqualTo(level));
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
     }
@@ -327,8 +328,8 @@ public class MaiMaiDxPlateDataTest
     {
         // "DECO*27" 不在 charters 列表，但 artists 列表里有 "sasakure.UK x DECO*27" —— substring 命中
         var q = MustParse("DECO*27将完成表");
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Artist>());
-        Assert.That(((PlateData.Selector.Artist)q.Selector).Name, Is.EqualTo("DECO*27"));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Artist>());
+        Assert.That(((PlateData.Selector.Artist)q.Selectors.Single()).Name, Is.EqualTo("DECO*27"));
     }
 
     [Test]
@@ -336,8 +337,8 @@ public class MaiMaiDxPlateDataTest
     {
         // 验证 substring 方向：用户输 collab 名义里的部分 ("sasakure.UK")，应命中 Artist
         var q = MustParse("sasakure.UK将完成表");
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Artist>());
-        Assert.That(((PlateData.Selector.Artist)q.Selector).Name, Is.EqualTo("sasakure.UK"));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Artist>());
+        Assert.That(((PlateData.Selector.Artist)q.Selectors.Single()).Name, Is.EqualTo("sasakure.UK"));
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -350,9 +351,9 @@ public class MaiMaiDxPlateDataTest
         // "rintaro soma" 在 Charters 和 Artists 列表里都有 → Selector 应合并为 CharterOrArtist，
         // handler 按 OR 筛 (谱师维度命中 ∪ 作曲家维度命中)。
         var q = MustParse("rintaro soma将完成表");
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.CharterOrArtist>(),
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.CharterOrArtist>(),
             "rintaro soma 同时是已知谱师和作曲家，应解析为 CharterOrArtist union");
-        Assert.That(((PlateData.Selector.CharterOrArtist)q.Selector).Name, Is.EqualTo("rintaro soma"));
+        Assert.That(((PlateData.Selector.CharterOrArtist)q.Selectors.Single()).Name, Is.EqualTo("rintaro soma"));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
     }
@@ -362,8 +363,8 @@ public class MaiMaiDxPlateDataTest
     {
         // 输 substring "rintaro" 仍应命中 union（charter "rintaro soma" 含 + artist "rintaro soma" 含）。
         var q = MustParse("rintaro完成表");
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.CharterOrArtist>());
-        Assert.That(((PlateData.Selector.CharterOrArtist)q.Selector).Name, Is.EqualTo("rintaro"));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.CharterOrArtist>());
+        Assert.That(((PlateData.Selector.CharterOrArtist)q.Selectors.Single()).Name, Is.EqualTo("rintaro"));
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -376,8 +377,8 @@ public class MaiMaiDxPlateDataTest
         // "サファ太" 不在 charters 列表直接条目，但 "サファ太 vs 翠楼屋" 含它 — substring 命中
         // 且 artists 列表里没含 → 单边 Charter (不是 CharterOrArtist)
         var q = MustParse("サファ太将完成表");
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Charter>());
-        Assert.That(((PlateData.Selector.Charter)q.Selector).Name, Is.EqualTo("サファ太"));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(((PlateData.Selector.Charter)q.Selectors.Single()).Name, Is.EqualTo("サファ太"));
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -389,8 +390,8 @@ public class MaiMaiDxPlateDataTest
     {
         // "14+神完成表" → Selector.Level("14+") + Fc=AP + 默认难度 [3, 4]
         var q = MustParse("14+神完成表");
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Level>());
-        Assert.That(((PlateData.Selector.Level)q.Selector).Label, Is.EqualTo("14+"));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Level>());
+        Assert.That(((PlateData.Selector.Level)q.Selectors.Single()).Label, Is.EqualTo("14+"));
         Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.Fc));
         Assert.That(q.Threshold.Level, Is.EqualTo(3));
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
@@ -401,8 +402,8 @@ public class MaiMaiDxPlateDataTest
     {
         // "14.9FDX完成表" → Selector.Constant(14.9) + Fs=FDX + 默认难度 [3, 4]
         var q = MustParse("14.9FDX完成表");
-        Assert.That(q.Selector, Is.InstanceOf<PlateData.Selector.Constant>());
-        Assert.That(((PlateData.Selector.Constant)q.Selector).Value, Is.EqualTo(14.9).Within(0.001));
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Constant>());
+        Assert.That(((PlateData.Selector.Constant)q.Selectors.Single()).Value, Is.EqualTo(14.9).Within(0.001));
         Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.Fs));
         Assert.That(q.Threshold.Level, Is.EqualTo(4));
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -259,12 +259,15 @@ public class MaiMaiDxPlateDataTest
     public void DifficultySingleKanjiNotAccepted()
     {
         // 单字"红"不在 difficulty alias map（避免跟未来代字冲突，要写就写"红谱"或"EXPERT"）。
-        // 新版"字段位置任意"算法下，"真代SSS+红完成表" 阈值 SSS+ 在中间也能剥，剩"真代红"
-        // 走 charter substring（catch-all），LevelIdxes 仍是默认 MASTER+Re:MASTER ([3, 4])。
+        // multi-selector 解析下，"真代SSS+红完成表" 剥阈值后剩"真代红"
+        //   → "真代" 作 Plate(真), 单字"红"作 Charter（catch-all，handler 找不到含"红"的谱师报 0 首）。
+        // LevelIdxes 仍是默认 MASTER+Re:MASTER ([3, 4])。
         var q = MustParse("真代SSS+红完成表");
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}), "single '红' must not be parsed as difficulty");
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS+"));
-        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(q.Selectors, Has.Exactly(2).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("真"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Charter>().Single().Name, Is.EqualTo("红"));
     }
 
     [TestCase("真代神白谱完成表", 4)]
@@ -407,5 +410,125 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.Fs));
         Assert.That(q.Threshold.Level, Is.EqualTo(4));
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // Multi-selector (AND 合取)
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void MultiSelector_PlateAndLevel()
+    {
+        // "镜代13+AP完成表" → Plate(镜) ∩ Level("13+") + Fc=AP
+        var q = MustParse("镜代13+AP完成表");
+        Assert.That(q.Selectors, Has.Exactly(2).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
+        Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
+    }
+
+    [Test]
+    public void MultiSelector_PlateAndGenre()
+    {
+        // "镜代V家将完成表" → Plate(镜) ∩ Genre("niconico & VOCALOID") + SSS
+        var q = MustParse("镜代V家将完成表");
+        Assert.That(q.Selectors, Has.Exactly(2).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Genre>().Single().FullName, Is.EqualTo("niconico & VOCALOID"));
+        Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
+    }
+
+    [Test]
+    public void MultiSelector_PlateAndConstant()
+    {
+        // "镜代14.6神完成表" → Plate(镜) ∩ Constant(14.6) + AP
+        var q = MustParse("镜代14.6神完成表");
+        Assert.That(q.Selectors, Has.Exactly(2).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Constant>().Single().Value, Is.EqualTo(14.6).Within(0.001));
+        Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
+    }
+
+    [Test]
+    public void MultiSelector_LevelAndCharter()
+    {
+        // "14+翠楼屋将完成表" → Level("14+") ∩ Charter("翠楼屋")
+        var q = MustParse("14+翠楼屋将完成表");
+        Assert.That(q.Selectors, Has.Exactly(2).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("14+"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Charter>().Single().Name, Is.EqualTo("翠楼屋"));
+    }
+
+    [Test]
+    public void MultiSelector_GenreAndCharter()
+    {
+        // "V家翠楼屋将完成表" → Genre(niconico) ∩ Charter("翠楼屋")
+        var q = MustParse("V家翠楼屋将完成表");
+        Assert.That(q.Selectors, Has.Exactly(2).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Genre>().Single().FullName, Is.EqualTo("niconico & VOCALOID"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Charter>().Single().Name, Is.EqualTo("翠楼屋"));
+    }
+
+    [Test]
+    public void MultiSelector_ThreeWayPlateLevelGenre()
+    {
+        // "镜代13+V家将完成表" → 3 个 selector AND
+        var q = MustParse("镜代13+V家将完成表");
+        Assert.That(q.Selectors, Has.Exactly(3).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Genre>().Single().FullName, Is.EqualTo("niconico & VOCALOID"));
+    }
+
+    [TestCase("镜代13+AP完成表")]
+    [TestCase("AP镜代13+完成表")]
+    [TestCase("13+AP镜代完成表")]
+    [TestCase("13+镜代AP完成表")]
+    [TestCase("AP13+镜代完成表")]
+    public void MultiSelector_OrderIndependent(string raw)
+    {
+        // 多 selector + 阈值/难度的字段顺序应不影响解析结果（rightmost match + iterative strip）
+        var q = MustParse(raw);
+        Assert.That(q.Selectors, Has.Exactly(2).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
+        Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // 同类 selector 冲突 → ConflictingSelector
+    // ──────────────────────────────────────────────────────────────────────
+
+    [Test]
+    public void Conflict_TwoPlates()
+    {
+        var err = MustFail("镜代真完成表");
+        Assert.That(err.Kind, Is.EqualTo(PlateData.ErrorKind.ConflictingSelector));
+        Assert.That(err.Detail, Is.EqualTo("版本"));
+    }
+
+    [Test]
+    public void Conflict_TwoLevels()
+    {
+        var err = MustFail("13+15完成表");
+        Assert.That(err.Kind, Is.EqualTo(PlateData.ErrorKind.ConflictingSelector));
+        Assert.That(err.Detail, Is.EqualTo("难度或定数"));
+    }
+
+    [Test]
+    public void Conflict_LevelAndConstant()
+    {
+        // Constant 已隐含 Level；二者同给视作冲突
+        var err = MustFail("13+14.6完成表");
+        Assert.That(err.Kind, Is.EqualTo(PlateData.ErrorKind.ConflictingSelector));
+        Assert.That(err.Detail, Is.EqualTo("难度或定数"));
+    }
+
+    [Test]
+    public void Conflict_TwoGenres()
+    {
+        var err = MustFail("V家东方完成表");
+        Assert.That(err.Kind, Is.EqualTo(PlateData.ErrorKind.ConflictingSelector));
+        Assert.That(err.Detail, Is.EqualTo("类别"));
     }
 }

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -531,4 +531,36 @@ public class MaiMaiDxPlateDataTest
         Assert.That(err.Kind, Is.EqualTo(PlateData.ErrorKind.ConflictingSelector));
         Assert.That(err.Detail, Is.EqualTo("类别"));
     }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // 宴会場 special-case：宴谱只有 1-2 个低 idx 谱面（没有 MASTER+Re:MASTER），
+    // 默认 LevelIdxes=[3,4] 会全过滤光。Genre("宴会場") + 用户未给难度 → 默认全难度。
+    // ──────────────────────────────────────────────────────────────────────
+
+    [TestCase("宴会场完成表",   "宴会場")]
+    [TestCase("宴谱完成表",     "宴会場")]
+    public void BanquetGenreDefaultsToAllDifficulties(string raw, string fullName)
+    {
+        var q = MustParse(raw);
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Genre>());
+        Assert.That(((PlateData.Selector.Genre)q.Selectors.Single()).FullName, Is.EqualTo(fullName));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {0, 1, 2, 3, 4}),
+            "宴会場 Genre 用户未给难度时默认应扩为全难度");
+    }
+
+    [Test]
+    public void BanquetGenreExplicitDifficultyKept()
+    {
+        // 用户显式给 BASIC → LevelIdxes 仍是 [0]，不被特殊扩展
+        var q = MustParse("宴会场BASIC完成表");
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {0}));
+    }
+
+    [Test]
+    public void NonBanquetGenreKeepsDefaultMasterRemaster()
+    {
+        // 其他 Genre（如 V家）默认仍是 [3,4]；只 宴会場 特殊扩展
+        var q = MustParse("V家完成表");
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
+    }
 }

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -387,13 +387,14 @@ public partial class MaiMaiDx
         "\n" +
         "完整格式：mai (对象)(成绩)[难度]完成表\n" +
         "\n" +
-        "(对象) — 必填，六选一：\n" +
+        "(对象) — 必填，下面六类中可任选 1 个或多个（多个时取 AND 交集）：\n" +
         "  · 版本代字：真 / 超 / 橙 / 暁 / 熊 / 華 / 鏡 …（后面加 '代' 也行，例如 熊代）\n" +
         "  · 谱师名：例如 翠楼屋（合作谱 'サファ太 vs 翠楼屋' 也算上）\n" +
         "  · 类别：术力口 / V家 / 东方 / 击中 / 流行 / 动漫 / 其他 / 宴会场 / 舞萌\n" +
         "  · 作曲家：例如 HIMEHINA、DECO*27（合作名义 'sasakure.UK x DECO*27' 也算上）\n" +
         "  · 难度 label：13 / 13+ / 14 / 14+ 等（游戏内显示难度）\n" +
         "  · 定数：13.5 / 14.7 等（必含小数点，1 位小数）\n" +
+        "  注：同类只能给一个（'镜代真'、'13+15'、'13+14.6' 会报冲突）\n" +
         "\n" +
         "(成绩) — 不写就是 '将'（SSS）\n" +
         "  · 将=SSS / 大将=SSS+\n" +
@@ -405,13 +406,16 @@ public partial class MaiMaiDx
         "  · 绿谱 / 黄谱 / 红谱 / 紫谱 / 白谱（白谱 = Re:MASTER）\n" +
         "  · 或英文缩写 BSC / ADV / EXP / MST\n" +
         "\n" +
-        "其他例子（顺序可以随便换）：\n" +
-        "  mai 真完成表          ← 阈值省略，默认 '将'\n" +
+        "其他例子（字段顺序可以随便换）：\n" +
+        "  mai 真完成表             ← 阈值省略，默认 '将'\n" +
         "  mai 翠楼屋将完成表\n" +
         "  mai HIMEHINA神完成表\n" +
-        "  mai 14+大将完成表     ← 难度 label\n" +
-        "  mai 13.5神完成表      ← 定数\n" +
-        "  mai 紫谱将真完成表    ← 字段顺序随便换";
+        "  mai 14+大将完成表        ← 难度 label\n" +
+        "  mai 13.5神完成表         ← 定数\n" +
+        "  mai 紫谱将真完成表       ← 字段顺序随便换\n" +
+        "  mai 镜代13+AP完成表      ← 版本 + 难度 多 selector\n" +
+        "  mai 镜代V家将完成表      ← 版本 + 类别 多 selector\n" +
+        "  mai 14+翠楼屋将完成表    ← 难度 + 谱师 多 selector";
 
     public static MarisaPluginTrigger.PluginTrigger PlateTrigger => (message, _) =>
         message.Command.EndsWith(PlateData.CommandSuffix);

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -449,7 +449,7 @@ public partial class MaiMaiDx
 
         if (pairs.Count == 0)
         {
-            message.Reply($"没有找到 {query!.Selector.Display} 对应的歌曲");
+            message.Reply($"没有找到 {string.Join(" + ", query!.Selectors.Select(s => s.Display))} 对应的歌曲");
             return MarisaPluginTaskState.CompletedTask;
         }
 
@@ -474,61 +474,51 @@ public partial class MaiMaiDx
         {
             // 完成表默认 MASTER + Re:MASTER；用户显式给难度（红谱/EXPERT/...）则单元素 list 限定。
             var levelIdxes = q.LevelIdxes;
-            var allCharts = SongDb.SongList
+            return SongDb.SongList
                 .SelectMany(song => song.Constants.Select((constant, i) => (constant, i, song)))
-                .Where(t => levelIdxes.Contains(t.i));
-
-            return q.Selector switch
-            {
-                PlateData.Selector.Plate p => allCharts
-                    .Where(t => p.Versions.Any(v => string.Equals(v, t.song.Version, StringComparison.OrdinalIgnoreCase)))
-                    .Select(t => (t.constant, t.i, t.song))
-                    .ToList(),
-
-                // substring 匹配：兼容 "サファ太 vs 翠楼屋" 这种合作谱师名义。
-                PlateData.Selector.Charter c => allCharts
-                    .Where(t => t.i < t.song.Charters.Count
-                             && t.song.Charters[t.i].Contains(c.Name, StringComparison.OrdinalIgnoreCase))
-                    .Select(t => (t.constant, t.i, t.song))
-                    .ToList(),
-
-                // song-level substring 匹配，兼容 "sasakure.UK x DECO*27" 这种合作作曲名义。
-                PlateData.Selector.Artist a => allCharts
-                    .Where(t => !string.IsNullOrEmpty(t.song.Info.Artist)
-                             && t.song.Info.Artist.Contains(a.Name, StringComparison.OrdinalIgnoreCase))
-                    .Select(t => (t.constant, t.i, t.song))
-                    .ToList(),
-
-                // 谱师 ∪ 作曲家：处理 "rintaro soma" 这种身兼两职的人。
-                PlateData.Selector.CharterOrArtist ca => allCharts
-                    .Where(t => (t.i < t.song.Charters.Count
-                                 && t.song.Charters[t.i].Contains(ca.Name, StringComparison.OrdinalIgnoreCase))
-                              || (!string.IsNullOrEmpty(t.song.Info.Artist)
-                                  && t.song.Info.Artist.Contains(ca.Name, StringComparison.OrdinalIgnoreCase)))
-                    .Select(t => (t.constant, t.i, t.song))
-                    .ToList(),
-
-                PlateData.Selector.Genre g => allCharts
-                    .Where(t => string.Equals(t.song.Info.Genre, g.FullName, StringComparison.Ordinal))
-                    .Select(t => (t.constant, t.i, t.song))
-                    .ToList(),
-
-                // 难度 label：匹 song.Levels[i] 精确相等
-                PlateData.Selector.Level lvl => allCharts
-                    .Where(t => t.i < t.song.Levels.Count
-                             && string.Equals(t.song.Levels[t.i], lvl.Label, StringComparison.Ordinal))
-                    .Select(t => (t.constant, t.i, t.song))
-                    .ToList(),
-
-                // 定数：song.Constants[i] 精确等于 (0.05 tolerance for floating point safety；定数小数点 1 位)
-                PlateData.Selector.Constant cst => allCharts
-                    .Where(t => Math.Abs(t.constant - cst.Value) < 0.05)
-                    .Select(t => (t.constant, t.i, t.song))
-                    .ToList(),
-
-                _ => [],
-            };
+                .Where(t => levelIdxes.Contains(t.i))
+                .Where(t => q.Selectors.All(sel => MatchSelector(sel, t.constant, t.i, t.song)))
+                .Select(t => (t.constant, t.i, t.song))
+                .ToList();
         }
+
+        // 单 chart × 单 selector 的命中判断；handler 用 Selectors.All(...) 求 AND 交集。
+        static bool MatchSelector(PlateData.Selector sel, double constant, int levelIdx, MaiMaiSong song) => sel switch
+        {
+            PlateData.Selector.Plate p =>
+                p.Versions.Any(v => string.Equals(v, song.Version, StringComparison.OrdinalIgnoreCase)),
+
+            // substring 匹配：兼容 "サファ太 vs 翠楼屋" 这种合作谱师名义。
+            PlateData.Selector.Charter c =>
+                levelIdx < song.Charters.Count
+                && song.Charters[levelIdx].Contains(c.Name, StringComparison.OrdinalIgnoreCase),
+
+            // song-level substring 匹配，兼容 "sasakure.UK x DECO*27" 这种合作作曲名义。
+            PlateData.Selector.Artist a =>
+                !string.IsNullOrEmpty(song.Info.Artist)
+                && song.Info.Artist.Contains(a.Name, StringComparison.OrdinalIgnoreCase),
+
+            // 谱师 ∪ 作曲家：处理 "rintaro soma" 这种身兼两职的人。
+            PlateData.Selector.CharterOrArtist ca =>
+                (levelIdx < song.Charters.Count
+                 && song.Charters[levelIdx].Contains(ca.Name, StringComparison.OrdinalIgnoreCase))
+                || (!string.IsNullOrEmpty(song.Info.Artist)
+                    && song.Info.Artist.Contains(ca.Name, StringComparison.OrdinalIgnoreCase)),
+
+            PlateData.Selector.Genre g =>
+                string.Equals(song.Info.Genre, g.FullName, StringComparison.Ordinal),
+
+            // 难度 label：匹 song.Levels[i] 精确相等
+            PlateData.Selector.Level lvl =>
+                levelIdx < song.Levels.Count
+                && string.Equals(song.Levels[levelIdx], lvl.Label, StringComparison.Ordinal),
+
+            // 定数：song.Constants[i] 精确等于 (0.05 tolerance for floating point safety；定数小数点 1 位)
+            PlateData.Selector.Constant cst =>
+                Math.Abs(constant - cst.Value) < 0.05,
+
+            _ => false,
+        };
     }
 
     #endregion

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -387,14 +387,14 @@ public partial class MaiMaiDx
         "\n" +
         "完整格式：mai (对象)(成绩)[难度]完成表\n" +
         "\n" +
-        "(对象) — 必填，下面六类中可任选 1 个或多个（多个时取 AND 交集）：\n" +
+        "(对象) — 必填，下面六类中至少给 1 个；也可以同时给多个，要求歌曲全部满足才入选：\n" +
         "  · 版本代字：真 / 超 / 橙 / 暁 / 熊 / 華 / 鏡 …（后面加 '代' 也行，例如 熊代）\n" +
         "  · 谱师名：例如 翠楼屋（合作谱 'サファ太 vs 翠楼屋' 也算上）\n" +
         "  · 类别：术力口 / V家 / 东方 / 击中 / 流行 / 动漫 / 其他 / 宴会场 / 舞萌\n" +
         "  · 作曲家：例如 HIMEHINA、DECO*27（合作名义 'sasakure.UK x DECO*27' 也算上）\n" +
         "  · 难度 label：13 / 13+ / 14 / 14+ 等（游戏内显示难度）\n" +
         "  · 定数：13.5 / 14.7 等（必含小数点，1 位小数）\n" +
-        "  注：同类只能给一个（'镜代真'、'13+15'、'13+14.6' 会报冲突）\n" +
+        "  注：同一类不能给两个（如 '镜代真'/'13+15'/'13+14.6' 会冲突报错）\n" +
         "\n" +
         "(成绩) — 不写就是 '将'（SSS）\n" +
         "  · 将=SSS / 大将=SSS+\n" +
@@ -413,9 +413,9 @@ public partial class MaiMaiDx
         "  mai 14+大将完成表        ← 难度 label\n" +
         "  mai 13.5神完成表         ← 定数\n" +
         "  mai 紫谱将真完成表       ← 字段顺序随便换\n" +
-        "  mai 镜代13+AP完成表      ← 版本 + 难度 多 selector\n" +
-        "  mai 镜代V家将完成表      ← 版本 + 类别 多 selector\n" +
-        "  mai 14+翠楼屋将完成表    ← 难度 + 谱师 多 selector";
+        "  mai 镜代13+AP完成表      ← 版本 + 难度 组合\n" +
+        "  mai 镜代V家将完成表      ← 版本 + 类别 组合\n" +
+        "  mai 14+翠楼屋将完成表    ← 难度 + 谱师 组合";
 
     public static MarisaPluginTrigger.PluginTrigger PlateTrigger => (message, _) =>
         message.Command.EndsWith(PlateData.CommandSuffix);

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -464,10 +464,11 @@ public partial class MaiMaiDx
 
         static string FormatError(PlateData.ParseError err) => err.Kind switch
         {
-            PlateData.ErrorKind.UnsupportedPlate => $"不支持该版本：{err.Detail}",
-            PlateData.ErrorKind.UnknownSelector  => $"无法识别版本/谱师/类别/作曲家/难度/定数：{err.Detail}",
-            PlateData.ErrorKind.EmptyQuery       => "'完成表' 前面要写一个版本代字 / 谱师名 / 类别 / 作曲家名 / 难度 / 定数",
-            _                                    => "命令格式错误",
+            PlateData.ErrorKind.UnsupportedPlate     => $"不支持该版本：{err.Detail}",
+            PlateData.ErrorKind.UnknownSelector      => $"无法识别版本/谱师/类别/作曲家/难度/定数：{err.Detail}",
+            PlateData.ErrorKind.EmptyQuery           => "'完成表' 前面要写一个版本代字 / 谱师名 / 类别 / 作曲家名 / 难度 / 定数",
+            PlateData.ErrorKind.ConflictingSelector  => $"{err.Detail}只能指定一次",
+            _                                        => "命令格式错误",
         };
 
         List<(double Constant, int LevelIdx, MaiMaiSong Song)> SelectCharts(PlateData.Query q)


### PR DESCRIPTION
PR #38 后续 — 用户反馈 2 个功能改进 + 顺手补 1 个 bug。

## Commits

### 1. \`e74df1b\` refactor(maimai): PlateData.Query Selector → Selectors list

纯重构铺路。\`Query.Selector\` (单) → \`Selectors: IReadOnlyList<Selector>\`。TryParse 仍返回单 selector list，行为不变。

### 2. \`3ba4450\` feat(maimai): 完成表支持多 selector AND 组合 (用户反馈 #1)

之前 \`镜代13+AP完成表\` 无法解析出"镜代版本的所有 13+ 谱面"。重写 TryParse 第 3 步成迭代式：每轮在剩余 selectorPart 内找一个'硬'token (Plate / Genre / Constant / Level) 的最佳匹配 (length DESC, rightmost tie-break)，剥掉，加入 selectors。直到无新匹配。剩下连续片段走 Charter / Artist / CharterOrArtist / catch-all。

handler SelectCharts 改用 \`q.Selectors.All(MatchSelector(...))\` 求 AND 交集。

冲突规则：
- 同类 selector 出现两次 → \`ConflictingSelector\` 报错
- Level + Constant 同给 → 也算冲突 (Constant 隐含 Level)

例子：\`镜代13+AP完成表\` / \`镜代V家将完成表\` / \`14+翠楼屋将完成表\` / \`镜代13+V家将完成表\`

### 3. \`1bba31d\` fix(maimai): stats-bar 中央完成率按命令阈值动态计算 (用户反馈 #2)

之前 \`StatsBar.vue\` 硬编码 \`(rankStat.app+sssp+sss)/total\` = "SSS 及以上" 完成率，跟用户输入的阈值维度脱钩。例如 \`镜神完成表\` (Fc=AP) 应显示 AP 完成率，但实际显示的是 SSS 完成率。

改成按 \`plate.Dim\` + \`plate.Level\` 动态算：Achievement / Fc / Fs 三个维度分发。sum mode 兜底 SSS 维持现有行为。抽 Summary.vue 私有的 ordinal 函数到 \`utils/ordinal.ts\` 让 StatsBar 复用。

### 4. \`6ba94c3\` fix(maimai): 宴会場 Genre 默认扩展到全难度（顺手修，用户报）

\`宴会场完成表\` / \`宴谱完成表\` 在 master 上报"没有找到对应的歌曲"。原因：宴谱 (id > 100000) 只有 1-2 个低 idx 谱面（没有 MASTER+Re:MASTER），\`PlateData.DefaultLevelIdxes=[3,4]\` 把它们全过滤光。

TryParse 后置 special-case：selector 命中 \`Genre("宴会場")\` 且用户没显式给难度 → 强制 LevelIdxes 扩成 \`[0..4]\` 全难度。

### 5. \`3367443\` docs(maimai): PlateUsage 增加多 selector 例子 + 冲突说明

帮助文本里加 3 个 multi-selector 例子，并提示同类 selector 冲突。

## 视觉验证

\`mai 辉代14+神完成表\` 一图覆盖了 commit 1-3 的所有功能点：

![辉代14+神完成表](https://github.com/NakashimaYuki/MarisaBot/releases/download/plate-progress-vue-preview/35-plate-hui-14plus-shen-v11.png)

- **Title** \`辉代14+神完成表\` — 多 selector 输入正确保留（Commit 1, 2）
- **筛 11 个 chart** = FiNALE (辉代) ∩ 14+ master+remaster — 多 selector AND filter 工作（Commit 2）
- **顶部 72.73%** = 8 AP / 11 total — **按 AP 维度算**而非 SSS（Commit 3）。这就是与 PR #38 v10 的关键差别（v10 也是 14+神但显示的是 SSS%）
- **14.9 / 14.8 group** 全 AP → 100.00% + SSS+ min-rank icon
- **14.7 / 14.6 group** 有 NP → 0.00% + 不显示 min-rank（PR #38 Commit 3 保留）

## Test plan

- [x] \`dotnet build\` clean (0 warning)
- [x] \`MaiMaiDxPlateDataTest\` 115/115 通过（96 旧 + 15 multi-sel + 4 banquet）
- [x] \`WebContextTest\` 3/3 通过
- [x] \`vite build\` 0 error
- [x] 视觉验证：\`辉代14+神完成表\` 截图 v11