### PR TITLE
fix(maimai): b50/b35 排除宴会场谱面（宴谱无定数不应计入 rating）

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/AllNetDataFetcher.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/AllNetDataFetcher.cs
@@ -39,6 +39,7 @@ public class AllNetDataFetcher(SongDb<MaiMaiSong> songDb) : DataFetcher(songDb)
         var scores = await GetPolicy("GetScores").ExecuteAsync(async () => await GetScores(id));
 
         var group = scores
+            .Where(x => x.Key.Id <= 100000)
             .GroupBy(x => SongDb.SongIndexer[x.Key.Id].Info.IsNew)
             .ToList();
 

--- a/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/DivingFishDataFetcher.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/DivingFishDataFetcher.cs
@@ -24,7 +24,7 @@ public class DivingFishDataFetcher : DataFetcher
         var raw = await FetchScores(message, false);
 
         var group = raw.Records
-            .Where(x => SongDb.SongIndexer.ContainsKey(x.Id))
+            .Where(x => x.Id <= 100000 && SongDb.SongIndexer.ContainsKey(x.Id))
             .GroupBy(x => SongDb.SongIndexer[x.Id].Info.IsNew)
             .ToList();
 

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -564,6 +564,7 @@ public partial class MaiMaiDx
         try
         {
             var scores = (await fetcher.GetScores(message))
+                .Where(kv => kv.Key.Id <= 100000)
                 .OrderByDescending(kv => kv.Value.Rating).ThenBy(x => x.Key.Id)
                 .Select(x => x.Value)
                 .ToList();


### PR DESCRIPTION
群友反馈 `mai b50` 里混入了宴会场（宴谱）谱面——宴谱没有真正定数、不计入 rating，不应出现在 b50。

## 根因
有三处在本地计算 best-list 时没有排除宴谱（宴谱判定 `Id > 100000`，与 `MaiMaiSong` 的「宴定数归零」同口径）：
- `DivingFishDataFetcher.GetRating`：把玩家全部记录（在 SongDb 内的）按 rating 取 top 35/15。宴谱也在 SongDb 里（所以定数才会被归零），且 diving-fish 记录自带 `ds`，故宴谱可能带真实 rating 占 b50 名额。← 复现的泄漏点
- `AllNetDataFetcher.GetRating`：同样的分组取 top。
- `b35` 命令：自己从 `GetScores`（含宴谱）取 top 50。

## 改动
- 三处分别加 `Id <= 100000` 过滤。
- **不动 `GetScores`** —— 完成表 / summary 仍要靠它拿宴谱。
- **lxns 无需改** —— 其 `/bests` 是服务端算好的 rating bests，本就不含宴谱。

## 实测核验（真实 diving-fish 数据，非单测）
- 判定式：线上歌单 52 张宴谱 **Id 全部 > 100000、零误判**（DX 谱 10000–99999、SD < 10000，不会误伤）。
- 正向对照：把真实宴谱 `[宴]In Chaos`（Id 100022，真实定数 14.7）按 SSS+ 注入某真实玩家成绩 → 单曲 ra 330：**旧逻辑混入 b50、新逻辑排除**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
