### PR TITLE
feat(maimai): 传分/导——经 maimai-score-hub 同步机台成绩到水鱼/落雪

### DIFF
--- a/Marisa.Database/BotDbContext.cs
+++ b/Marisa.Database/BotDbContext.cs
@@ -23,7 +23,9 @@ public static class BotDbContext
 
         return Realm.GetInstance(new RealmConfiguration(DatabasePath)
         {
-            SchemaVersion = 4
+            // 5: MaiMaiDxBind 增加 FriendCode（可空列，自动迁移给旧行补 null）。
+            // 注意：字符串列必须保持 optional——optional→required 的自动迁移会清空整列存量数据
+            SchemaVersion = 5
         });
     }
 

--- a/Marisa.Database/BotDbContext.cs
+++ b/Marisa.Database/BotDbContext.cs
@@ -23,8 +23,6 @@ public static class BotDbContext
 
         return Realm.GetInstance(new RealmConfiguration(DatabasePath)
         {
-            // 5: MaiMaiDxBind 增加 FriendCode（可空列，自动迁移给旧行补 null）。
-            // 注意：字符串列必须保持 optional——optional→required 的自动迁移会清空整列存量数据
             SchemaVersion = 5
         });
     }

--- a/Marisa.Database/Entity/Plugin/MaiMaiDx/MaiMaiDxBind.cs
+++ b/Marisa.Database/Entity/Plugin/MaiMaiDx/MaiMaiDxBind.cs
@@ -22,4 +22,10 @@ public partial class MaiMaiDxBind : IRealmObject, IHaveId, IHaveUId
     public int AimeId { get; set; }
 
     public string ServerName { get; set; } = string.Empty;
+
+    /// <summary>
+    ///     maimai DX 好友码（游戏内「フレンド」里的数字）。用于 `导` 命令经 maimai-score-hub 推分。
+    ///     仅存好友码（非机密），查分器导入令牌不落库。可空：老数据自动迁移。
+    /// </summary>
+    public string? FriendCode { get; set; }
 }

--- a/Marisa.Database/Entity/Plugin/MaiMaiDx/MaiMaiDxBind.cs
+++ b/Marisa.Database/Entity/Plugin/MaiMaiDx/MaiMaiDxBind.cs
@@ -22,7 +22,6 @@ public partial class MaiMaiDxBind : IRealmObject, IHaveId, IHaveUId
 
     public int AimeId { get; set; }
 
-    // 注解必须保持可空：optional→required 的 Realm 自动迁移是删列重建，会清空存量数据
     public string? ServerName { get; set; } = string.Empty;
 
     /// <summary>

--- a/Marisa.Database/Entity/Plugin/MaiMaiDx/MaiMaiDxBind.cs
+++ b/Marisa.Database/Entity/Plugin/MaiMaiDx/MaiMaiDxBind.cs
@@ -1,4 +1,5 @@
-﻿using Marisa.Database.Entity;
+﻿#nullable enable
+using Marisa.Database.Entity;
 using Realms;
 
 namespace Marisa.Database.Entity.Plugin.MaiMaiDx;
@@ -21,7 +22,8 @@ public partial class MaiMaiDxBind : IRealmObject, IHaveId, IHaveUId
 
     public int AimeId { get; set; }
 
-    public string ServerName { get; set; } = string.Empty;
+    // 注解必须保持可空：optional→required 的 Realm 自动迁移是删列重建，会清空存量数据
+    public string? ServerName { get; set; } = string.Empty;
 
     /// <summary>
     ///     maimai DX 好友码（游戏内「フレンド」里的数字）。用于 `导` 命令经 maimai-score-hub 推分。

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Flurl.Http;
+
+namespace Marisa.Plugin.Shared.MaiMaiDx;
+
+/// <summary>
+///     bakapiano 的 maimai-score-hub (MSH) 公开 API 的轻量客户端。
+///     用于 <c>maimai 导</c> 命令把玩家的华立成绩推到他【本人】的水鱼 / 落雪查分器。
+///     MSH 官方开放接入（公开 OpenAPI + 全开 CORS）；我们带一个专门的 User-Agent 表明身份。
+///     契约见 https://github.com/bakapiano/maimai-score-hub/blob/main/shared/openapi/openapi.yaml
+/// </summary>
+public class MaiScoreHubClient
+{
+    public const string BaseUrl = "https://maimai.bakapiano.com/api";
+
+    private const string UserAgent = "MarisaBot-maimai-sync/1.0 (+https://github.com/QingQiz/MarisaBot)";
+
+    private static IFlurlRequest Req(string path) => $"{BaseUrl}{path}"
+        .WithHeader("User-Agent", UserAgent)
+        .WithTimeout(30);
+
+    private static IFlurlRequest Authed(string path, string jwt) => Req(path)
+        .WithHeader("Authorization", "Bearer " + jwt);
+
+    public sealed record LoginRequestResult(string JobId, string? BotFriendCode, string? Message);
+
+    public sealed record LoginStatusResult(bool Done, string Status, string? Stage, string? Token, string? Message);
+
+    public sealed record ProfileResult(bool HasLxns, bool HasDivingFish, bool AutoLxns, bool AutoDivingFish);
+
+    public sealed record ExportResult(bool Success, int Exported, int Scores, string? Message);
+
+    /// <summary>POST /auth/login-request — 用好友码发起登录+抓分任务。</summary>
+    public async Task<LoginRequestResult> LoginRequestAsync(string friendCode)
+    {
+        var json = await Req("/auth/login-request")
+            .PostJsonAsync(new { friendCode, skipUpdateScore = false, useIdleUpdate = false })
+            .ReceiveString();
+
+        using var doc = JsonDocument.Parse(json);
+        var root  = doc.RootElement;
+        var jobId = root.TryGetProperty("jobId", out var j) ? j.GetString() ?? "" : "";
+
+        string? bot = null;
+        if (root.TryGetProperty("job", out var job) && job.ValueKind == JsonValueKind.Object &&
+            job.TryGetProperty("botUserFriendCode", out var b) && b.ValueKind == JsonValueKind.String)
+        {
+            bot = b.GetString();
+        }
+
+        var msg = root.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String ? m.GetString() : null;
+        return new LoginRequestResult(jobId, bot, msg);
+    }
+
+    /// <summary>GET /auth/login-status?jobId= — 轮询任务，完成时附带 JWT。</summary>
+    public async Task<LoginStatusResult> LoginStatusAsync(string jobId)
+    {
+        var json = await Req("/auth/login-status").SetQueryParam("jobId", jobId).GetStringAsync();
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        string? S(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+        var status = S("status") ?? "";
+        var token  = S("token");
+        var done   = root.TryGetProperty("done", out var d) && d.ValueKind == JsonValueKind.True;
+
+        // 拿到 token（或终态 completed）就算抓分完成
+        if (!string.IsNullOrEmpty(token) || status == "completed") done = true;
+
+        return new LoginStatusResult(done, status, S("stage"), token, S("message"));
+    }
+
+    /// <summary>GET /users/profile（Bearer）— 看 MSH 里已配置了哪些查分器令牌。</summary>
+    public async Task<ProfileResult> GetProfileAsync(string jwt)
+    {
+        var json = await Authed("/users/profile", jwt).GetStringAsync();
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        bool B(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.True;
+
+        return new ProfileResult(B("hasLxnsImportToken"), B("hasDivingFishImportToken"), B("autoExportLxns"), B("autoExportDivingFish"));
+    }
+
+    /// <summary>PATCH /users/profile（Bearer）— 设置某查分器导入令牌并开启自动导出。</summary>
+    public async Task SetTokenAsync(string jwt, string prober, string token)
+    {
+        object body = prober == "lxns"
+            ? new { lxnsImportToken = token, autoExportLxns = true }
+            : new { divingFishImportToken = token, autoExportDivingFish = true };
+
+        await Authed("/users/profile", jwt).PatchJsonAsync(body);
+    }
+
+    /// <summary>POST /sync/latest/{prober}（Bearer）— 把抓到的成绩推到用户自己的查分器。</summary>
+    public async Task<ExportResult> ExportAsync(string jwt, string prober)
+    {
+        var path = prober == "lxns" ? "/sync/latest/lxns" : "/sync/latest/diving-fish";
+
+        var json = await Authed(path, jwt)
+            .AllowHttpStatus("400-499")
+            .PostJsonAsync(new { })
+            .ReceiveString();
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        int I(string k) => root.TryGetProperty(k, out var v) && v.TryGetInt32(out var n) ? n : 0;
+
+        var success = root.TryGetProperty("success", out var s) && s.ValueKind == JsonValueKind.True;
+        var msg     = root.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String ? m.GetString() : null;
+
+        return new ExportResult(success, I("exported"), I("scores"), msg);
+    }
+}

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -24,7 +24,7 @@ public class MaiScoreHubClient
 
     public sealed record LoginRequestResult(string JobId, string? BotFriendCode, string? AuthToken, string? Message);
 
-    public sealed record LoginStatusResult(bool Done, string Status, string? Stage, string? Token, string? Message);
+    public sealed record LoginStatusResult(bool Done, string Status, string? Stage, string? Token, string? Message, string? BotFriendCode);
 
     public sealed record ProfileResult(bool HasLxns, bool HasDivingFish, bool AutoLxns, bool AutoDivingFish);
 
@@ -61,16 +61,25 @@ public class MaiScoreHubClient
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        string? S(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+        string? S(JsonElement e, string k) => e.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
 
-        var status = S("status") ?? "";
-        var token  = S("token");
+        var status = S(root, "status") ?? "";
+        var token  = S(root, "token");
         var done   = root.TryGetProperty("done", out var d) && d.ValueKind == JsonValueKind.True;
 
-        // 拿到 token（或终态 completed）就算抓分完成
+        // 实测 stage / 失败原因 / 机器人好友码都在嵌套的 job 里（根级没有；完成时整个 job 缺失）
+        string? stage = null, error = null, botFriendCode = null;
+        if (root.TryGetProperty("job", out var job) && job.ValueKind == JsonValueKind.Object)
+        {
+            stage         = S(job, "stage");
+            error         = S(job, "error");
+            botFriendCode = S(job, "botUserFriendCode");
+        }
+
+        // 拿到 token（或终态 completed）就算抓分完成——实测完成时 status 仍是 processing 且无 done 字段
         if (!string.IsNullOrEmpty(token) || status == "completed") done = true;
 
-        return new LoginStatusResult(done, status, S("stage"), token, S("message"));
+        return new LoginStatusResult(done, status, stage, token, error ?? S(root, "message"), botFriendCode);
     }
 
     /// <summary>GET /users/profile（Bearer）— 看 MSH 里已配置了哪些查分器令牌。</summary>
@@ -109,10 +118,21 @@ public class MaiScoreHubClient
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        int I(string k) => root.TryGetProperty(k, out var v) && v.TryGetInt32(out var n) ? n : 0;
+        int I(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var n) ? n : 0;
 
-        var success = root.TryGetProperty("success", out var s) && s.ValueKind == JsonValueKind.True;
-        var msg     = root.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String ? m.GetString() : null;
+        // 实测返回（HTTP 201）没有顶层 success：{"status":200,"scores":N,"exported":N,"response":{...}}
+        var success = root.TryGetProperty("status", out var s) && s.ValueKind == JsonValueKind.Number &&
+                      s.TryGetInt32(out var code) && code == 200;
+
+        // 查分器自己的回执在嵌套 response 里（水鱼有 message="更新成功"，落雪只有 success 标志）；出错时兜顶层 message
+        string? msg = null;
+        if (root.TryGetProperty("response", out var resp) && resp.ValueKind == JsonValueKind.Object &&
+            resp.TryGetProperty("message", out var rm) && rm.ValueKind == JsonValueKind.String)
+        {
+            msg = rm.GetString();
+        }
+
+        msg ??= root.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String ? m.GetString() : null;
 
         return new ExportResult(success, I("exported"), I("scores"), msg);
     }

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -22,7 +22,7 @@ public class MaiScoreHubClient
     private static IFlurlRequest Authed(string path, string jwt) => Req(path)
         .WithHeader("Authorization", "Bearer " + jwt);
 
-    public sealed record LoginRequestResult(string JobId, string? BotFriendCode, string? Message);
+    public sealed record LoginRequestResult(string JobId, string? BotFriendCode, string? AuthToken, string? Message);
 
     public sealed record LoginStatusResult(bool Done, string Status, string? Stage, string? Token, string? Message);
 
@@ -48,8 +48,9 @@ public class MaiScoreHubClient
             bot = b.GetString();
         }
 
