### PR TITLE
fix(guess): 修猜歌排名 Realm IQueryable.Take 不支持

### DIFF
--- a/Marisa.Plugin.Shared/Interface/IMarisaPluginWithCoverGuess.cs
+++ b/Marisa.Plugin.Shared/Interface/IMarisaPluginWithCoverGuess.cs
@@ -25,10 +25,15 @@ public interface IMarisaPluginWithCoverGuess<TSong, TSongGuess> where TSong : So
             .OrderByDescending(g => g.TimesCorrect)
             .ThenBy(g => g.TimesWrong)
             .ThenBy(g => g.TimesStart)
+            .AsEnumerable()
             .Take(10)
             .ToList();
 
-        if (res.Count == 0) message.Reply("None");
+        if (res.Count == 0)
+        {
+            message.Reply("None");
+            return MarisaPluginTaskState.CompletedTask;
+        }
 
         message.Reply(string.Join('\n', res.Select((guess, i) =>
             $"{i + 1}、 {guess.Name}： (s:{guess.TimesStart}, w:{guess.TimesWrong}, c:{guess.TimesCorrect})")));


### PR DESCRIPTION
## Summary

- 群里输入"舞萌猜歌排名"报错 `The method 'Take' is not supported`。Realm 的 LINQ provider 不支持 `Skip`/`Take`，在 `OrderBy`/`ThenBy` 后插 `AsEnumerable()` 切回 LINQ to Objects 再 `Take(10)`。Sort 仍在 native 侧，`Take` 是 streaming 不会全表枚举。
- 顺手修空结果 fallthrough：原代码 `res.Count == 0` 时 `Reply("None")` 后没 `return`，会继续 reply 一条空字符串。
- 这是 `IMarisaPluginWithCoverGuess<,>` 的 default interface method，maimai / chunithm / ongeki 三个游戏共用，一处修三处生效。

## Test plan

- [x] `dotnet build Marisa.Plugin/Marisa.Plugin.csproj` — 0 errors, 0 warnings
- [x] 群里发 `mai 猜歌排名` / `chu 猜歌排名` / `ongeki 猜歌排名` 不再抛异常
- [x] 数据库无记录时回复 `None` 后不再多发一条空消息
- [x] 有记录时正常返回前 10 排名

🤖 Generated with [Claude Code](https://claude.com/claude-code)