### PR TITLE
fix(maimai): 传分抓分期间改用轻量任务接口轮询，修连续超时中断

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -30,6 +30,8 @@ public class MaiScoreHubClient
 
     public sealed record ExportResult(bool Success, int Exported, int Scores, string? Message);
 
+    public sealed record JobResult(string Status, string? Stage, string? Error);
+
     /// <summary>POST /auth/login-request — 用好友码发起登录+抓分任务。</summary>
     public async Task<LoginRequestResult> LoginRequestAsync(string friendCode)
     {
@@ -80,6 +82,23 @@ public class MaiScoreHubClient
         var done = status == "completed";
 
         return new LoginStatusResult(done, status, stage, token, error ?? S(root, "message"), botFriendCode);
+    }
+
+    /// <summary>
+    ///     GET /job/{jobId} — 轻量的任务状态查询（无需鉴权）。
+    ///     login-status 在抓分期间每次调用都伴随数据库写入与 JWT 签发，持续轮询会撞上服务端长时间停滞；
+    ///     MSH 自家前端跟踪抓分进度用的就是本接口。
+    /// </summary>
+    public async Task<JobResult> GetJobAsync(string jobId)
+    {
+        var json = await Req($"/job/{jobId}").GetStringAsync();
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        string? S(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+        return new JobResult(S("status") ?? "", S("stage"), S("error"));
     }
 
     /// <summary>GET /users/profile（Bearer）— 看 MSH 里已配置了哪些查分器令牌。</summary>

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -346,7 +346,11 @@ public partial class MaiMaiDx
             announced = true;
         }
 
-        // 轮询直到完成 / 失败 / 超时；MSH 繁忙时 send_request 阶段排队可达数分钟，故超时设为 10 分钟
+        // 第一阶段：轮询 login-status 等 JWT 下发，直到拿到 token / 失败 / 超时。
+        // MSH 繁忙时 send_request 阶段排队可达数分钟，故总超时设为 10 分钟。
+        // 注意只轮询到拿到 token 为止：login-status 在抓分（update_score）期间每次调用都伴随
+        // 数据库写入与 JWT 签发，持续轮询会撞上服务端 30 秒以上的响应停滞（实测连续超时），
+        // MSH 自家前端同样在拿到 token 后就不再调用该接口
         MaiScoreHubClient.LoginStatusResult? status = null;
         var deadline     = DateTime.UtcNow.AddMinutes(10);
         var pollFailures = 0;
@@ -367,7 +371,7 @@ public partial class MaiMaiDx
                 return;
             }
 
-            if (status.Done) break;
+            if (status.Done || !string.IsNullOrEmpty(status.Token)) break;
 
             if (status.Status is "failed" or "canceled")
             {
@@ -383,18 +387,60 @@ public partial class MaiMaiDx
             }
         }
 
-        if (status is not { Done: true })
+        if (status == null || (!status.Done && string.IsNullOrEmpty(status.Token)))
         {
             ReplyAt(message, $"等待超时（可能未及时同意好友申请）。同意后{retryHint}");
             return;
         }
 
-        // 实测 JWT 位于 login-status 完成响应的根级 token 字段；login-request 的 authToken 仅作回退
+        // 实测 JWT 在 update_score（抓分开始）阶段即随 login-status 下发；login-request 的 authToken 仅作回退
         var jwt = !string.IsNullOrEmpty(status.Token) ? status.Token! : login.AuthToken;
         if (string.IsNullOrEmpty(jwt))
         {
-            ReplyAt(message, "成绩抓取完成，但未获取到登录凭据（MSH 的 token 下发方式可能已变更）。请向开发者反馈。");
+            ReplyAt(message, "登录完成，但未获取到登录凭据（MSH 的 token 下发方式可能已变更）。请向开发者反馈。");
             return;
+        }
+
+        // 第二阶段：抓分仍在进行则改用轻量的 GET /job/{id} 等任务完成——
+        // 抓分记录在 status 变为 completed 之后才落库，过早导出会推送旧记录或报 Sync not found
+        if (!status.Done)
+        {
+            var crawlDone = false;
+            while (DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(5000);
+
+                MaiScoreHubClient.JobResult job;
+                try
+                {
+                    job          = await msh.GetJobAsync(login.JobId);
+                    pollFailures = 0;
+                }
+                catch (Exception e)
+                {
+                    if (++pollFailures < 6) continue;
+                    ReplyAt(message, $"同步中断：连续多次查询任务状态失败（{e.Message}）。稍后{retryHint}");
+                    return;
+                }
+
+                if (job.Status == "completed")
+                {
+                    crawlDone = true;
+                    break;
+                }
+
+                if (job.Status is "failed" or "canceled")
+                {
+                    ReplyAt(message, $"同步失败：{job.Error ?? job.Status}。{retryHint}");
+                    return;
+                }
+            }
+
+            if (!crawlDone)
+            {
+                ReplyAt(message, $"等待超时（成绩抓取未完成）。稍后{retryHint}");
+                return;
+            }
         }
 
         // 设置新令牌（如有），随后查询 MSH 中已配置的查分器


### PR DESCRIPTION
## 现象

#57 实装后两位用户稳定复现：

```
同步中断：连续多次查询任务状态失败（Call timed out: GET https://maimai.bakapiano.com/api/auth/login-status?jobId=...）。稍后重试「mai 导」即可。
```

## 根因（对照 maimai-score-hub 源码与部署记录确认）

- `auth.service.ts` `checkStatus`：进入 `update_score`（抓分）阶段后，**每次调用**都执行全量 job 文档捞取 + `users.findByFriendCode` + `users.update(profile)` 数据库**写入** + JWT 签发
- MSH 后端部署在内存紧张的单机（mongo 容量 3.5G，仓库内有 2026-05-14 OOM、05-29 169% CPU、06-10 "memory-starved mongo ... times out" 的公开记录；05-31 起整机迁至无公网 IP 的内网机器经反向隧道出网），抓分阶段恰是 worker 大量写库的窗口，该接口停滞 30 秒以上是真实发生的
- #57 把轮询从「拿到 token 即止」改为贯穿整个抓分阶段（数分钟），持续 5s 间隔打在这条重路径上 → 连续 6 次 30s 超时触发放弃逻辑
- **MSH 自家前端从不这么用**：`LoginPage.tsx` 拿到第一个 token（即 update_score 开始时刻）就永久停止轮询 login-status，改用轻量的 `GET /api/job/{jobId}`（公开接口、裸查任务文档，无用户读写、无 JWT 签发）以 1.5s 间隔跟踪抓分进度

## 修复（对齐 upstream 自己的用法）

轮询拆为两阶段：

1. login-status 仅轮询至 token 下发（重接口至多被调用数次，与官网行为一致）
2. 改用 `GET /job/{jobId}` 等 `status == "completed"`（响应根级含 status/stage/error，已对照 `toJobResponse` 源码核对），失败时取 `error` 字段；之后照常设令牌/导出，#57 的 Sync not found 导出重试保留

两阶段共享原有的 10 分钟总超时与瞬时失败容忍（连续 6 次才放弃）。

本 PR 由 Claude Fable 5 编写。

🤖 Generated with [Claude Code](https://claude.com/claude-code)