### PR TITLE
fix(maimai): 传分抓分阶段独立计时，修好友申请送达慢导致的「成绩抓取未完成」

### DIFF
--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -405,6 +405,11 @@ public partial class MaiMaiDx
         // 抓分记录在 status 变为 completed 之后才落库，过早导出会推送旧记录或报 Sync not found
         if (!status.Done)
         {
+            // 抓分阶段单独计时：第一阶段需等待好友申请送达并被接受，MSH 机器人账号繁忙时好友申请
+            // 的发出会排队数分钟，可能已耗去第一阶段的大部分时间；若与抓分共用同一截止时间，抓分等待
+            // 会因预算所剩无几而超时。此处好友申请已被接受，仅需等待服务端抓分（其自带 30 分钟硬上限）
+            deadline = DateTime.UtcNow.AddMinutes(10);
+
             var crawlDone = false;
             while (DateTime.UtcNow < deadline)
             {


### PR DESCRIPTION
## 现象

#58 部署后，好友申请送达较慢的用户会遇到：

```
@用户 Bot 账号（好友码...）已发出好友申请，去NET里同意一下，请在10分钟内完成操作。
@用户 等待超时（成绩抓取未完成）。稍后重试「mai 导」即可。
```

好友申请送达较快时，同一用户一切正常（实测 2137 条成功推送落雪与水鱼）。

## 根因

#58 的两阶段轮询共用同一个 10 分钟截止时间（`deadline` 在登录前设定一次）：

- 第一阶段（login-status 轮询至取得 token）需等待好友申请送达并被接受。MSH 机器人账号繁忙时，好友申请的发出会在 send_request 阶段排队数分钟，这段耗时主要取决于服务端而非用户操作。
- 当第一阶段耗去大部分预算后，第二阶段（GET /job 等待抓分完成，本身需数分钟）所剩时间不足，于是好友申请虽已接受、抓分也在正常进行，用户仍被报「成绩抓取未完成」。

实测确认：同一用户、同一版本，唯一变量是好友申请送达的快慢——送达慢则超时，送达快则成功。这正是第二阶段预算被第一阶段挤占的特征（探测线上残留 job 可见多数任务长时间停留在 send_request 阶段，印证好友申请发出确实存在排队）。

## 修复

进入第二阶段（已取得 token，即好友申请已被接受、抓分已开始）时，将截止时间重置为全新的 10 分钟，使抓分等待独立计时。第一阶段等待好友申请的 10 分钟预算保持不变。

改动仅一行（含注释 3 行），位于 `if (!status.Done)` 内，不影响第一阶段的超时路径。

本 PR 由 Claude Fable 5 编写。

🤖 Generated with [Claude Code](https://claude.com/claude-code)