+        var authToken = root.TryGetProperty("authToken", out var a) && a.ValueKind == JsonValueKind.String ? a.GetString() : null;
         var msg = root.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String ? m.GetString() : null;
-        return new LoginRequestResult(jobId, bot, msg);
+        return new LoginRequestResult(jobId, bot, authToken, msg);
     }
 
     /// <summary>GET /auth/login-status?jobId= — 轮询任务，完成时附带 JWT。</summary>

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -67,7 +67,7 @@ public class MaiScoreHubClient
         var token  = S(root, "token");
         var done   = root.TryGetProperty("done", out var d) && d.ValueKind == JsonValueKind.True;
 
-        // 实测 stage / 失败原因 / 机器人好友码都在嵌套的 job 里（根级没有；完成时整个 job 缺失）
+        // 实测 stage / 失败原因 / 机器人好友码均位于嵌套的 job 对象中（根级没有这些字段；完成时 job 整体缺失）
         string? stage = null, error = null, botFriendCode = null;
         if (root.TryGetProperty("job", out var job) && job.ValueKind == JsonValueKind.Object)
         {
@@ -76,7 +76,7 @@ public class MaiScoreHubClient
             botFriendCode = S(job, "botUserFriendCode");
         }
 
-        // 拿到 token（或终态 completed）就算抓分完成——实测完成时 status 仍是 processing 且无 done 字段
+        // 取到 token（或终态 completed）即视为抓分完成；实测完成时 status 仍为 processing 且无 done 字段
         if (!string.IsNullOrEmpty(token) || status == "completed") done = true;
 
         return new LoginStatusResult(done, status, stage, token, error ?? S(root, "message"), botFriendCode);
@@ -120,11 +120,11 @@ public class MaiScoreHubClient
 
         int I(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var n) ? n : 0;
 
-        // 实测返回（HTTP 201）没有顶层 success：{"status":200,"scores":N,"exported":N,"response":{...}}
+        // 实测返回（HTTP 201）无顶层 success 字段：{"status":200,"scores":N,"exported":N,"response":{...}}
         var success = root.TryGetProperty("status", out var s) && s.ValueKind == JsonValueKind.Number &&
                       s.TryGetInt32(out var code) && code == 200;
 
-        // 查分器自己的回执在嵌套 response 里（水鱼有 message="更新成功"，落雪只有 success 标志）；出错时兜顶层 message
+        // 查分器的回执位于嵌套的 response 对象中（水鱼为 message="更新成功"，落雪仅有 success 标志）；出错时回退到顶层 message
         string? msg = null;
         if (root.TryGetProperty("response", out var resp) && resp.ValueKind == JsonValueKind.Object &&
             resp.TryGetProperty("message", out var rm) && rm.ValueKind == JsonValueKind.String)

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -189,13 +189,19 @@ public partial class MaiMaiDx
             }
         }
 
-        if (status is not { Done: true } || string.IsNullOrEmpty(status.Token))
+        if (status is not { Done: true })
         {
-            message.Reply("等待超时或没拿到登录凭据（多半是没及时同意好友申请）。同意后重试 `maimai 导` 即可。");
+            message.Reply("等待超时（多半是没及时同意好友申请）。同意后重试 `maimai 导` 即可。");
             return;
         }
 
-        var jwt = status.Token!;
+        // JWT 可能来自 login-status 的 token，也可能来自 login-request 的 authToken（契约不明，两处都兜）
+        var jwt = !string.IsNullOrEmpty(status.Token) ? status.Token! : login.AuthToken;
+        if (string.IsNullOrEmpty(jwt))
+        {
+            message.Reply("抓分完成但没拿到登录凭据（MSH 的 token 下发方式可能变了）。请反馈给开发者。");
+            return;
+        }
 
         // 设置新令牌（如有），再看 MSH 里配置了哪些查分器
         if (newTokens is { } t)

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -59,7 +59,6 @@ public partial class MaiMaiDx
 
             var bind = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == next.Sender.Id);
 
-            // 原地改而不是删了重建：同一行上还有「导」存的 FriendCode（和 AimeId），删行会把它们一起抹掉
             realm.Write(() =>
             {
                 if (bind == null)
@@ -79,8 +78,8 @@ public partial class MaiMaiDx
 
     #region 推分同步（导）
 
-    [MarisaPluginDoc("把成绩从NET导到查分器(水鱼/落雪)。首次「导」会一步步引导；也可直接「导 <好友码>」、「导 落雪 xxx 水鱼 yyy」（设置导入令牌，发一个也行）。基于 bakapiano/maimai-score-hub")]
-    [MarisaPluginCommand("传分", "导")]
+    [MarisaPluginDoc("把成绩从NET导到查分器(水鱼/落雪)，首次使用会引导设置")]
+    [MarisaPluginCommand("传分", "导", "sync")]
     [MarisaPluginTrigger(nameof(MarisaPluginTrigger.PlainTextTrigger))]
     private async Task<MarisaPluginTaskState> Sync(Message message)
     {

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -59,15 +59,14 @@ public partial class MaiMaiDx
 
             var bind = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == next.Sender.Id);
 
-            if (bind != null)
+            // 原地改而不是删了重建：同一行上还有「导」存的 FriendCode（和 AimeId），删行会把它们一起抹掉
+            realm.Write(() =>
             {
-                realm.Write(() => realm.Remove(bind));
-            }
-
-            realm.Write(() => realm.AddWithAutoId(new MaiMaiDxBind(next.Sender.Id, 0)
-            {
-                ServerName = servers[idx]
-            }));
+                if (bind == null)
+                    realm.AddWithAutoId(new MaiMaiDxBind(next.Sender.Id, 0) { ServerName = servers[idx] });
+                else
+                    bind.ServerName = servers[idx];
+            });
 
             message.Reply("好了");
             return Task.FromResult(MarisaPluginTaskState.CompletedTask);
@@ -80,8 +79,8 @@ public partial class MaiMaiDx
 
     #region 推分同步（导）
 
-    [MarisaPluginDoc("把成绩从华立(机台)推/导到查分器(水鱼/落雪)。首次需【私聊】配置一次令牌，之后群里也能直接用；`导 令牌`=补设/更换令牌，`导 重置`=连好友码一起重设。基于 bakapiano/maimai-score-hub")]
-    [MarisaPluginCommand("导", "导分")]
+    [MarisaPluginDoc("把成绩从NET导到查分器(水鱼/落雪)。首次「导」会一步步引导；也可直接「导 <好友码>」、「导 落雪 xxx 水鱼 yyy」（设置导入令牌，发一个也行）。基于 bakapiano/maimai-score-hub")]
+    [MarisaPluginCommand("传分", "导")]
     [MarisaPluginTrigger(nameof(MarisaPluginTrigger.PlainTextTrigger))]
     private async Task<MarisaPluginTaskState> Sync(Message message)
     {
@@ -93,113 +92,192 @@ public partial class MaiMaiDx
             friendCode = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == qq)?.FriendCode;
         }
 
-        // 同步一跑几分钟，期间别再进任何流程（尤其别白收一遍令牌再丢掉）
+        var (fcArg, lxns, df, junk) = ParseSyncArgs(message.Command.ToString());
+        if (junk != null)
+        {
+            // 不回显没解析出来的原文——里面可能混着真令牌，bot 发出去的消息用户撤不回
+            message.Reply($"有解析失败的参数（令牌前后记得加空格）。\n{UsageText}");
+            return MarisaPluginTaskState.CompletedTask;
+        }
+
+        var newTokens = lxns == null && df == null ? ((string? Lxns, string? DivingFish)?)null : (lxns, df);
+
+        if (newTokens != null && message.GroupInfo != null)
+        {
+            message.Reply("令牌解析成功。建议立即「撤回」含有令牌的消息。");
+        }
+
+        // 同步一跑几分钟，期间别再进任何流程（带令牌的要明说没收，不然用户以为设置上了）
         if (Syncing.ContainsKey(qq))
         {
-            message.Reply("已经有一个同步在进行中了，等它结束再来。");
+            message.Reply(newTokens == null
+                ? "已有一个传分任务在进行中，请在该任务结束后再次发送指令。"
+                : "已有一个传分任务在进行中，请在该任务结束后再次发送带令牌的指令。");
             return MarisaPluginTaskState.CompletedTask;
         }
 
-        var cmd = message.Command.Trim().ToString();
-        // 「导 令牌」= 补设/更换查分器令牌（首次失败后好友码已存、令牌却没到 MSH 时也靠这个救）；
-        // 「导 重置」= 好友码填错了之类，连好友码一起重来
-        var wantTokenSetup = cmd.EndsWith("令牌");
-        var wantReset      = cmd.EndsWith("重置");
-
-        // 已设置过且不是要重新配置 → 直接同步（群里也行，不需要任何机密）
-        if (!string.IsNullOrWhiteSpace(friendCode) && !wantTokenSetup && !wantReset)
+        // 本条消息带了好友码：绑定/换绑
+        if (fcArg != null)
         {
-            StartSync(message, friendCode!, null);
-            return MarisaPluginTaskState.CompletedTask;
+            PersistFriendCode(qq, fcArg);
+            friendCode = fcArg;
         }
 
