### PR TITLE
fix: reset 命令空操作 + 派生缓存不刷新

### DIFF
--- a/Marisa.Plugin.Shared/Util/SongDb/SongDb.cs
+++ b/Marisa.Plugin.Shared/Util/SongDb/SongDb.cs
@@ -75,7 +75,15 @@ public class SongDb<TSong> : ICanReset where TSong : Song
 
     public void Reset()
     {
-        _songList = null;
+        // 重新生成歌单，并作废所有从它派生的缓存——否则 SongList 虽刷新，
+        // SongIndexer / SongAlias 仍指向旧数据（b50 的 is_new 走 SongIndexer，会一直 stale）。
+        _songList    = null;
+        _songIndexer = null;
+
+        // alias 索引重建时会新建 FileSystemWatcher，先 dispose 旧的防泄漏。
+        _songAliasChangedWatcher?.Dispose();
+        _songAliasChangedWatcher = null!;
+        _songAlias               = null;
     }
 
     private Dictionary<ReadOnlyMemory<char>, List<ReadOnlyMemory<char>>> GetSongAliases()

--- a/Marisa.Plugin.Test/SongDbResetTest.cs
+++ b/Marisa.Plugin.Test/SongDbResetTest.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Linq;
+using Marisa.Plugin.Shared.Interface;
+using Marisa.Plugin.Shared.Util.SongDb;
+using NUnit.Framework;
+using SixLabors.ImageSharp;
+
+namespace Marisa.Plugin.Test;
+
+public class SongDbResetTest
+{
+    private sealed class StubSong : Song
+    {
+        // 测试只用到 Id / Title（SongIndexer 走 ToDictionary(Id)），其余抽象成员不会被调用。
+        public override string MaxLevel() => throw new NotSupportedException();
+        public override string GetImage() => throw new NotSupportedException();
+        public override Image  GetCover() => throw new NotSupportedException();
+    }
+
+    private static SongDb<StubSong> NewDb(Func<int, StubSong[]> gen, out Func<int> calls)
+    {
+        var n = 0;
+        calls = () => n;
+        var capture = gen;
+        return new SongDb<StubSong>("nonexistent.tsv", "nonexistent.tmp", () =>
+        {
+            n++;
+            return capture(n).ToList();
+        });
+    }
+
+    [Test]
+    public void Reset_RegeneratesSongList_AndRebuildsIndexer()
+    {
+        var db = NewDb(gen => [new StubSong { Id = gen, Title = $"song{gen}" }], out var calls);
+
+        var list1  = db.SongList;     // 触发生成 #1
+        var index1 = db.SongIndexer;  // 从 #1 建索引
+        Assert.That(calls(), Is.EqualTo(1));
+        Assert.That(index1[1].Title, Is.EqualTo("song1"));
+
+        db.Reset();
+
+        var list2  = db.SongList;     // 应重新生成 #2
+        var index2 = db.SongIndexer;  // 应重建
+
+        Assert.That(calls(), Is.EqualTo(2), "Reset 后再访问 SongList 应重新调用 generator");
+        Assert.That(list2,  Is.Not.SameAs(list1));
+        // 这条是 b50 rollover 的关键：SongIndexer 必须一起作废重建，否则 is_new 查询仍读旧索引。
+        Assert.That(index2, Is.Not.SameAs(index1), "Reset 后 SongIndexer 必须重建");
+        Assert.That(index2.ContainsKey(2), Is.True,  "新索引应反映重新生成的歌单");
+        Assert.That(index2.ContainsKey(1), Is.False, "旧歌单的 id 不应残留在新索引里");
+    }
+
+    [Test]
+    public void ResetCommandFilter_NeedsInterfaceCheck_NotIsSubclassOf()
+    {
+        // 复刻 reset 命令的筛选语义：从一堆对象里挑出实现了 ICanReset 的。
+        var db = NewDb(_ => [], out _);
+        object[] items = { db, "not-resettable", 123 };
+
+        // 曾经的坏写法：IsSubclassOf 只认类继承链，对接口恒 false → 一个都选不中（reset 因此空转）。
+        var brokenCount = items.Count(x => x.GetType().IsSubclassOf(typeof(ICanReset)));
+        Assert.That(brokenCount, Is.EqualTo(0), "IsSubclassOf(接口) 恒 false，钉住这个陷阱");
+
+        // 正确写法：OfType 做接口判断 + 转换。
+        var selected = items.OfType<ICanReset>().ToList();
+        Assert.That(selected, Has.Count.EqualTo(1));
+        Assert.That(selected[0], Is.SameAs(db));
+    }
+}

