### PR TITLE
fix(maimai): 传分等待任务真正完成再导出，修首次使用必现的 Sync not found

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -65,7 +65,6 @@ public class MaiScoreHubClient
 
         var status = S(root, "status") ?? "";
         var token  = S(root, "token");
-        var done   = root.TryGetProperty("done", out var d) && d.ValueKind == JsonValueKind.True;
 
         // 实测 stage / 失败原因 / 机器人好友码均位于嵌套的 job 对象中（根级没有这些字段；完成时 job 整体缺失）
         string? stage = null, error = null, botFriendCode = null;
@@ -76,8 +75,9 @@ public class MaiScoreHubClient
             botFriendCode = S(job, "botUserFriendCode");
         }
 
-        // 取到 token（或终态 completed）即视为抓分完成；实测完成时 status 仍为 processing 且无 done 字段
-        if (!string.IsNullOrEmpty(token) || status == "completed") done = true;
+        // token 在 update_score（抓分进行中）阶段就会随响应下发，不能作为完成依据：
+        // 抓分记录要等 status 变为 completed 之后才创建，过早导出会报 Sync not found（首次使用必现）
+        var done = status == "completed";
 
         return new LoginStatusResult(done, status, stage, token, error ?? S(root, "message"), botFriendCode);
     }

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -423,6 +423,14 @@ public partial class MaiMaiDx
             try
             {
                 var r = await msh.ExportAsync(jwt, p);
+
+                // 抓分记录在任务 completed 之后才异步落库，导出可能恰好跑在落库之前，稍候重试
+                for (var retry = 0; retry < 5 && !r.Success && r.Message == "Sync not found"; retry++)
+                {
+                    await Task.Delay(3000);
+                    r = await msh.ExportAsync(jwt, p);
+                }
+
                 sb.AppendLine(r.Success ? $"{name} ✅ 导入 {r.Exported}/{r.Scores} 条" : $"{name} ❌ {r.Message ?? "失败"}");
             }
             catch (Exception e)


### PR DESCRIPTION
## 现象

首次使用的用户传分失败（老用户正常）：

```
@用户 同步完成：
水鱼 ❌ Sync not found
```

## 根因（对照 maimai-score-hub 源码确认）

1. `auth.service.ts` `checkStatus`：`status === 'completed'` **或** `status === 'processing' && stage === 'update_score'`（抓分进行中）都会返回 `{status, token, user}` —— 两种响应形状相同，仅 `status` 值不同
2. `job.service.ts`：抓分记录（`createFromJob`）在 `status` 置为 `completed` **之后**才创建
3. `sync.service.ts`：导出接口 `findOne({friendCode})` 取最近一条抓分记录，查不到即 404 `Sync not found`

客户端把「拿到 token」当成抓分完成并立即导出。首次使用没有历史记录可兜底 → 必现 404；老用户能"成功"是查到了上一次的记录，**实际可能导出旧数据**，属同一缺陷的静默形态。

## 修复

- `LoginStatusAsync`：`status == "completed"` 才视为完成，token 仅随手记录（它在 update_score 阶段就会下发）
- 导出遇 `Sync not found` 时重试（至多 5 次、间隔 3s）：`completed` 置位与抓分记录落库之间仍有窗口

本 PR 由 Claude Fable 5 编写。

🤖 Generated with [Claude Code](https://claude.com/claude-code)