-        // 接下来都要让用户发导入令牌，必须私聊
-        if (message.GroupInfo != null)
+        if (!string.IsNullOrWhiteSpace(friendCode))
         {
-            message.Reply(string.IsNullOrWhiteSpace(friendCode)
-                ? "首次使用「导」需要配置查分器令牌。请【私聊我】发送 `maimai 导` 完成一次设置（令牌不要发在群里，会泄露）。设置好以后群里也能直接用。"
-                : $"这一步需要发查分器令牌，请【私聊我】发送 `maimai 导 {(wantReset ? "重置" : "令牌")}`（令牌不要发在群里，会泄露）。");
+            StartSync(message, friendCode!, newTokens);
             return MarisaPluginTaskState.CompletedTask;
         }
 
-        // 已有好友码且只是换令牌：跳过好友码一步
-        if (!string.IsNullOrWhiteSpace(friendCode) && !wantReset)
-        {
-            await AskTokensAndSync(message, friendCode!);
-            return MarisaPluginTaskState.CompletedTask;
-        }
+        // 首次使用：对话引导。先收好友码，必要时再收令牌。
+        // 用单对话状态机（ToBeContinued 续话）；不能在对话 handler 里再 AddDialogAsync 同一个
+        // key —— AddDialogAsync 自旋等 key 释放，而 key 要等 handler 返回才释放，会死锁。
+        message.Reply(newTokens == null
+            ? "「首次传分设置」先发送你的 maimai DX 好友码（NET-好友-你的好友号码，15 位数字）。\n" +
+              "发送请求后会有bot账号在NET里加好友，同意后自动传分到水鱼/落雪。"
+            : "令牌解析成功，还差好友码：发送你的 maimai DX 好友码（NET-好友-你的好友号码，15 位数字）。");
 
-        message.Reply(
-            "【设置 · 推分同步】\n" +
-            "先发送你的 maimai DX 好友码（游戏内「フレンド」里那串数字）。\n" +
-            "之后我会用 maimai-score-hub 的机器人号给你发游戏内好友申请，你同意后我就能抓成绩并同步到查分器。"
-        );
-
-        // 同一个对话先收好友码、再收令牌（ToBeContinued 保住对话）。
-        // 不能在对话 handler 里再 AddDialogAsync 同一个 key：AddDialogAsync 会自旋等 key 释放，
-        // 而 key 要等 handler 返回才释放 —— 死锁。
+        var pendingTokens = newTokens;
+        var startedAt = DateTime.UtcNow;
         string? fc = null;
-        await DialogManager.AddDialogAsync((message.GroupInfo?.Id, message.Sender.Id), async next =>
+        await DialogManager.AddDialogAsync((message.GroupInfo?.Id, qq), next =>
         {
+            // 烂尾的引导对话别永远挂着——不然几天后随手发的一串数字会被当好友码绑掉。
+            // Canceled 会移除对话并把这条消息正常转给其它插件
+            if (DateTime.UtcNow - startedAt > TimeSpan.FromMinutes(10))
+            {
+                return Task.FromResult(MarisaPluginTaskState.Canceled);
+            }
+
+            var input = next.Command.Trim().ToString();
+
+            // 第一步：好友码
             if (fc == null)
             {
-                var input = next.Command.Trim().ToString();
-                if (input.Length is < 6 or > 20 || !input.All(char.IsDigit))
+                if (input.Length != 15 || !input.All(char.IsAsciiDigit))
                 {
-                    next.Reply("好友码应该是一串数字，格式不对，已退出。可重新 `maimai 导`。");
-                    return MarisaPluginTaskState.Canceled;
+                    next.Reply("好友码应该是一串 15 位的数字，解析失败，先退出了。可重新发「mai 导」。");
+                    return Task.FromResult(MarisaPluginTaskState.Canceled);
                 }
 
                 fc = input;
-                next.Reply(TokenPrompt);
-                return MarisaPluginTaskState.ToBeContinued;
+                PersistFriendCode(next.Sender.Id, fc);
+                startedAt = DateTime.UtcNow; // 续上超时：过期语义是「闲置 10 分钟」而不是从开对话起算
+
+                if (pendingTokens != null)
+                {
+                    StartSync(next, fc, pendingTokens);
+                    return Task.FromResult(MarisaPluginTaskState.CompletedTask);
+                }
+
+                next.Reply(
+                    "好友码已绑定。接着发查分器的【导入令牌】（不是密码！），一行一个，发一个也行：\n" +
+                    "落雪 xxx\n" +
+                    "水鱼 yyy\n" +
+                    "令牌获取方法：\n\n" +
+                    "水鱼：首页-编辑个人资料-成绩导入Token\n\n" +
+                    "落雪：账号详情-个人API密钥\n\n" +
+                    "建议发送令牌后立即「撤回」消息。不需要设置就发「跳过」。");
+                return Task.FromResult(MarisaPluginTaskState.ToBeContinued);
             }
 
-            return await HandleTokensAndSync(next, fc);
+            // 第二步：令牌（或跳过）
+            if (input is "跳过" or "skip")
+            {
+                StartSync(next, fc, null);
+                return Task.FromResult(MarisaPluginTaskState.CompletedTask);
+            }
+
+            var (fcExtra, lx, d, leftover) = ParseSyncArgs(input);
+            if (lx == null && d == null)
+            {
+                next.Reply("没解析到令牌（格式：落雪 xxx / 水鱼 yyy），先退出了。之后可随时发「mai 导 落雪 xxx 水鱼 yyy」完成设置。");
+                return Task.FromResult(MarisaPluginTaskState.Canceled);
+            }
+
+            if (leftover != null || fcExtra != null)
+            {
+                // 半对半错（比如「水鱼yyy」漏了空格）宁可不收，免得用户以为两个都设置上了；
+                // 原文不回显（里面可能是真令牌）
+                next.Reply("部分解析失败（可能少了空格），先退出了。可重新发「mai 导 落雪 xxx 水鱼 yyy」。" +
+                           (next.GroupInfo != null ? "建议立即「撤回」含有令牌的消息。" : ""));
+                return Task.FromResult(MarisaPluginTaskState.Canceled);
+            }
+
+            if (next.GroupInfo != null)
+            {
+                next.Reply("令牌解析成功。建议立即「撤回」含有令牌的消息。");
+            }
+
+            StartSync(next, fc, (lx, d));
+            return Task.FromResult(MarisaPluginTaskState.CompletedTask);
         }, this);
 
         return MarisaPluginTaskState.CompletedTask;
     }
 
-    private const string TokenPrompt =
-        "现在发送你要同步的查分器【导入令牌】（不是密码！）。\n" +
-        "一行一个，至少一个，两个都发就两边都推：\n" +
-        "  落雪 <你的落雪个人 API 令牌>\n" +
-        "  水鱼 <你的水鱼 Import-Token>\n" +
-        "令牌在哪拿：落雪→个人主页/开发者；水鱼→个人主页的「导入 token」。";
+    private const string UsageText =
+        "用法：\n" +
+        "mai 导 —— 同步成绩到查分器（首次会一步步引导）\n" +
+        "mai 导 <好友码> —— 绑定/换绑好友码\n" +
+        "mai 导 落雪 xxx 水鱼 yyy —— 设置查分器导入令牌（发一个也行）\n" +
+        "令牌获取方法：\n\n" +
+        "水鱼：首页-编辑个人资料-成绩导入Token\n\n" +
+        "落雪：账号详情-个人API密钥\n\n" +
+        "建议发送令牌后立即「撤回」消息。";
 
-    /// <summary>问用户要查分器导入令牌，收到后存好友码并开始同步。</summary>
-    private Task AskTokensAndSync(Message message, string friendCode)
+    private static readonly Regex SyncTokenArg = new(
+        @"(?<=^|\s)(?<key>落雪|水鱼|lxns|diving-fish|divingfish|df)[:：\s]+(?<val>\S+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>
+    ///     解析「导」后面的参数：15 位纯数字是好友码，「落雪/水鱼 xxx」是对应查分器的导入令牌，
+    ///     其余内容原样带回（Junk 非空说明没看懂，应当回用法而不是瞎猜）。
+    /// </summary>
+    private static (string? Fc, string? Lxns, string? Df, string? Junk) ParseSyncArgs(string args)
     {
-        message.Reply(TokenPrompt);
-        return DialogManager.AddDialogAsync((message.GroupInfo?.Id, message.Sender.Id), tkMsg => HandleTokensAndSync(tkMsg, friendCode), this);
+        string? lxns = null, df = null;
+
+        var rest = SyncTokenArg.Replace(args, m =>
+        {
+            var val = m.Groups["val"].Value;
+            // 「落雪 水鱼 yyy」这种没给值的，整段还回去当没看懂（真令牌都是 ASCII）
+            if (val.Any(c => c > 127)) return m.Value;
+
+            if (m.Groups["key"].Value.ToLowerInvariant() is "落雪" or "lxns") lxns = val;
+            else df = val;
+            return " ";
+        });
+
+        string? fc = null;
+        var junk = new List<string>();
+        foreach (var w in rest.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (fc == null && w.Length == 15 && w.All(char.IsAsciiDigit)) fc = w;
+            else junk.Add(w);
+        }
+
+        return (fc, lxns, df, junk.Count == 0 ? null : string.Join(' ', junk));
     }
 
-    /// <summary>令牌对话的收尾：解析令牌、持久化好友码、把同步丢到后台。令牌只经手转交 MSH，不落库。</summary>
-    private static Task<MarisaPluginTaskState> HandleTokensAndSync(Message tkMsg, string friendCode)
+    /// <summary>只持久化好友码，令牌不落库（只经手转交 MSH）。</summary>
+    private static void PersistFriendCode(long qq, string friendCode)
     {
-        var (lxns, df) = ParseTokens(tkMsg.Command.Trim().ToString());
-        if (lxns == null && df == null)
+        using var realm = BotDbContext.OpenRealm();
+        var bind = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == qq);
+        realm.Write(() =>
         {
-            tkMsg.Reply("没识别到令牌（格式：`落雪 xxx` / `水鱼 xxx`），已退出。可发 `maimai 导 令牌` 重新设置。");
-            return Task.FromResult(MarisaPluginTaskState.Canceled);
-        }
-
-        // 只持久化好友码，令牌不落库
-        using (var realm = BotDbContext.OpenRealm())
-        {
-            var b = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == tkMsg.Sender.Id);
-            realm.Write(() =>
+            if (bind == null)
             {
-                if (b == null)
-                    realm.AddWithAutoId(new MaiMaiDxBind(tkMsg.Sender.Id, 0) { FriendCode = friendCode });
-                else
-                    b.FriendCode = friendCode;
-            });
-        }
-
-        StartSync(tkMsg, friendCode, (lxns, df));
-        return Task.FromResult(MarisaPluginTaskState.CompletedTask);
+                // ServerName 不能留空：空串会被 GetDataFetcher 的 _ 分支路由到华立 fetcher（AimeId=0 必坏），
+                // 给没 bind 过的人按默认值补上水鱼
+                realm.AddWithAutoId(new MaiMaiDxBind(qq, 0) { FriendCode = friendCode, ServerName = "DivingFish" });
+            }
+            else
+            {
+                bind.FriendCode = friendCode;
+            }
+        });
     }
 
     /// <summary>正在后台同步的用户，防止同一个人并发开多个 MSH 任务。</summary>