--- a/Marisa.Plugin/Chunithm/Chunithm.cs
+++ b/Marisa.Plugin/Chunithm/Chunithm.cs
@@ -43,7 +43,10 @@ public partial class Chunithm :
     public void Reset()
     {
         SongDb.Reset();
-        new DivingFishDataFetcher(SongDb).Reset();
+        // 共享歌单缓存是 LxnsDataFetcher 的 static _songList（DivingFish 也走它），必须清；
+        // DivingFish 自己的 _songTitleIndexer 是实例字段、handler 每次请求都新建 fetcher，
+        // 对临时实例调 Reset 没有意义，故不再调用它。
+        new LxnsDataFetcher(SongDb).Reset();
         new LouisDataFetcher(SongDb).Reset();
     }
 

--- a/Marisa.Plugin/Command.cs
+++ b/Marisa.Plugin/Command.cs
@@ -378,10 +378,9 @@ public class Command : MarisaPluginBase
             return MarisaPluginTaskState.CompletedTask;
         }
 
-        var filtered =
-            from plugin in plugins
-            where plugin.GetType().IsSubclassOf(typeof(ICanReset))
-            select plugin as ICanReset;
+        // 必须用 OfType/is，不能用 plugin.GetType().IsSubclassOf(typeof(ICanReset))——
+        // IsSubclassOf 只认类继承链，对「接口」恒返回 false，曾导致 reset 命令完全空转。
+        var filtered = plugins.OfType<ICanReset>();
 
         foreach (var canReset in filtered)
         {


### PR DESCRIPTION
## 问题

`reset` 命令（清插件缓存、用于版本更新后免重启刷新歌单）**自 2024-12 引入起从未生效过**。`Command.cs` 用 `plugin.GetType().IsSubclassOf(typeof(ICanReset))` 筛插件，但 `ICanReset` 是接口，而 `Type.IsSubclassOf` 只走类继承链、对接口**恒返回 false**，筛选结果永远为空 → `foreach { Reset() }` 一次都没跑过。（git 追溯：buggy 谓词与 reset 命令是同一 commit `58413009` 引入，之后没人动过。）

把命令修活后，又发现两处「刷了等于没刷」：

1. **`SongDb.Reset` 只置空 `_songList`**，没动派生的 `_songIndexer` / `_songAlias`。b50 新旧划分走 `SongDb.SongIndexer[id].Info.IsNew` —— 旧索引不重建就一直 stale，**这正是版本更新后 `is_new` 不刷新的直接根因**。
2. **`Chunithm.Reset` 漏清真正的缓存**：`new DivingFishDataFetcher(SongDb).Reset()` 清的是临时实例的实例字段（handler 每次请求都新建 fetcher，从不复用），无意义；而真正被共享的歌单缓存是 `LxnsDataFetcher` 的 `static _songList`（DivingFish 也经 `GetSharedSongList` 走它），之前从没被清过。

## 改动

- `Command.cs`：`IsSubclassOf` → `plugins.OfType<ICanReset>()`（接口感知）。
- `SongDb.Reset`：一并作废 `_songIndexer` 与 `_songAlias`；重建 alias 索引会新建 `FileSystemWatcher`，先 `Dispose()` 旧的防泄漏。
- `Chunithm.Reset`：去掉无意义的 DivingFish throwaway-reset，补上 `LxnsDataFetcher.Reset()`（清共享 static 歌单），保留 Louis（它也是 static 缓存）。

各 fetcher 自身的 `Reset()` 方法未改，只改了「谁来调、调谁」。

## 影响

修好后，机厅版本更新（如本次舞萌DX2026 / PRiSM PLUS）导致 diving-fish `is_new` 翻转时，维护者发一句 `reset` 即可热刷新 maimai 歌单与新旧划分，不必重启进程。

## Test plan

- [x] `dotnet test --filter SongDbResetTest` — 2 passed（`Reset` 后 SongIndexer 必须重建；reset 筛选必须用接口判断而非 IsSubclassOf）
- [x] 全量编译通过（Command/Chunithm/SongDb 改动均 0 error）
- [ ] 线上 `reset` 后 `mai b50` 反映最新新旧划分

🤖 Generated with [Claude Code](https://claude.com/claude-code)