### PR TITLE
fix(maimai): 完成表解析保护含版本代字的谱师名

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -413,6 +413,15 @@ public static class PlateData
 
             if (matchStart < 0) break;
 
+            // 反查保护：版本代字/类别单字若嵌在更长且能对上某谱师/曲师名的片段里（如"隅田川星人"的"星"、"超七味"的"超"），它是名字的一部分而非 selector，否决匹配让整段落到下面 Charter/Artist
+            if (matched is Selector.Plate or Selector.Genre
+                && workingPart.Length > matchLen
+                && (TryResolveCharterPrecise(workingPart, knownCharters, out _)
+                    || TryResolveArtist(workingPart, knownArtists, out _)))
+            {
+                break;
+            }
+
             // 同类冲突检查（Level + Constant 视为同类——Constant 隐含 Level，二者只能给一个）
             if (matched is Selector.Plate && selectors.OfType<Selector.Plate>().Any())
             {

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -12,6 +12,7 @@ public class MaiMaiDxPlateDataTest
     private static readonly IReadOnlyCollection<string> Charters =
     [
         "翠楼屋", "サファ太 vs 翠楼屋", "Jack", "はっぴー", "ロシェ@ペンギン", "rioN", "rintaro soma",
+        "超七味星人", "隅田川星人", // 名字含版本代字（超=GreeN / 星=UNiVERSE），验证反查保护
     ];
 
     // 含合作名义"sasakure.UK x DECO*27"，验证 substring 命中；"HIMEHINA" 验证纯 artist 单边命中。
@@ -682,5 +683,38 @@ public class MaiMaiDxPlateDataTest
     public void DxScoreStarHelper_Boundaries(int dxScore, int maxDx, int expected)
     {
         Assert.That(PlateData.DxScoreStar(dxScore, maxDx), Is.EqualTo(expected));
+    }
+
+    // 反查保护：谱师名里恰好含版本代字时（"超七味星人"含超/星、"隅田川星人"含星），整名当 charter，不被切成 Plate + 残名。覆盖全名与半截名。
+    [TestCase("隅田川星人将完成表", "隅田川星人")]
+    [TestCase("隅田川星人完成表",   "隅田川星人")]
+    [TestCase("超七味星人完成表",   "超七味星人")]
+    [TestCase("超七味完成表",       "超七味")]
+    public void ProtectsCharterNameContainingPlateKanji(string raw, string charter)
+    {
+        var query = MustParse(raw);
+        Assert.That(query.Selectors, Has.None.InstanceOf<PlateData.Selector.Plate>());
+        Assert.That(query.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(((PlateData.Selector.Charter)query.Selectors.Single()).Name, Is.EqualTo(charter));
+    }
+
+    // 只给一个版本代字字时（即便 mock 里存在含该字的谱师），length == 代字长度，length 判据短路保护，仍当版本。
+    [TestCase("超将完成表", "超")]
+    [TestCase("星将完成表", "星")]
+    public void StillTreatsBarePlateKanjiAsVersion(string raw, string kanji)
+    {
+        var query = MustParse(raw);
+        Assert.That(query.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Plate>());
+        Assert.That(((PlateData.Selector.Plate)query.Selectors.Single()).Kanji, Is.EqualTo(kanji));
+    }
+
+    // 多轮 strip 后保护仍生效：先 strip Level(14)，剩"超七味星人"再触发反查保护，与 Level selector 共存。
+    [Test]
+    public void ProtectsCharterNameAlongsideLevelToken()
+    {
+        var query = MustParse("超七味星人14完成表");
+        Assert.That(query.Selectors, Has.None.InstanceOf<PlateData.Selector.Plate>());
+        Assert.That(query.Selectors.OfType<PlateData.Selector.Charter>().Single().Name, Is.EqualTo("超七味星人"));
+        Assert.That(query.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("14"));
     }
 }


### PR DESCRIPTION
## 问题

实际使用中，部分谱师名恰好包含版本代字单字，被多 selector 解析循环误切：

- `mai 隅田川星人将完成表` → `隅田川星人` 里的 `星`(UNiVERSE) 被切成 `Plate(星) + Charter(隅田川人)` → 0 首
- `mai 超七味`(半截名) → `超`(GreeN) 被切成 `Plate(超) + Charter(七味)`，限定在 GreeN 版找含「七味」的谱师 → 0 首

根因：`TryFindRightmostPlateInString` 对版本代字单字做 `LastIndexOf`，只问「这个字在不在串里」，不问「它是不是某个谱师名的一部分」。

## 修复

在解析循环里加**反查保护**：当本轮最优硬 token 是 `Plate`/`Genre` 单字、且**当前剩余片段整体能对上某个已知谱师/曲师名、且比该代字更长**时，否决这次匹配，让整段落到下面的 Charter/Artist 解析。

关键是那个长度判据 `workingPart.Length > matchLen`，它精确区分两种意图：

| 输入（剥离成绩/难度后） | 是谱师子串？ | 比代字长？ | 结论 |
|---|---|---|---|
| `真` | 可能 | 否 (1==1) | 当版本（不误伤） |
| `隅田川星人` | 是 | 是 (5>1) | 当谱师 |
| `超七味` | 是(`超七味星人`含它) | 是 (3>1) | 当谱师 |
| `超14` | 否 | — | 正常 strip 版本+等级 |

复用现有 `TryResolveCharterPrecise` / `TryResolveArtist`，不新增 helper，不碰 handler。对「字段随意互换」的设计零破坏。

## Test plan

- [x] `dotnet test --filter MaiMaiDxPlateDataTest` — 165 passed（原有 + 新增 7 个 case）
- [x] 反查保护：全名 `隅田川星人` / 半截名 `超七味` 解析为单 Charter，无 Plate
- [x] 不误伤：单字 `超`/`星`（mock 里存在含该字的谱师）仍解析为 Plate
- [x] 多轮共存：`超七味星人14` → Charter + Level(14)
- [x] 群里实测 `mai 隅田川星人将完成表` / `mai 超七味完成表` 返回正确歌曲集

🤖 Generated with [Claude Code](https://claude.com/claude-code)