@@ -215,8 +293,8 @@ public partial class MaiMaiDx
         if (!Syncing.TryAdd(message.Sender.Id, 0))
         {
             message.Reply(newTokens == null
-                ? "已经有一个同步在进行中了，等它结束再来。"
-                : "已经有一个同步在进行中了，刚发的令牌没有提交。等它结束后请【私聊我】发送 `maimai 导 令牌` 重发一次。");
+                ? "已有一个传分任务在进行中，请在该任务结束后再次发送指令。"
+                : "已有一个传分任务在进行中，请在该任务结束后再次发送带令牌的指令。");
             return;
         }
 
@@ -237,10 +315,10 @@ public partial class MaiMaiDx
         });
     }
 
-    /// <summary>中途失败时令牌不会保存（令牌不落库），带着令牌跑的失败要用「导 令牌」重来。</summary>
+    /// <summary>中途失败时令牌不会保存（令牌不落库），带着令牌跑的失败要重发令牌。</summary>
     private static string RetryHint((string? Lxns, string? DivingFish)? newTokens) => newTokens == null
-        ? "重试 `maimai 导` 即可。"
-        : "请【私聊我】发送 `maimai 导 令牌` 重试（令牌需要重新发一次）。";
+        ? "重试「mai 导」即可。"
+        : "重发一遍「mai 导 落雪/水鱼 xxx」重试（失败时令牌可能未被保存）。";
 
     /// <summary>跑一次完整同步：登录 → 轮询 → （可选设令牌）→ 推到所有已配置的查分器。</summary>
     private static async Task RunSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
@@ -249,13 +327,13 @@ public partial class MaiMaiDx
 
         var retryHint = RetryHint(newTokens);
 
-        message.Reply("正在请求登录…（首次需要你在游戏里同意机器人的好友申请，已是好友则会直接抓分）");
+        message.Reply("正在发送请求…（马上会有bot加你好友）");
 
         var login = await msh.LoginRequestAsync(friendCode);
         var announced = false;
         if (!string.IsNullOrEmpty(login.BotFriendCode))
         {
-            message.Reply($"已用机器人账号（好友码 {login.BotFriendCode}）发起好友申请，请进游戏【同意好友】。我最多等 10 分钟，同意后会自动抓分并同步。");
+            message.Reply($"Bot 账号（好友码{login.BotFriendCode}）已发出好友申请，去NET里同意一下，请在10分钟内完成操作。");
             announced = true;
         }
 
@@ -288,11 +366,10 @@ public partial class MaiMaiDx
                 return;
             }
 
-            // 实测 botUserFriendCode 只在轮询的 job 里下发（login-request 不带）；
-            // 已是好友的任务也可能路过 wait_acceptance，所以措辞要两种情况都对
+            // 实测 botUserFriendCode 只在轮询的 job 里下发（login-request 不带），等好友同意阶段提示一次
             if (!announced && status.Stage == "wait_acceptance" && !string.IsNullOrEmpty(status.BotFriendCode))
             {
-                message.Reply($"机器人账号（好友码 {status.BotFriendCode}）已发出好友申请：游戏里有待同意的申请就【同意】一下，已是好友则无需操作。我最多等 10 分钟，完成后自动抓分并同步。");
+                message.Reply($"Bot 账号（好友码{status.BotFriendCode}）已发出好友申请，去NET里同意一下，请在10分钟内完成操作。");
                 announced = true;
             }
         }
@@ -326,7 +403,7 @@ public partial class MaiMaiDx
 
         if (targets.Count == 0)
         {
-            message.Reply("华立成绩已抓取，但还没配置任何查分器令牌。请【私聊我】发送 `maimai 导 令牌` 完成设置。");
+            message.Reply("成绩已抓取，但还没配置任何查分器令牌。发送「mai 导 落雪 xxx 水鱼 yyy」完成设置（发一个也行，建议发送令牌后立即「撤回」消息）。");
             return;
         }
 
@@ -346,28 +423,6 @@ public partial class MaiMaiDx
         }
 
         message.Reply(sb.ToString().TrimEnd());
-    }
-
-    private static (string? Lxns, string? DivingFish) ParseTokens(string text)
-    {
-        string? lxns = null, df = null;
-
-        foreach (var raw in text.Split('\n'))
-        {
-            var line = raw.Trim();
-            if (line.Length == 0) continue;
-
-            var sp  = line.IndexOfAny([' ', '\t', '：', ':']);
-            var val = sp >= 0 ? line[(sp + 1)..].Trim() : "";
-
-            if (line.StartsWith("落雪") || line.StartsWith("lxns", StringComparison.OrdinalIgnoreCase))
-                lxns = val;
-            else if (line.StartsWith("水鱼") || line.StartsWith("df", StringComparison.OrdinalIgnoreCase) ||
-                     line.StartsWith("divingfish", StringComparison.OrdinalIgnoreCase) || line.StartsWith("diving-fish", StringComparison.OrdinalIgnoreCase))
-                df = val;
-        }
-
-        return (string.IsNullOrWhiteSpace(lxns) ? null : lxns, string.IsNullOrWhiteSpace(df) ? null : df);
     }
 
     #endregion

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -80,9 +80,9 @@ public partial class MaiMaiDx
 
     private const string UsageText =
         "用法：\n" +
-        "mai 导 —— 同步成绩到查分器（首次会一步步引导）\n" +
+        "mai 导 —— 同步成绩到查分器（首次使用会引导设置）\n" +
         "mai 导 <好友码> —— 绑定/换绑好友码\n" +
-        "mai 导 落雪 xxx 水鱼 yyy —— 设置查分器导入令牌（发一个也行）\n" +
+        "mai 导 落雪 xxx 水鱼 yyy —— 设置查分器导入令牌（可只填其中一个）\n" +
         "令牌获取方法：\n\n" +
         "水鱼：首页-编辑个人资料-成绩导入Token\n\n" +
         "落雪：账号详情-个人API密钥\n\n" +
@@ -92,7 +92,7 @@ public partial class MaiMaiDx
         @"(?<=^|\s)(?<key>落雪|水鱼|lxns|diving-fish|divingfish|df)[:：\s]+(?<val>\S+)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
-    /// <summary>正在后台同步的用户，防止同一个人并发开多个 MSH 任务。</summary>
+    /// <summary>正在后台同步的用户集合，防止同一用户并发发起多个 MSH 任务。</summary>
     private static readonly ConcurrentDictionary<long, byte> Syncing = new();
 
     [MarisaPluginDoc("把成绩从NET导到查分器(水鱼/落雪)，首次使用会引导设置")]
@@ -111,8 +111,8 @@ public partial class MaiMaiDx
         var (fcArg, lxns, df, junk) = ParseSyncArgs(message.Command.ToString());
         if (junk != null)
         {
-            // 不回显没解析出来的原文——里面可能混着真令牌，bot 发出去的消息用户撤不回
-            message.Reply($"有解析失败的参数（令牌前后记得加空格）。\n{UsageText}");
+            // 解析失败的原文不回显：其中可能包含真实令牌，而 bot 发出的消息用户无法撤回
+            message.Reply($"有解析失败的参数（请确认令牌前后有空格分隔）。\n{UsageText}");
             return MarisaPluginTaskState.CompletedTask;
         }
 
@@ -123,7 +123,7 @@ public partial class MaiMaiDx
             message.Reply("令牌解析成功。建议立即「撤回」含有令牌的消息。");
         }
 
-        // 同步一跑几分钟，期间别再进任何流程（带令牌的要明说没收，不然用户以为设置上了）
+        // 同步任务可能持续数分钟，期间拒绝新的指令；携带令牌的指令需明确告知未提交，避免用户误以为设置已生效
         if (Syncing.ContainsKey(qq))
         {
             message.Reply(newTokens == null
@@ -132,7 +132,7 @@ public partial class MaiMaiDx
             return MarisaPluginTaskState.CompletedTask;
         }
 
-        // 本条消息带了好友码：绑定/换绑
+        // 消息中携带好友码：执行绑定/换绑
         if (fcArg != null)
         {
             PersistFriendCode(qq, fcArg);
@@ -145,21 +145,22 @@ public partial class MaiMaiDx
             return MarisaPluginTaskState.CompletedTask;
         }
 
-        // 首次使用：对话引导。先收好友码，必要时再收令牌。
-        // 用单对话状态机（ToBeContinued 续话）；不能在对话 handler 里再 AddDialogAsync 同一个
-        // key —— AddDialogAsync 自旋等 key 释放，而 key 要等 handler 返回才释放，会死锁。
+        // 首次使用：通过对话引导完成设置，先收集好友码，必要时再收集令牌。
+        // 实现为单个对话的状态机（ToBeContinued 表示继续当前对话）。注意不能在对话 handler 内
+        // 对同一 key 再次调用 AddDialogAsync：它会自旋等待 key 释放，而 key 要到 handler 返回
+        // 之后才会释放，二者互相等待形成死锁。
         message.Reply(newTokens == null
             ? "「首次传分设置」先发送你的 maimai DX 好友码（NET-好友-你的好友号码，15 位数字）。\n" +
               "发送请求后会有bot账号在NET里加好友，同意后自动传分到水鱼/落雪。"
-            : "令牌解析成功，还差好友码：发送你的 maimai DX 好友码（NET-好友-你的好友号码，15 位数字）。");
+            : "令牌解析成功，还需要好友码：请发送你的 maimai DX 好友码（NET-好友-你的好友号码，15 位数字）。");
 
         var pendingTokens = newTokens;
         var startedAt = DateTime.UtcNow;
         string? fc = null;
         await DialogManager.AddDialogAsync((message.GroupInfo?.Id, qq), next =>
         {
-            // 烂尾的引导对话别永远挂着——不然几天后随手发的一串数字会被当好友码绑掉。
-            // Canceled 会移除对话并把这条消息正常转给其它插件
+            // 闲置超过 10 分钟的引导对话视为已放弃，避免长期驻留——否则用户日后偶然发送的
+            // 一串数字会被误认为好友码。返回 Canceled 会移除对话，并把该消息正常转交其它插件处理
             if (DateTime.UtcNow - startedAt > TimeSpan.FromMinutes(10))
             {
                 return Task.FromResult(MarisaPluginTaskState.Canceled);
@@ -167,18 +168,18 @@ public partial class MaiMaiDx
 
             var input = next.Command.Trim().ToString();
 
-            // 第一步：好友码
+            // 第一步：收集好友码
             if (fc == null)
             {
                 if (input.Length != 15 || !input.All(char.IsAsciiDigit))
                 {
-                    next.Reply("好友码应该是一串 15 位的数字，解析失败，先退出了。可重新发「mai 导」。");
+                    next.Reply("好友码应为 15 位数字，解析失败，已退出设置。可重新发送「mai 导」。");
                     return Task.FromResult(MarisaPluginTaskState.Canceled);
                 }
 
                 fc = input;
                 PersistFriendCode(next.Sender.Id, fc);
-                startedAt = DateTime.UtcNow; // 续上超时：过期语义是「闲置 10 分钟」而不是从开对话起算
+                startedAt = DateTime.UtcNow; // 刷新计时：超时语义为「闲置 10 分钟」，而非从对话创建起算
 
                 if (pendingTokens != null)
                 {
@@ -187,17 +188,17 @@ public partial class MaiMaiDx
                 }
 
                 next.Reply(
-                    "好友码已绑定。接着发查分器的【导入令牌】（不是密码！），一行一个，发一个也行：\n" +
+                    "好友码已绑定。接下来请发送查分器的【导入令牌】（不是账号密码），一行一个，可只填其中一个：\n" +
                     "落雪 xxx\n" +
                     "水鱼 yyy\n" +
                     "令牌获取方法：\n\n" +
                     "水鱼：首页-编辑个人资料-成绩导入Token\n\n" +
                     "落雪：账号详情-个人API密钥\n\n" +
-                    "建议发送令牌后立即「撤回」消息。不需要设置就发「跳过」。");
+                    "建议发送令牌后立即「撤回」消息。如果不需要设置令牌，请发送「跳过」。");
                 return Task.FromResult(MarisaPluginTaskState.ToBeContinued);
             }
 
-            // 第二步：令牌（或跳过）
+            // 第二步：收集令牌（或跳过）
             if (input is "跳过" or "skip")
             {
                 StartSync(next, fc, null);
@@ -207,15 +208,15 @@ public partial class MaiMaiDx
             var (fcExtra, lx, d, leftover) = ParseSyncArgs(input);
             if (lx == null && d == null)
             {
-                next.Reply("没解析到令牌（格式：落雪 xxx / 水鱼 yyy），先退出了。之后可随时发「mai 导 落雪 xxx 水鱼 yyy」完成设置。");
+                next.Reply("没有解析到令牌（格式：落雪 xxx / 水鱼 yyy），已退出设置。之后可随时发送「mai 导 落雪 xxx 水鱼 yyy」完成设置。");
                 return Task.FromResult(MarisaPluginTaskState.Canceled);
             }
 
             if (leftover != null || fcExtra != null)
             {
-                // 半对半错（比如「水鱼yyy」漏了空格）宁可不收，免得用户以为两个都设置上了；
-                // 原文不回显（里面可能是真令牌）
-                next.Reply("部分解析失败（可能少了空格），先退出了。可重新发「mai 导 落雪 xxx 水鱼 yyy」。" +
+                // 部分解析成功（如「水鱼yyy」缺少空格）时整体拒绝，避免用户误以为两个令牌都已设置；
+                // 原文不回显，其中可能包含真实令牌
+                next.Reply("部分参数解析失败（请确认令牌前后有空格分隔），已退出设置。可重新发送「mai 导 落雪 xxx 水鱼 yyy」。" +
                            (next.GroupInfo != null ? "建议立即「撤回」含有令牌的消息。" : ""));
                 return Task.FromResult(MarisaPluginTaskState.Canceled);
             }
@@ -231,8 +232,8 @@ public partial class MaiMaiDx
 
         return MarisaPluginTaskState.CompletedTask;
 
-        // 解析「导」后面的参数：15 位纯数字是好友码，「落雪/水鱼 xxx」是对应查分器的导入令牌，
-        // 其余内容原样带回（Junk 非空说明没看懂，应当回用法而不是瞎猜）
+        // 解析「导」命令的参数：15 位纯数字视为好友码，「落雪/水鱼 xxx」视为对应查分器的导入令牌；
+        // 无法解析的部分经 Junk 返回，Junk 非空时应回复用法说明，而不是猜测用户意图
         static (string? Fc, string? Lxns, string? Df, string? Junk) ParseSyncArgs(string args)
         {
             string? lxnsTok = null, dfTok = null;
@@ -240,7 +241,7 @@ public partial class MaiMaiDx
             var rest = SyncTokenArg.Replace(args, m =>
             {
                 var val = m.Groups["val"].Value;
-                // 「落雪 水鱼 yyy」这种没给值的，整段还回去当没看懂（真令牌都是 ASCII）
+                // 令牌值均为 ASCII；匹配到非 ASCII 值（如「落雪 水鱼 yyy」缺少令牌值）时整段视为解析失败
                 if (val.Any(c => c > 127)) return m.Value;
 
                 if (m.Groups["key"].Value.ToLowerInvariant() is "落雪" or "lxns") lxnsTok = val;
@@ -259,7 +260,7 @@ public partial class MaiMaiDx
             return (fcVal, lxnsTok, dfTok, junkWords.Count == 0 ? null : string.Join(' ', junkWords));
         }
 
-        // 只持久化好友码，令牌不落库（只经手转交 MSH）
+        // 仅持久化好友码；令牌不落库，仅经手转交 MSH
         static void PersistFriendCode(long uid, string code)
         {
             using var realm = BotDbContext.OpenRealm();
@@ -268,7 +269,8 @@ public partial class MaiMaiDx
             {
                 if (bind == null)
                 {
-                    // ServerName 不能留空：空串会被 GetDataFetcher 的 _ 分支路由到华立 fetcher（AimeId=0 必坏）
+                    // ServerName 不能留空：空串会被 GetDataFetcher 路由到华立 fetcher，而该用户没有
+                    // AimeId，查询必定失败；新建记录时默认使用水鱼
                     realm.AddWithAutoId(new MaiMaiDxBind(uid, 0) { FriendCode = code, ServerName = "DivingFish" });
                 }
                 else
@@ -280,9 +282,9 @@ public partial class MaiMaiDx
     }
 
     /// <summary>
-    ///     把一次完整同步丢到后台执行并立即返回。
-    ///     同步要等用户游戏内同意好友（最长 10 分钟），不能占着消息管线：
-    ///     BotDriver 对每条消息有 10 分钟硬超时，对话挂起期间还会把用户的其它消息当令牌吃掉。
+    ///     在后台启动一次完整同步并立即返回。
+    ///     同步需要等待用户在游戏内同意好友申请（最长 10 分钟），不能阻塞消息处理管线：
+    ///     BotDriver 对每条消息有 10 分钟硬超时，且对话挂起期间会拦截该用户的所有后续消息。
     /// </summary>
     private static void StartSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
     {
@@ -311,10 +313,10 @@ public partial class MaiMaiDx
         });
     }
 
-    /// <summary>中途失败时令牌不会保存（令牌不落库），带着令牌跑的失败要重发令牌。</summary>
+    /// <summary>失败后的重试提示。令牌不落库，携带令牌的同步失败后需要用户重发令牌。</summary>
     private static string RetryHint((string? Lxns, string? DivingFish)? newTokens) => newTokens == null
         ? "重试「mai 导」即可。"
-        : "重发一遍「mai 导 落雪/水鱼 xxx」重试（失败时令牌可能未被保存）。";
+        : "请重新发送「mai 导 落雪/水鱼 xxx」（失败时令牌可能未被保存）。";
 
     /// <summary>跑一次完整同步：登录 → 轮询 → （可选设令牌）→ 推到所有已配置的查分器。</summary>
     private static async Task RunSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
@@ -333,7 +335,7 @@ public partial class MaiMaiDx
             announced = true;
         }
 
-        // 轮询直到完成 / 失败 / 超时（MSH 忙时 send_request 排队可达数分钟，所以放宽到 10 分钟）
+        // 轮询直到完成 / 失败 / 超时；MSH 繁忙时 send_request 阶段排队可达数分钟，故超时设为 10 分钟
         MaiScoreHubClient.LoginStatusResult? status = null;
         var deadline     = DateTime.UtcNow.AddMinutes(10);
         var pollFailures = 0;
@@ -348,7 +350,7 @@ public partial class MaiMaiDx
             }
             catch (Exception e)
             {
-                // 10 分钟要询问 ~120 次，个别瞬时失败（5xx/超时）不该让整个等待报废
+                // 10 分钟内约轮询 120 次，容忍偶发的瞬时失败（5xx/超时），连续多次失败才放弃
                 if (++pollFailures < 6) continue;
                 message.Reply($"同步中断：连续多次查询任务状态失败（{e.Message}）。稍后{retryHint}");
                 return;
@@ -362,7 +364,7 @@ public partial class MaiMaiDx
                 return;
             }
 
-            // 实测 botUserFriendCode 只在轮询的 job 里下发（login-request 不带），等好友同意阶段提示一次
+            // 实测 botUserFriendCode 仅在轮询返回的 job 对象中下发（login-request 不携带），在等待好友同意阶段提示一次
             if (!announced && status.Stage == "wait_acceptance" && !string.IsNullOrEmpty(status.BotFriendCode))
             {
                 message.Reply($"Bot 账号（好友码{status.BotFriendCode}）已发出好友申请，去NET里同意一下，请在10分钟内完成操作。");
@@ -372,19 +374,19 @@ public partial class MaiMaiDx
 
         if (status is not { Done: true })
         {
-            message.Reply($"等待超时（多半是没及时同意好友申请）。同意后{retryHint}");
+            message.Reply($"等待超时（可能未及时同意好友申请）。同意后{retryHint}");
             return;
         }
 
-        // 实测 JWT 在 login-status 完成时的根级 token；login-request 的 authToken 只是兜底
+        // 实测 JWT 位于 login-status 完成响应的根级 token 字段；login-request 的 authToken 仅作回退
         var jwt = !string.IsNullOrEmpty(status.Token) ? status.Token! : login.AuthToken;
         if (string.IsNullOrEmpty(jwt))
         {
-            message.Reply("抓分完成但没拿到登录凭据（MSH 的 token 下发方式可能变了）。请反馈给开发者。");
+            message.Reply("成绩抓取完成，但未获取到登录凭据（MSH 的 token 下发方式可能已变更）。请向开发者反馈。");
             return;
         }
 
-        // 设置新令牌（如有），再看 MSH 里配置了哪些查分器
+        // 设置新令牌（如有），随后查询 MSH 中已配置的查分器
         if (newTokens is { } t)
         {
             if (!string.IsNullOrWhiteSpace(t.Lxns)) await msh.SetTokenAsync(jwt, "lxns", t.Lxns!);
@@ -399,7 +401,7 @@ public partial class MaiMaiDx
 
         if (targets.Count == 0)
         {
-            message.Reply("成绩已抓取，但还没配置任何查分器令牌。发送「mai 导 落雪 xxx 水鱼 yyy」完成设置（发一个也行，建议发送令牌后立即「撤回」消息）。");
+            message.Reply("成绩已抓取，但尚未配置任何查分器令牌。发送「mai 导 落雪 xxx 水鱼 yyy」完成设置（可只填其中一个，建议发送令牌后立即「撤回」消息）。");
             return;
         }
 

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using System.Text.RegularExpressions;
 using Marisa.Database;
@@ -79,7 +80,7 @@ public partial class MaiMaiDx
 
     #region 推分同步（导）
 
-    [MarisaPluginDoc("把成绩从华立(机台)推/导到查分器(水鱼/落雪)。首次需【私聊】配置一次令牌，之后群里也能直接用。基于 bakapiano/maimai-score-hub")]
+    [MarisaPluginDoc("把成绩从华立(机台)推/导到查分器(水鱼/落雪)。首次需【私聊】配置一次令牌，之后群里也能直接用；`导 令牌`=补设/更换令牌，`导 重置`=连好友码一起重设。基于 bakapiano/maimai-score-hub")]
     [MarisaPluginCommand("导", "导分")]
     [MarisaPluginTrigger(nameof(MarisaPluginTrigger.PlainTextTrigger))]
     private async Task<MarisaPluginTaskState> Sync(Message message)
@@ -92,110 +93,217 @@ public partial class MaiMaiDx
             friendCode = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == qq)?.FriendCode;
         }
 
-        // 已设置过 → 直接同步（群里也行，不需要任何机密）
-        if (!string.IsNullOrWhiteSpace(friendCode))
+        // 同步一跑几分钟，期间别再进任何流程（尤其别白收一遍令牌再丢掉）
+        if (Syncing.ContainsKey(qq))
         {
-            await RunSync(message, friendCode!, null);
+            message.Reply("已经有一个同步在进行中了，等它结束再来。");
             return MarisaPluginTaskState.CompletedTask;
         }
 
-        // 首次设置：要让用户发导入令牌，必须私聊
+        var cmd = message.Command.Trim().ToString();
+        // 「导 令牌」= 补设/更换查分器令牌（首次失败后好友码已存、令牌却没到 MSH 时也靠这个救）；
+        // 「导 重置」= 好友码填错了之类，连好友码一起重来
+        var wantTokenSetup = cmd.EndsWith("令牌");
+        var wantReset      = cmd.EndsWith("重置");
+
+        // 已设置过且不是要重新配置 → 直接同步（群里也行，不需要任何机密）
+        if (!string.IsNullOrWhiteSpace(friendCode) && !wantTokenSetup && !wantReset)
+        {
+            StartSync(message, friendCode!, null);
+            return MarisaPluginTaskState.CompletedTask;
+        }
+
+        // 接下来都要让用户发导入令牌，必须私聊
         if (message.GroupInfo != null)
         {
-            message.Reply("首次使用「导」需要配置查分器令牌。请【私聊我】发送 `maimai 导` 完成一次设置（令牌不要发在群里，会泄露）。设置好以后群里也能直接用。");
+            message.Reply(string.IsNullOrWhiteSpace(friendCode)
+                ? "首次使用「导」需要配置查分器令牌。请【私聊我】发送 `maimai 导` 完成一次设置（令牌不要发在群里，会泄露）。设置好以后群里也能直接用。"
+                : $"这一步需要发查分器令牌，请【私聊我】发送 `maimai 导 {(wantReset ? "重置" : "令牌")}`（令牌不要发在群里，会泄露）。");
+            return MarisaPluginTaskState.CompletedTask;
+        }
+
+        // 已有好友码且只是换令牌：跳过好友码一步
+        if (!string.IsNullOrWhiteSpace(friendCode) && !wantReset)
+        {
+            await AskTokensAndSync(message, friendCode!);
             return MarisaPluginTaskState.CompletedTask;
         }
 
         message.Reply(
-            "【首次设置 · 推分同步】\n" +
-            "第一步：发送你的 maimai DX 好友码（游戏内「フレンド」里那串数字）。\n" +
+            "【设置 · 推分同步】\n" +
+            "先发送你的 maimai DX 好友码（游戏内「フレンド」里那串数字）。\n" +
             "之后我会用 maimai-score-hub 的机器人号给你发游戏内好友申请，你同意后我就能抓成绩并同步到查分器。"
         );
 
-        await DialogManager.AddDialogAsync((message.GroupInfo?.Id, message.Sender.Id), async fcMsg =>
+        // 同一个对话先收好友码、再收令牌（ToBeContinued 保住对话）。
+        // 不能在对话 handler 里再 AddDialogAsync 同一个 key：AddDialogAsync 会自旋等 key 释放，
+        // 而 key 要等 handler 返回才释放 —— 死锁。
+        string? fc = null;
+        await DialogManager.AddDialogAsync((message.GroupInfo?.Id, message.Sender.Id), async next =>
         {
-            var fc = fcMsg.Command.Trim().ToString().Trim();
-            if (fc.Length is < 6 or > 20 || !fc.All(char.IsDigit))
+            if (fc == null)
             {
-                fcMsg.Reply("好友码应该是一串数字，格式不对，已退出。可重新 `maimai 导`。");
-                return MarisaPluginTaskState.Canceled;
-            }
-
-            fcMsg.Reply(
-                "好。第二步：发送你要同步的查分器【导入令牌】（不是密码！）。\n" +
-                "一行一个，至少一个，两个都发就两边都推：\n" +
-                "  落雪 <你的落雪个人 API 令牌>\n" +
-                "  水鱼 <你的水鱼 Import-Token>\n" +
-                "令牌在哪拿：落雪→个人主页/开发者；水鱼→个人主页的「导入 token」。"
-            );
-
-            await DialogManager.AddDialogAsync((fcMsg.GroupInfo?.Id, fcMsg.Sender.Id), async tkMsg =>
-            {
-                var (lxns, df) = ParseTokens(tkMsg.Command.Trim().ToString());
-                if (lxns == null && df == null)
+                var input = next.Command.Trim().ToString();
+                if (input.Length is < 6 or > 20 || !input.All(char.IsDigit))
                 {
-                    tkMsg.Reply("没识别到令牌（格式：`落雪 xxx` / `水鱼 xxx`），已退出。可重新 `maimai 导`。");
+                    next.Reply("好友码应该是一串数字，格式不对，已退出。可重新 `maimai 导`。");
                     return MarisaPluginTaskState.Canceled;
                 }
 
-                // 只持久化好友码，令牌不落库
-                using (var realm = BotDbContext.OpenRealm())
-                {
-                    var b = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == tkMsg.Sender.Id);
-                    realm.Write(() =>
-                    {
-                        if (b == null)
-                            realm.AddWithAutoId(new MaiMaiDxBind(tkMsg.Sender.Id, 0) { FriendCode = fc });
-                        else
-                            b.FriendCode = fc;
-                    });
-                }
+                fc = input;
+                next.Reply(TokenPrompt);
+                return MarisaPluginTaskState.ToBeContinued;
+            }
 
-                await RunSync(tkMsg, fc, (lxns, df));
-                return MarisaPluginTaskState.CompletedTask;
-            }, this);
-
-            return MarisaPluginTaskState.CompletedTask;
+            return await HandleTokensAndSync(next, fc);
         }, this);
 
         return MarisaPluginTaskState.CompletedTask;
     }
+
+    private const string TokenPrompt =
+        "现在发送你要同步的查分器【导入令牌】（不是密码！）。\n" +
+        "一行一个，至少一个，两个都发就两边都推：\n" +
+        "  落雪 <你的落雪个人 API 令牌>\n" +
+        "  水鱼 <你的水鱼 Import-Token>\n" +
+        "令牌在哪拿：落雪→个人主页/开发者；水鱼→个人主页的「导入 token」。";
+
+    /// <summary>问用户要查分器导入令牌，收到后存好友码并开始同步。</summary>
+    private Task AskTokensAndSync(Message message, string friendCode)
+    {
+        message.Reply(TokenPrompt);
+        return DialogManager.AddDialogAsync((message.GroupInfo?.Id, message.Sender.Id), tkMsg => HandleTokensAndSync(tkMsg, friendCode), this);
+    }
+
+    /// <summary>令牌对话的收尾：解析令牌、持久化好友码、把同步丢到后台。令牌只经手转交 MSH，不落库。</summary>
+    private static Task<MarisaPluginTaskState> HandleTokensAndSync(Message tkMsg, string friendCode)
+    {
+        var (lxns, df) = ParseTokens(tkMsg.Command.Trim().ToString());
+        if (lxns == null && df == null)
+        {
+            tkMsg.Reply("没识别到令牌（格式：`落雪 xxx` / `水鱼 xxx`），已退出。可发 `maimai 导 令牌` 重新设置。");
+            return Task.FromResult(MarisaPluginTaskState.Canceled);
+        }
+
+        // 只持久化好友码，令牌不落库
+        using (var realm = BotDbContext.OpenRealm())
+        {
+            var b = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == tkMsg.Sender.Id);
+            realm.Write(() =>
+            {
+                if (b == null)
+                    realm.AddWithAutoId(new MaiMaiDxBind(tkMsg.Sender.Id, 0) { FriendCode = friendCode });
+                else
+                    b.FriendCode = friendCode;
+            });
+        }
+
+        StartSync(tkMsg, friendCode, (lxns, df));
+        return Task.FromResult(MarisaPluginTaskState.CompletedTask);
+    }
+
+    /// <summary>正在后台同步的用户，防止同一个人并发开多个 MSH 任务。</summary>
+    private static readonly ConcurrentDictionary<long, byte> Syncing = new();
+
+    /// <summary>
+    ///     把一次完整同步丢到后台执行并立即返回。
+    ///     同步要等用户游戏内同意好友（最长 10 分钟），不能占着消息管线：
+    ///     BotDriver 对每条消息有 10 分钟硬超时，对话挂起期间还会把用户的其它消息当令牌吃掉。
+    /// </summary>
+    private static void StartSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
+    {
+        if (!Syncing.TryAdd(message.Sender.Id, 0))
+        {
+            message.Reply(newTokens == null
+                ? "已经有一个同步在进行中了，等它结束再来。"
+                : "已经有一个同步在进行中了，刚发的令牌没有提交。等它结束后请【私聊我】发送 `maimai 导 令牌` 重发一次。");
+            return;
+        }
+
+        Task.Run(async () =>
+        {
+            try
+            {
+                await RunSync(message, friendCode, newTokens);
+            }
+            catch (Exception e)
+            {
+                message.Reply($"同步失败：{e.Message}。{RetryHint(newTokens)}");
+            }
+            finally
+            {
+                Syncing.TryRemove(message.Sender.Id, out _);
+            }
+        });
+    }
+
+    /// <summary>中途失败时令牌不会保存（令牌不落库），带着令牌跑的失败要用「导 令牌」重来。</summary>
+    private static string RetryHint((string? Lxns, string? DivingFish)? newTokens) => newTokens == null
+        ? "重试 `maimai 导` 即可。"
+        : "请【私聊我】发送 `maimai 导 令牌` 重试（令牌需要重新发一次）。";
 
     /// <summary>跑一次完整同步：登录 → 轮询 → （可选设令牌）→ 推到所有已配置的查分器。</summary>
     private static async Task RunSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
     {
         var msh = new MaiScoreHubClient();
 
+        var retryHint = RetryHint(newTokens);
+
         message.Reply("正在请求登录…（首次需要你在游戏里同意机器人的好友申请，已是好友则会直接抓分）");
 
         var login = await msh.LoginRequestAsync(friendCode);
+        var announced = false;
         if (!string.IsNullOrEmpty(login.BotFriendCode))
         {
-            message.Reply($"已用机器人账号（好友码 {login.BotFriendCode}）发起好友申请，请进游戏【同意好友】。我最多等 3 分钟，同意后会自动抓分并同步。");
+            message.Reply($"已用机器人账号（好友码 {login.BotFriendCode}）发起好友申请，请进游戏【同意好友】。我最多等 10 分钟，同意后会自动抓分并同步。");
+            announced = true;
         }
 
-        // 轮询直到完成 / 失败 / 超时
+        // 轮询直到完成 / 失败 / 超时（MSH 忙时 send_request 排队可达数分钟，所以放宽到 10 分钟）
         MaiScoreHubClient.LoginStatusResult? status = null;
-        var deadline = DateTime.UtcNow.AddMinutes(3);
+        var deadline     = DateTime.UtcNow.AddMinutes(10);
+        var pollFailures = 0;
         while (DateTime.UtcNow < deadline)
         {
             await Task.Delay(5000);
-            status = await msh.LoginStatusAsync(login.JobId);
+
+            try
+            {
+                status       = await msh.LoginStatusAsync(login.JobId);
+                pollFailures = 0;
+            }
+            catch (Exception e)
+            {
+                // 10 分钟要询问 ~120 次，个别瞬时失败（5xx/超时）不该让整个等待报废
+                if (++pollFailures < 6) continue;
+                message.Reply($"同步中断：连续多次查询任务状态失败（{e.Message}）。稍后{retryHint}");
+                return;
+            }
+
             if (status.Done) break;
+
             if (status.Status is "failed" or "canceled")
             {
-                message.Reply($"同步失败：{status.Message ?? status.Status}");
+                message.Reply($"同步失败：{status.Message ?? status.Status}。{retryHint}");
                 return;
+            }
+
+            // 实测 botUserFriendCode 只在轮询的 job 里下发（login-request 不带）；
+            // 已是好友的任务也可能路过 wait_acceptance，所以措辞要两种情况都对
+            if (!announced && status.Stage == "wait_acceptance" && !string.IsNullOrEmpty(status.BotFriendCode))
+            {
+                message.Reply($"机器人账号（好友码 {status.BotFriendCode}）已发出好友申请：游戏里有待同意的申请就【同意】一下，已是好友则无需操作。我最多等 10 分钟，完成后自动抓分并同步。");
+                announced = true;
             }
         }
 
         if (status is not { Done: true })
         {
-            message.Reply("等待超时（多半是没及时同意好友申请）。同意后重试 `maimai 导` 即可。");
+            message.Reply($"等待超时（多半是没及时同意好友申请）。同意后{retryHint}");
             return;
         }
 
-        // JWT 可能来自 login-status 的 token，也可能来自 login-request 的 authToken（契约不明，两处都兜）
+        // 实测 JWT 在 login-status 完成时的根级 token；login-request 的 authToken 只是兜底
         var jwt = !string.IsNullOrEmpty(status.Token) ? status.Token! : login.AuthToken;
         if (string.IsNullOrEmpty(jwt))
         {
@@ -218,7 +326,7 @@ public partial class MaiMaiDx
 
         if (targets.Count == 0)
         {
-            message.Reply("华立成绩已抓取，但还没配置任何查分器令牌。请【私聊我】重新 `maimai 导` 设置令牌。");
+            message.Reply("华立成绩已抓取，但还没配置任何查分器令牌。请【私聊我】发送 `maimai 导 令牌` 完成设置。");
             return;
         }
 

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -77,6 +77,187 @@ public partial class MaiMaiDx
 
     #endregion
 
+    #region 推分同步（导）
+
+    [MarisaPluginDoc("把成绩从华立(机台)推/导到查分器(水鱼/落雪)。首次需【私聊】配置一次令牌，之后群里也能直接用。基于 bakapiano/maimai-score-hub")]
+    [MarisaPluginCommand("导", "导分")]
+    [MarisaPluginTrigger(nameof(MarisaPluginTrigger.PlainTextTrigger))]
+    private async Task<MarisaPluginTaskState> Sync(Message message)
+    {
+        var qq = message.Sender.Id;
+
+        string? friendCode;
+        using (var realm = BotDbContext.OpenRealm())
+        {
+            friendCode = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == qq)?.FriendCode;
+        }
+
+        // 已设置过 → 直接同步（群里也行，不需要任何机密）
+        if (!string.IsNullOrWhiteSpace(friendCode))
+        {
+            await RunSync(message, friendCode!, null);
+            return MarisaPluginTaskState.CompletedTask;
+        }
+
+        // 首次设置：要让用户发导入令牌，必须私聊
+        if (message.GroupInfo != null)
+        {
+            message.Reply("首次使用「导」需要配置查分器令牌。请【私聊我】发送 `maimai 导` 完成一次设置（令牌不要发在群里，会泄露）。设置好以后群里也能直接用。");
+            return MarisaPluginTaskState.CompletedTask;
+        }
+
+        message.Reply(
+            "【首次设置 · 推分同步】\n" +
+            "第一步：发送你的 maimai DX 好友码（游戏内「フレンド」里那串数字）。\n" +
+            "之后我会用 maimai-score-hub 的机器人号给你发游戏内好友申请，你同意后我就能抓成绩并同步到查分器。"
+        );
+
+        await DialogManager.AddDialogAsync((message.GroupInfo?.Id, message.Sender.Id), async fcMsg =>
+        {
+            var fc = fcMsg.Command.Trim().ToString().Trim();
+            if (fc.Length is < 6 or > 20 || !fc.All(char.IsDigit))
+            {
+                fcMsg.Reply("好友码应该是一串数字，格式不对，已退出。可重新 `maimai 导`。");
+                return MarisaPluginTaskState.Canceled;
+            }
+
+            fcMsg.Reply(
+                "好。第二步：发送你要同步的查分器【导入令牌】（不是密码！）。\n" +
+                "一行一个，至少一个，两个都发就两边都推：\n" +
+                "  落雪 <你的落雪个人 API 令牌>\n" +
+                "  水鱼 <你的水鱼 Import-Token>\n" +
+                "令牌在哪拿：落雪→个人主页/开发者；水鱼→个人主页的「导入 token」。"
+            );
+
+            await DialogManager.AddDialogAsync((fcMsg.GroupInfo?.Id, fcMsg.Sender.Id), async tkMsg =>
+            {
+                var (lxns, df) = ParseTokens(tkMsg.Command.Trim().ToString());
+                if (lxns == null && df == null)
+                {
+                    tkMsg.Reply("没识别到令牌（格式：`落雪 xxx` / `水鱼 xxx`），已退出。可重新 `maimai 导`。");
+                    return MarisaPluginTaskState.Canceled;
+                }
+
+                // 只持久化好友码，令牌不落库
+                using (var realm = BotDbContext.OpenRealm())
+                {
+                    var b = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == tkMsg.Sender.Id);
+                    realm.Write(() =>
+                    {
+                        if (b == null)
+                            realm.AddWithAutoId(new MaiMaiDxBind(tkMsg.Sender.Id, 0) { FriendCode = fc });
+                        else
+                            b.FriendCode = fc;
+                    });
+                }
+
+                await RunSync(tkMsg, fc, (lxns, df));
+                return MarisaPluginTaskState.CompletedTask;
+            }, this);
+
+            return MarisaPluginTaskState.CompletedTask;
+        }, this);
+
+        return MarisaPluginTaskState.CompletedTask;
+    }
+
+    /// <summary>跑一次完整同步：登录 → 轮询 → （可选设令牌）→ 推到所有已配置的查分器。</summary>
+    private static async Task RunSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
+    {
+        var msh = new MaiScoreHubClient();
+
+        message.Reply("正在请求登录…（首次需要你在游戏里同意机器人的好友申请，已是好友则会直接抓分）");
+
+        var login = await msh.LoginRequestAsync(friendCode);
+        if (!string.IsNullOrEmpty(login.BotFriendCode))
+        {
+            message.Reply($"已用机器人账号（好友码 {login.BotFriendCode}）发起好友申请，请进游戏【同意好友】。我最多等 3 分钟，同意后会自动抓分并同步。");
+        }
+
+        // 轮询直到完成 / 失败 / 超时
+        MaiScoreHubClient.LoginStatusResult? status = null;
+        var deadline = DateTime.UtcNow.AddMinutes(3);
+        while (DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(5000);
+            status = await msh.LoginStatusAsync(login.JobId);
+            if (status.Done) break;
+            if (status.Status is "failed" or "canceled")
+            {
+                message.Reply($"同步失败：{status.Message ?? status.Status}");
+                return;
+            }
+        }
+
+        if (status is not { Done: true } || string.IsNullOrEmpty(status.Token))
+        {
+            message.Reply("等待超时或没拿到登录凭据（多半是没及时同意好友申请）。同意后重试 `maimai 导` 即可。");
+            return;
+        }
+
+        var jwt = status.Token!;
+
+        // 设置新令牌（如有），再看 MSH 里配置了哪些查分器
+        if (newTokens is { } t)
+        {
+            if (!string.IsNullOrWhiteSpace(t.Lxns)) await msh.SetTokenAsync(jwt, "lxns", t.Lxns!);
+            if (!string.IsNullOrWhiteSpace(t.DivingFish)) await msh.SetTokenAsync(jwt, "diving-fish", t.DivingFish!);
+        }
+
+        var profile = await msh.GetProfileAsync(jwt);
+
+        var targets = new List<string>();
+        if (profile.HasLxns) targets.Add("lxns");
+        if (profile.HasDivingFish) targets.Add("diving-fish");
+
+        if (targets.Count == 0)
+        {
+            message.Reply("华立成绩已抓取，但还没配置任何查分器令牌。请【私聊我】重新 `maimai 导` 设置令牌。");
+            return;
+        }
+
+        var sb = new StringBuilder("同步完成：\n");
+        foreach (var p in targets)
+        {
+            var name = p == "lxns" ? "落雪" : "水鱼";
+            try
+            {
+                var r = await msh.ExportAsync(jwt, p);
+                sb.AppendLine(r.Success ? $"{name} ✅ 导入 {r.Exported}/{r.Scores} 条" : $"{name} ❌ {r.Message ?? "失败"}");
+            }
+            catch (Exception e)
+            {
+                sb.AppendLine($"{name} ❌ {e.Message}");
+            }
+        }
+
+        message.Reply(sb.ToString().TrimEnd());
+    }
+
+    private static (string? Lxns, string? DivingFish) ParseTokens(string text)
+    {
+        string? lxns = null, df = null;
+
+        foreach (var raw in text.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (line.Length == 0) continue;
+
+            var sp  = line.IndexOfAny([' ', '\t', '：', ':']);
+            var val = sp >= 0 ? line[(sp + 1)..].Trim() : "";
+
+            if (line.StartsWith("落雪") || line.StartsWith("lxns", StringComparison.OrdinalIgnoreCase))
+                lxns = val;
+            else if (line.StartsWith("水鱼") || line.StartsWith("df", StringComparison.OrdinalIgnoreCase) ||
+                     line.StartsWith("divingfish", StringComparison.OrdinalIgnoreCase) || line.StartsWith("diving-fish", StringComparison.OrdinalIgnoreCase))
+                df = val;
+        }
+
+        return (string.IsNullOrWhiteSpace(lxns) ? null : lxns, string.IsNullOrWhiteSpace(df) ? null : df);
+    }
+
+    #endregion
+
     #region unlock
 
     [MarisaPluginDisabled]

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -78,6 +78,23 @@ public partial class MaiMaiDx
 
     #region 推分同步（导）
 
+    private const string UsageText =
+        "用法：\n" +
+        "mai 导 —— 同步成绩到查分器（首次会一步步引导）\n" +
+        "mai 导 <好友码> —— 绑定/换绑好友码\n" +
+        "mai 导 落雪 xxx 水鱼 yyy —— 设置查分器导入令牌（发一个也行）\n" +
+        "令牌获取方法：\n\n" +
+        "水鱼：首页-编辑个人资料-成绩导入Token\n\n" +
+        "落雪：账号详情-个人API密钥\n\n" +
+        "建议发送令牌后立即「撤回」消息。";
+
+    private static readonly Regex SyncTokenArg = new(
+        @"(?<=^|\s)(?<key>落雪|水鱼|lxns|diving-fish|divingfish|df)[:：\s]+(?<val>\S+)",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+    /// <summary>正在后台同步的用户，防止同一个人并发开多个 MSH 任务。</summary>
+    private static readonly ConcurrentDictionary<long, byte> Syncing = new();
+
     [MarisaPluginDoc("把成绩从NET导到查分器(水鱼/落雪)，首次使用会引导设置")]
     [MarisaPluginCommand("传分", "导", "sync")]
     [MarisaPluginTrigger(nameof(MarisaPluginTrigger.PlainTextTrigger))]
@@ -261,23 +278,6 @@ public partial class MaiMaiDx
             });
         }
     }
-
-    private const string UsageText =
-        "用法：\n" +
-        "mai 导 —— 同步成绩到查分器（首次会一步步引导）\n" +
-        "mai 导 <好友码> —— 绑定/换绑好友码\n" +
-        "mai 导 落雪 xxx 水鱼 yyy —— 设置查分器导入令牌（发一个也行）\n" +
-        "令牌获取方法：\n\n" +
-        "水鱼：首页-编辑个人资料-成绩导入Token\n\n" +
-        "落雪：账号详情-个人API密钥\n\n" +
-        "建议发送令牌后立即「撤回」消息。";
-
-    private static readonly Regex SyncTokenArg = new(
-        @"(?<=^|\s)(?<key>落雪|水鱼|lxns|diving-fish|divingfish|df)[:：\s]+(?<val>\S+)",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    /// <summary>正在后台同步的用户，防止同一个人并发开多个 MSH 任务。</summary>
-    private static readonly ConcurrentDictionary<long, byte> Syncing = new();
 
     /// <summary>
     ///     把一次完整同步丢到后台执行并立即返回。

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -213,6 +213,53 @@ public partial class MaiMaiDx
         }, this);
 
         return MarisaPluginTaskState.CompletedTask;
+
+        // 解析「导」后面的参数：15 位纯数字是好友码，「落雪/水鱼 xxx」是对应查分器的导入令牌，
+        // 其余内容原样带回（Junk 非空说明没看懂，应当回用法而不是瞎猜）
+        static (string? Fc, string? Lxns, string? Df, string? Junk) ParseSyncArgs(string args)
+        {
+            string? lxnsTok = null, dfTok = null;
+
+            var rest = SyncTokenArg.Replace(args, m =>
+            {
+                var val = m.Groups["val"].Value;
+                // 「落雪 水鱼 yyy」这种没给值的，整段还回去当没看懂（真令牌都是 ASCII）
+                if (val.Any(c => c > 127)) return m.Value;
+
+                if (m.Groups["key"].Value.ToLowerInvariant() is "落雪" or "lxns") lxnsTok = val;
+                else dfTok = val;
+                return " ";
+            });
+
+            string? fcVal = null;
+            var junkWords = new List<string>();
+            foreach (var w in rest.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (fcVal == null && w.Length == 15 && w.All(char.IsAsciiDigit)) fcVal = w;
+                else junkWords.Add(w);
+            }
+
+            return (fcVal, lxnsTok, dfTok, junkWords.Count == 0 ? null : string.Join(' ', junkWords));
+        }
+
+        // 只持久化好友码，令牌不落库（只经手转交 MSH）
+        static void PersistFriendCode(long uid, string code)
+        {
+            using var realm = BotDbContext.OpenRealm();
+            var bind = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == uid);
+            realm.Write(() =>
+            {
+                if (bind == null)
+                {
+                    // ServerName 不能留空：空串会被 GetDataFetcher 的 _ 分支路由到华立 fetcher（AimeId=0 必坏）
+                    realm.AddWithAutoId(new MaiMaiDxBind(uid, 0) { FriendCode = code, ServerName = "DivingFish" });
+                }
+                else
+                {
+                    bind.FriendCode = code;
+                }
+            });
+        }
     }
 
     private const string UsageText =
@@ -228,56 +275,6 @@ public partial class MaiMaiDx
     private static readonly Regex SyncTokenArg = new(
         @"(?<=^|\s)(?<key>落雪|水鱼|lxns|diving-fish|divingfish|df)[:：\s]+(?<val>\S+)",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    /// <summary>
-    ///     解析「导」后面的参数：15 位纯数字是好友码，「落雪/水鱼 xxx」是对应查分器的导入令牌，
-    ///     其余内容原样带回（Junk 非空说明没看懂，应当回用法而不是瞎猜）。
-    /// </summary>
-    private static (string? Fc, string? Lxns, string? Df, string? Junk) ParseSyncArgs(string args)
-    {
-        string? lxns = null, df = null;
-
-        var rest = SyncTokenArg.Replace(args, m =>
-        {
-            var val = m.Groups["val"].Value;
-            // 「落雪 水鱼 yyy」这种没给值的，整段还回去当没看懂（真令牌都是 ASCII）
-            if (val.Any(c => c > 127)) return m.Value;
-
-            if (m.Groups["key"].Value.ToLowerInvariant() is "落雪" or "lxns") lxns = val;
-            else df = val;
-            return " ";
-        });
-
-        string? fc = null;
-        var junk = new List<string>();
-        foreach (var w in rest.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
-        {
-            if (fc == null && w.Length == 15 && w.All(char.IsAsciiDigit)) fc = w;
-            else junk.Add(w);
-        }
-
-        return (fc, lxns, df, junk.Count == 0 ? null : string.Join(' ', junk));
-    }
-
-    /// <summary>只持久化好友码，令牌不落库（只经手转交 MSH）。</summary>
-    private static void PersistFriendCode(long qq, string friendCode)
-    {
-        using var realm = BotDbContext.OpenRealm();
-        var bind = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == qq);
-        realm.Write(() =>
-        {
-            if (bind == null)
-            {
-                // ServerName 不能留空：空串会被 GetDataFetcher 的 _ 分支路由到华立 fetcher（AimeId=0 必坏），
-                // 给没 bind 过的人按默认值补上水鱼
-                realm.AddWithAutoId(new MaiMaiDxBind(qq, 0) { FriendCode = friendCode, ServerName = "DivingFish" });
-            }
-            else
-            {
-                bind.FriendCode = friendCode;
-            }
-        });
-    }
 
     /// <summary>正在后台同步的用户，防止同一个人并发开多个 MSH 任务。</summary>
     private static readonly ConcurrentDictionary<long, byte> Syncing = new();


### PR DESCRIPTION
## 概要

新增 `传分` / `导` 命令：经 [bakapiano/maimai-score-hub](https://github.com/bakapiano/maimai-score-hub)（MSH，官方开放接入：公开 OpenAPI + 全开 CORS）把玩家的机台成绩同步到他本人的水鱼 / 落雪查分器。「bot 转发调 MSH」的思路来自 QingQiz。

## 用法

- `mai 导` —— 同步成绩（首次会在群里/私聊一步步引导：好友码 → 令牌/跳过）
- `mai 导 <好友码>` —— 绑定/换绑好友码（15 位数字）并同步
- `mai 导 落雪 xxx 水鱼 yyy` —— 设置查分器导入令牌并同步（发一个也行，只推到配置过的查分器；令牌仅首次需要，MSH 服务端保存）

流程：login-request(好友码) → 用户游戏内同意 MSH 机器人好友申请 → 轮询拿 JWT →（带令牌时）PATCH 设置令牌 + autoExport → 推到所有已配置查分器。

## 设计要点

- **令牌经手不落库**：bot 只把令牌转交 MSH，本地只存 `MaiMaiDxBind.FriendCode`
- **群聊可用**（与群友讨论后的决定）：每个收到令牌的路径都会提醒用户「撤回」消息；解析失败的输入一律不回显原文（bot 的消息用户撤不回，防止把真令牌再播一遍）
- **同步后台化**：等好友同意最长 10 分钟，不能占消息管线（BotDriver 每条消息有 10 分钟 Polly 硬超时；对话挂起期间还会吞掉用户的其它消息），Task.Run detach + 每用户并发护栏
- **客户端按真实返回对齐**（2026-06-12 实测，仓库里的 openapi.yaml 已过时）：导出成功判据是顶层 `status==200`（无顶层 `success`）；`stage`/`error`/`botUserFriendCode` 在嵌套 `job` 里；完成时 JWT 在根级 `token` 且 `status` 仍是 `processing`
- 首次引导用单对话状态机（`ToBeContinued` 续话）——在对话 handler 里再 `AddDialogAsync` 同 key 会和 `DialogManager` 的自旋互等死锁
- `bind/绑定` 改为原地更新 `ServerName`（原先删行重建，现在会把同一行的 `FriendCode` 一起抹掉）

## ⚠️ 部署注意（数据库迁移）

- `MaiMaiDxBind` 新增 `FriendCode` 可空列，`SchemaVersion` 4 → 5：**不 bump 的话存量库会在第一条消息时抛 `RealmMigrationNeededException`（波及全部查库功能）**
- 已用 Realm 20.1.0 实测 v4 库 → v5 自动迁移：数据完好、无需 MigrationCallback。注意实体字符串列必须保持 schema-optional（`string?`）——optional→required 的自动迁移是删列重建，会清空整列存量数据（代码里有注释）

## 测试状态

- MSH 全链路（login → 同意好友 → 抓分 → 推送）已用独立脚本实测通过一次：2134 条成绩同时推到落雪+水鱼成功
- bot 侧已本地编译（0 error 0 warning）；**群内引导对话路径还没在真 bot 上跑过**——我这边起不了 bot，实装后麻烦先拿首次设置流程过一遍

本 PR 由 Claude Fable 5 编写。

🤖 Generated with [Claude Code](https://claude.com/claude-code)