### PR TITLE
fix(maimai): adjust completion plate defaults and 舞 scope

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -54,8 +54,10 @@ public static class PlateData
     /// </summary>
     public sealed record Query(IReadOnlyList<Selector> Selectors, Threshold Threshold, IReadOnlyList<int> LevelIdxes);
 
-    /// <summary>默认难度：未指定时同时查 MASTER + Re:MASTER。</summary>
+    /// <summary>非版本查询的默认难度：MASTER + Re:MASTER。</summary>
     public static readonly IReadOnlyList<int> DefaultLevelIdxes = [3, 4];
+
+    private static readonly IReadOnlyList<int> DefaultPlateLevelIdxes = [3];
 
     /// <summary>默认阈值（"将"=SSS）。用户未指定阈值时自动应用。</summary>
     public static readonly Threshold DefaultThreshold = new(Dimension.Achievement, 12, "SSS");
@@ -478,10 +480,11 @@ public static class PlateData
             return false;
         }
 
-        // 宴会場 special-case：宴谱（id > 100000）只有 1-2 个低 idx 谱面（没有 MASTER+Re:MASTER），
-        // 用 DefaultLevelIdxes=[3,4] 会把所有 宴会場 songs 过滤光。
-        // 用户未显式指定难度 (diffAt < 0) 且 selector 命中 Genre("宴会場") 时，扩展到全难度。
-        if (diffAt < 0 && selectors.OfType<Selector.Genre>().Any(g => g.FullName == "宴会場"))
+        if (diffAt < 0 && selectors.OfType<Selector.Plate>().Any())
+        {
+            levelIdxes = DefaultPlateLevelIdxes;
+        }
+        else if (diffAt < 0 && selectors.OfType<Selector.Genre>().Any(g => g.FullName == "宴会場"))
         {
             levelIdxes = [0, 1, 2, 3, 4];
         }

--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -161,39 +161,75 @@ public static class PlateData
         "maimai FiNALE",
     ];
 
-    // diving-fish 只有歌曲级发布日期；这些旧版本歌曲的 Re:MASTER 是 DX 时代追加，不能计入「舞」。
-    private static readonly (long Id, string Title)[] PostDxAddedFinaleAndEarlierRemasterEntries =
+    // diving-fish 只有歌曲级发布日期；「舞」的 Re:MASTER 采用白名单，避免后续 DX 时代追加旧曲白谱时自动误计入。
+    private static readonly (long Id, string Title)[] FinaleAndEarlierRemasterEntries =
     [
-        (47,  "源平大戦絵巻テーマソング"),
-        (85,  "JACKY [Remix]"),
-        (111, "Sky High [Reborn]"),
-        (115, "DADDY MULK -Groove remix-"),
-        (131, "Link"),
-        (133, "We Gonna Party"),
-        (134, "Night Fly"),
-        (144, "air's gravity"),
-        (155, "泣き虫O'clock"),
-        (219, "記憶、記録"),
-        (239, "System “Z”"),
-        (240, "Beat of getting entangled"),
-        (248, "Backyun! －悪い女－"),
-        (252, "みんなのマイマイマー"),
-        (260, "LUCIA"),
-        (261, "Death Scythe"),
-        (328, "言ノ葉カルマ"),
-        (364, "D✪N’T  ST✪P  R✪CKIN’"),
-        (367, "Dragoon"),
-        (378, "planet dancer"),
-        (389, "FLOWER"),
-        (463, "FEEL the BEATS"),
-        (464, "Revive The Rave"),
-        (472, "アージェントシンメトリー"),
-        (629, "Limit Break"),
-        (704, "SPILL OVER COLORS"),
+        (17,  "Future"),
+        (22,  "In Chaos"),
+        (23,  "Crush On You"),
+        (24,  "Sun Dance"),
+        (58,  "Endless World"),
+        (61,  "Beat Of Mind"),
+        (62,  "檄！帝国華撃団(改)"),
+        (65,  "ZIGG-ZAGG"),
+        (66,  "ワールズエンド・ダンスホール"),
+        (70,  "ジングルベル"),
+        (71,  "マトリョシカ"),
+        (80,  "City Escape: Act1"),
+        (81,  "Rooftop Run: Act1"),
+        (100, "Tell Your World"),
+        (107, "ロミオとシンデレラ"),
+        (143, "Fragrance"),
+        (145, "Starlight Disco"),
+        (146, "39"),
+        (198, "カゲロウデイズ"),
+        (200, "Bad Apple!! feat nomico"),
+        (204, "ナイト・オブ・ナイツ"),
+        (226, "Blew Moon"),
+        (227, "Garakuta Doll Play"),
+        (247, "Danza zandA"),
+        (255, "Burning Hearts ～炎のANGEL～"),
+        (256, "いーあるふぁんくらぶ"),
+        (265, "Save This World νMIX"),
+        (266, "Living Universe"),
+        (282, "からくりピエロ"),
+        (295, "緋色のDance"),
+        (296, "明星ロケット"),
+        (299, "ロストワンの号哭"),
+        (301, "患部で止まってすぐ溶ける～狂気の優曇華院"),
+        (310, "エピクロスの虹はもう見えない"),
+        (312, "ってゐ！ ～えいえんてゐVer～"),
+        (365, "ガラテアの螺旋"),
+        (414, "若い力 -SEGA HARD GIRLS MIX-"),
+        (496, "AMAZING MIGHTYYYY!!!!"),
+        (513, "だんだん早くなる"),
+        (532, "洗脳"),
+        (589, "Panopticon"),
+        (731, "妄想感傷代償連盟"),
+        (741, "インビジブル"),
+        (756, "CYBER Sparks"),
+        (759, "サドマミホリック"),
+        (763, "はやくそれになりたい！"),
+        (777, "花と、雪と、ドラムンベース。"),
+        (792, "ヒバナ"),
+        (793, "ロキ"),
+        (799, "QZKago Requiem"),
+        (803, "Schwarzschild"),
+        (806, "ナイトメア☆パーティーナイト"),
+        (809, "結ンデ開イテ羅刹ト骸"),
+        (812, "Alea jacta est!"),
+        (816, "クレイジークレイジーダンサーズ"),
+        (818, "隠然"),
+        (820, "FFT"),
+        (825, "雷切-RAIKIRI-"),
+        (830, "立ち入り禁止"),
+        (833, "the EmpErroR"),
+        (834, "PANDORA PARADOXXX"),
+        (838, "最終鬼畜妹フランドール・S"),
     ];
 
-    private static readonly HashSet<long> PostDxAddedFinaleAndEarlierRemasterSongIds =
-        PostDxAddedFinaleAndEarlierRemasterEntries.Select(e => e.Id).ToHashSet();
+    private static readonly HashSet<long> FinaleAndEarlierRemasterSongIds =
+        FinaleAndEarlierRemasterEntries.Select(e => e.Id).ToHashSet();
 
     /// <summary>
     ///     代字 → diving-fish 版本字符串集合。
@@ -246,11 +282,11 @@ public static class PlateData
         }
 
         return plate.Scope != PlateScope.FinaleAndEarlier
-               || !IsPostDxAddedFinaleAndEarlierRemaster(song.Id, levelIdx);
+               || IsFinaleAndEarlierChart(song.Id, levelIdx);
     }
 
-    public static bool IsPostDxAddedFinaleAndEarlierRemaster(long songId, int levelIdx) =>
-        levelIdx == 4 && PostDxAddedFinaleAndEarlierRemasterSongIds.Contains(songId);
+    public static bool IsFinaleAndEarlierChart(long songId, int levelIdx) =>
+        levelIdx != 4 || FinaleAndEarlierRemasterSongIds.Contains(songId);
 
     /// <summary>diving-fish 暂未提供数据的代字（CiRCLE 的丸）。报错而非"未识别"。</summary>
     public static readonly HashSet<string> BlockedPlateKanji = ["丸"];

--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -2,15 +2,17 @@ namespace Marisa.Plugin.Shared.MaiMaiDx;
 
 /// <summary>
 ///     完成表（plate progress）所用的数据表 + 命令解析。
-///     语义：游戏内的"真极/熊将/鏡神/..."等称号，按 BASIC ~ MASTER 四个难度的成绩判定。
-///     不参与 Re:MASTER。
+///     支持版本代字、谱师、类别、作曲家、难度 label、定数等选择条件。
 /// </summary>
 public static class PlateData
 {
     public const string CommandSuffix = "完成表";
     private const string OptionalDaiSuffix = "代";
+    private const string FinaleAndEarlierPlateKanji = "舞";
 
     public enum Dimension { Achievement, Fc, Fs, DxScore }
+
+    public enum PlateScope { VersionGroup, FinaleAndEarlier }
 
     /// <summary>
     ///     阈值定义。用 ordinal value 比较：score 的对应字段 ≥ Level 即视作达标。
@@ -23,7 +25,7 @@ public static class PlateData
     public abstract record Selector(string Display)
     {
         /// <summary>版本。Versions 是 diving-fish basic_info.from 字段值集合。</summary>
-        public sealed record Plate(string Kanji, string[] Versions) : Selector(Kanji);
+        public sealed record Plate(string Kanji, string[] Versions, PlateScope Scope = PlateScope.VersionGroup) : Selector(Kanji);
 
         /// <summary>谱师。Name 与 song.Charters[i] substring 匹配。</summary>
         public sealed record Charter(string Name) : Selector(Name);
@@ -142,6 +144,57 @@ public static class PlateData
         _                     => 0,
     };
 
+    private static readonly string[] FinaleAndEarlierVersions =
+    [
+        "maimai",
+        "maimai PLUS",
+        "maimai GreeN",
+        "maimai GreeN PLUS",
+        "maimai ORANGE",
+        "maimai ORANGE PLUS",
+        "maimai PiNK",
+        "maimai PiNK PLUS",
+        "maimai MURASAKi",
+        "maimai MURASAKi PLUS",
+        "maimai MiLK",
+        "MiLK PLUS",
+        "maimai FiNALE",
+    ];
+
+    // diving-fish 只有歌曲级发布日期；这些旧版本歌曲的 Re:MASTER 是 DX 时代追加，不能计入「舞」。
+    private static readonly (long Id, string Title)[] PostDxAddedFinaleAndEarlierRemasterEntries =
+    [
+        (47,  "源平大戦絵巻テーマソング"),
+        (85,  "JACKY [Remix]"),
+        (111, "Sky High [Reborn]"),
+        (115, "DADDY MULK -Groove remix-"),
+        (131, "Link"),
+        (133, "We Gonna Party"),
+        (134, "Night Fly"),
+        (144, "air's gravity"),
+        (155, "泣き虫O'clock"),
+        (219, "記憶、記録"),
+        (239, "System “Z”"),
+        (240, "Beat of getting entangled"),
+        (248, "Backyun! －悪い女－"),
+        (252, "みんなのマイマイマー"),
+        (260, "LUCIA"),
+        (261, "Death Scythe"),
+        (328, "言ノ葉カルマ"),
+        (364, "D✪N’T  ST✪P  R✪CKIN’"),
+        (367, "Dragoon"),
+        (378, "planet dancer"),
+        (389, "FLOWER"),
+        (463, "FEEL the BEATS"),
+        (464, "Revive The Rave"),
+        (472, "アージェントシンメトリー"),
+        (629, "Limit Break"),
+        (704, "SPILL OVER COLORS"),
+    ];
+
+    private static readonly HashSet<long> PostDxAddedFinaleAndEarlierRemasterSongIds =
+        PostDxAddedFinaleAndEarlierRemasterEntries.Select(e => e.Id).ToHashSet();
+
     /// <summary>
     ///     代字 → diving-fish 版本字符串集合。
     ///     繁简体差异（暁/晓 櫻/樱 菫/堇 輝/辉 華/华 鏡/镜）双向都收录指向同一个版本集合。
@@ -152,6 +205,7 @@ public static class PlateData
     /// </summary>
     public static readonly Dictionary<string, string[]> PlateVersionMap = new()
     {
+        ["舞"] = FinaleAndEarlierVersions,
         ["真"] = ["maimai", "maimai PLUS"],
         ["超"] = ["maimai GreeN"],
         ["檄"] = ["maimai GreeN PLUS"],
@@ -183,6 +237,20 @@ public static class PlateData
         ["镜"] = ["maimai でらっくす PRiSM"],
         ["彩"] = ["maimai でらっくす PRiSM PLUS"],
     };
+
+    public static bool MatchPlate(Selector.Plate plate, MaiMaiSong song, int levelIdx)
+    {
+        if (!plate.Versions.Any(v => string.Equals(v, song.Version, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        return plate.Scope != PlateScope.FinaleAndEarlier
+               || !IsPostDxAddedFinaleAndEarlierRemaster(song.Id, levelIdx);
+    }
+
+    public static bool IsPostDxAddedFinaleAndEarlierRemaster(long songId, int levelIdx) =>
+        levelIdx == 4 && PostDxAddedFinaleAndEarlierRemasterSongIds.Contains(songId);
 
     /// <summary>diving-fish 暂未提供数据的代字（CiRCLE 的丸）。报错而非"未识别"。</summary>
     public static readonly HashSet<string> BlockedPlateKanji = ["丸"];
@@ -480,9 +548,11 @@ public static class PlateData
             return false;
         }
 
-        if (diffAt < 0 && selectors.OfType<Selector.Plate>().Any())
+        if (diffAt < 0 && selectors.OfType<Selector.Plate>().FirstOrDefault() is { } plate)
         {
-            levelIdxes = DefaultPlateLevelIdxes;
+            levelIdxes = plate.Scope == PlateScope.FinaleAndEarlier
+                ? DefaultLevelIdxes
+                : DefaultPlateLevelIdxes;
         }
         else if (diffAt < 0 && selectors.OfType<Selector.Genre>().Any(g => g.FullName == "宴会場"))
         {
@@ -507,7 +577,7 @@ public static class PlateData
         var raw = selectorPart;
         if (PlateVersionMap.TryGetValue(raw, out var versions))
         {
-            selector = new Selector.Plate(raw, versions);
+            selector = CreatePlateSelector(raw, versions);
             return true;
         }
         if (BlockedPlateKanji.Contains(raw))
@@ -522,7 +592,7 @@ public static class PlateData
             var stripped = raw[..^OptionalDaiSuffix.Length];
             if (PlateVersionMap.TryGetValue(stripped, out var versions2))
             {
-                selector = new Selector.Plate(stripped, versions2);
+                selector = CreatePlateSelector(stripped, versions2);
                 return true;
             }
             if (BlockedPlateKanji.Contains(stripped))
@@ -694,9 +764,14 @@ public static class PlateData
 
         if (bestStart < 0) return false;
         start = bestStart; length = bestLen;
-        selector = new Selector.Plate(bestKanji!, bestVersions!);
+        selector = CreatePlateSelector(bestKanji!, bestVersions!);
         return true;
     }
+
+    private static Selector.Plate CreatePlateSelector(string kanji, string[] versions) =>
+        new(kanji, versions, kanji == FinaleAndEarlierPlateKanji
+            ? PlateScope.FinaleAndEarlier
+            : PlateScope.VersionGroup);
 
     /// <summary>
     ///     找 workingPart 内"最佳"Genre alias 或全名匹配。优先级 (length DESC, rightmost) —

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -145,10 +145,11 @@ public class MaiMaiDxPlateDataTest
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // 缺省 fallback：阈值未指定时默认 SSS（"将"）；难度未指定时默认 MASTER + Re:MASTER。
+    // 缺省 fallback：阈值未指定时默认 SSS（"将"）。难度未指定时，
+    // 版本代字查询默认 MASTER；其它查询默认 MASTER + Re:MASTER。
     // ──────────────────────────────────────────────────────────────────────
 
-    [TestCase("真完成表",   "真",   12)]   // selector=Plate, default SSS + (MASTER+Re:MASTER)
+    [TestCase("真完成表",   "真",   12)]   // selector=Plate, default SSS + MASTER
     [TestCase("真代完成表", "真",   12)]   // 含可选"代"
     [TestCase("熊完成表",   "熊",   12)]
     public void DefaultsToSssWhenThresholdMissingForPlate(string raw, string kanji, int level)
@@ -159,7 +160,7 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.Achievement));
         Assert.That(q.Threshold.Level, Is.EqualTo(level));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
-        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
     }
 
     [Test]
@@ -262,9 +263,9 @@ public class MaiMaiDxPlateDataTest
         // 单字"红"不在 difficulty alias map（避免跟未来代字冲突，要写就写"红谱"或"EXPERT"）。
         // multi-selector 解析下，"真代SSS+红完成表" 剥阈值后剩"真代红"
         //   → "真代" 作 Plate(真), 单字"红"作 Charter（catch-all，handler 找不到含"红"的谱师报 0 首）。
-        // LevelIdxes 仍是默认 MASTER+Re:MASTER ([3, 4])。
+        // 含版本代字，未显式指定难度时默认 MASTER。
         var q = MustParse("真代SSS+红完成表");
-        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}), "single '红' must not be parsed as difficulty");
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}), "single '红' must not be parsed as difficulty");
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS+"));
         Assert.That(q.Selectors, Has.Exactly(2).Items);
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("真"));
@@ -426,6 +427,7 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
     }
 
     [Test]
@@ -437,6 +439,7 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Genre>().Single().FullName, Is.EqualTo("niconico & VOCALOID"));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
     }
 
     [Test]
@@ -448,6 +451,7 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Constant>().Single().Value, Is.EqualTo(14.6).Within(0.001));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
     }
 
     [Test]
@@ -479,6 +483,7 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Genre>().Single().FullName, Is.EqualTo("niconico & VOCALOID"));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
     }
 
     [TestCase("镜代13+AP完成表")]
@@ -494,6 +499,7 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -565,6 +571,15 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
     }
 
+    [Test]
+    public void PlateSelectorOverridesBanquetDefaultDifficulties()
+    {
+        var q = MustParse("宴代宴会场完成表");
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("宴"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Genre>().Single().FullName, Is.EqualTo("宴会場"));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
+    }
+
     // ──────────────────────────────────────────────────────────────────────
     // DxScore 维度 — 5 个星档 threshold（1星-5星，对应 max DX 的 85/90/93/95/97%）
     // ──────────────────────────────────────────────────────────────────────
@@ -604,13 +619,14 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("14+"));
         Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.DxScore));
         Assert.That(q.Threshold.Level, Is.EqualTo(5));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
     }
 
     [Test]
-    public void DxScoreStar_DefaultLevelIdxes()
+    public void DxScoreStar_PlateDefaultsToMaster()
     {
         var q = MustParse("镜代5星完成表");
-        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}), "DxScore 没指定难度时仍默认 MASTER+Re:MASTER");
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
     }
 
     [Test]

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Dynamic;
 using System.Linq;
 using Marisa.Plugin.Shared.MaiMaiDx;
 using NUnit.Framework;
@@ -35,6 +36,36 @@ public class MaiMaiDxPlateDataTest
         return error!;
     }
 
+    private static MaiMaiSong CreateSong(long id, string version)
+    {
+        dynamic song = new ExpandoObject();
+        song.id = id.ToString();
+        song.title = $"song-{id}";
+        song.type = "SD";
+
+        dynamic basicInfo = new ExpandoObject();
+        basicInfo.title = $"song-{id}";
+        basicInfo.artist = "artist";
+        basicInfo.genre = "genre";
+        basicInfo.bpm = 120;
+        basicInfo.release_date = "2024-01-01";
+        basicInfo.from = version;
+        basicInfo.is_new = false;
+        song.basic_info = basicInfo;
+
+        song.ds = new[] { 3.0, 7.0, 10.0, 12.0, 13.0 };
+        song.level = new[] { "3", "7", "10", "12", "13" };
+        song.charts = Enumerable.Range(0, 5).Select(_ =>
+        {
+            dynamic chart = new ExpandoObject();
+            chart.notes = new long[] { 100, 10, 10, 0 };
+            chart.charter = "-";
+            return chart;
+        }).ToArray();
+
+        return new MaiMaiSong(song);
+    }
+
     [TestCase("真大将完成表",   "真",        13)]
     [TestCase("真将完成表",     "真",        12)]
     [TestCase("真代SSS+完成表", "真",        13)]
@@ -65,6 +96,32 @@ public class MaiMaiDxPlateDataTest
         var query = MustParse(raw);
         var plate = (PlateData.Selector.Plate)query.Selectors.Single();
         Assert.That(plate.Versions, Is.EquivalentTo(expected));
+    }
+
+    [Test]
+    public void FinaleAndEarlierPlateMapsToOldVersions()
+    {
+        var query = MustParse("舞将完成表");
+        var plate = query.Selectors.OfType<PlateData.Selector.Plate>().Single();
+
+        Assert.That(plate.Kanji, Is.EqualTo("舞"));
+        Assert.That(plate.Scope, Is.EqualTo(PlateData.PlateScope.FinaleAndEarlier));
+        Assert.That(plate.Versions, Is.EqualTo(new[]
+        {
+            "maimai",
+            "maimai PLUS",
+            "maimai GreeN",
+            "maimai GreeN PLUS",
+            "maimai ORANGE",
+            "maimai ORANGE PLUS",
+            "maimai PiNK",
+            "maimai PiNK PLUS",
+            "maimai MURASAKi",
+            "maimai MURASAKi PLUS",
+            "maimai MiLK",
+            "MiLK PLUS",
+            "maimai FiNALE",
+        }));
     }
 
     [TestCase("翠楼屋将完成表",     "翠楼屋", 12)]
@@ -161,6 +218,56 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Threshold.Level, Is.EqualTo(level));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
+    }
+
+    [TestCase("舞完成表")]
+    [TestCase("舞代完成表")]
+    public void FinaleAndEarlierPlateDefaultsToMasterRemaster(string raw)
+    {
+        var q = MustParse(raw);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Scope,
+            Is.EqualTo(PlateData.PlateScope.FinaleAndEarlier));
+        Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
+    }
+
+    [Test]
+    public void FinaleAndEarlierPlateExplicitDifficultyKept()
+    {
+        var q = MustParse("舞红谱完成表");
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {2}));
+    }
+
+    [TestCase(144, "maimai PLUS")]  // air's gravity
+    [TestCase(240, "maimai GreeN")] // Beat of getting entangled
+    [TestCase(261, "maimai GreeN")] // Death Scythe
+    public void FinaleAndEarlierPlateExcludesPostDxAddedRemaster(long songId, string version)
+    {
+        var plate = MustParse("舞完成表").Selectors.OfType<PlateData.Selector.Plate>().Single();
+        var song = CreateSong(songId, version);
+
+        Assert.That(PlateData.MatchPlate(plate, song, 4), Is.False);
+        Assert.That(PlateData.MatchPlate(plate, song, 3), Is.True);
+    }
+
+    [TestCase(146, "maimai PLUS")]   // 39
+    [TestCase(731, "MiLK PLUS")]     // 妄想感傷代償連盟
+    [TestCase(792, "maimai FiNALE")] // ヒバナ
+    public void FinaleAndEarlierPlateKeepsPreDxRemaster(long songId, string version)
+    {
+        var plate = MustParse("舞完成表").Selectors.OfType<PlateData.Selector.Plate>().Single();
+        var song = CreateSong(songId, version);
+
+        Assert.That(PlateData.MatchPlate(plate, song, 4), Is.True);
+    }
+
+    [Test]
+    public void NormalVersionPlateDoesNotApplyFinaleAndEarlierRemasterExclusion()
+    {
+        var plate = MustParse("真完成表").Selectors.OfType<PlateData.Selector.Plate>().Single();
+        var song = CreateSong(144, "maimai PLUS");
+
+        Assert.That(PlateData.MatchPlate(plate, song, 4), Is.True);
     }
 
     [Test]

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -241,7 +241,8 @@ public class MaiMaiDxPlateDataTest
     [TestCase(144, "maimai PLUS")]  // air's gravity
     [TestCase(240, "maimai GreeN")] // Beat of getting entangled
     [TestCase(261, "maimai GreeN")] // Death Scythe
-    public void FinaleAndEarlierPlateExcludesPostDxAddedRemaster(long songId, string version)
+    [TestCase(108, "maimai PLUS")]  // YA･DA･YO [Reborn]
+    public void FinaleAndEarlierPlateExcludesRemasterOutsideWhitelist(long songId, string version)
     {
         var plate = MustParse("舞完成表").Selectors.OfType<PlateData.Selector.Plate>().Single();
         var song = CreateSong(songId, version);
@@ -253,7 +254,7 @@ public class MaiMaiDxPlateDataTest
     [TestCase(146, "maimai PLUS")]   // 39
     [TestCase(731, "MiLK PLUS")]     // 妄想感傷代償連盟
     [TestCase(792, "maimai FiNALE")] // ヒバナ
-    public void FinaleAndEarlierPlateKeepsPreDxRemaster(long songId, string version)
+    public void FinaleAndEarlierPlateKeepsWhitelistedRemaster(long songId, string version)
     {
         var plate = MustParse("舞完成表").Selectors.OfType<PlateData.Selector.Plate>().Single();
         var song = CreateSong(songId, version);

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -999,42 +999,41 @@ public partial class MaiMaiDx
     }
 
     private const string PlateUsage =
-        "查询某个版本 / 谱师 / 类别 / 作曲家 / 难度 / 定数的完成情况，比如 mai 真大将完成表\n" +
+        "完成表用于查看指定范围内，还有哪些谱面没有达到目标成绩。\n" +
         "\n" +
-        "完整格式：mai (对象)(成绩)[难度]完成表\n" +
+        "用法：mai <范围><目标成绩><难度>完成表\n" +
+        "范围、目标成绩、难度的顺序不固定。\n" +
         "\n" +
-        "(对象) — 必填，下面六类中至少给 1 个；也可以同时给多个，要求歌曲全部满足才入选：\n" +
-        "  · 版本代字：真 / 超 / 橙 / 暁 / 熊 / 華 / 鏡 / 彩 …（后面加 '代' 也行，例如 熊代）\n" +
-        "  · 谱师名：例如 翠楼屋（合作谱 'サファ太 vs 翠楼屋' 也算上）\n" +
+        "范围必须填写，可以组合多个条件；组合时只保留同时满足所有条件的谱面。\n" +
+        "  · 版本代字：舞 / 真 / 超 / 橙 / 暁 / 熊 / 華 / 鏡 / 彩 等，可加“代”，如 熊代\n" +
+        "    舞表示 maimai 到 maimai FiNALE；DX 时代给旧曲追加的 Re:MASTER 不计入舞。\n" +
+        "  · 谱师：例如 翠楼屋。合作名义也会匹配，如 サファ太 vs 翠楼屋\n" +
         "  · 类别：术力口 / V家 / 东方 / 击中 / 流行 / 动漫 / 其他 / 宴会场 / 舞萌\n" +
-        "  · 作曲家：例如 HIMEHINA、DECO*27（合作名义 'sasakure.UK x DECO*27' 也算上）\n" +
-        "  · 难度 label：13 / 13+ / 14 / 14+ 等（游戏内显示难度）\n" +
-        "  · 定数：13.5 / 14.7 等（必含小数点，1 位小数）\n" +
-        "  注：同一类不能给两个（如 '镜代真'/'13+15'/'13+14.6' 会冲突报错）\n" +
+        "  · 作曲家：例如 HIMEHINA、DECO*27。合作名义也会匹配\n" +
+        "  · 难度等级：13 / 13+ / 14 / 14+ 等\n" +
+        "  · 定数：13.5 / 14.7 等，必须写 1 位小数\n" +
         "\n" +
-        "(成绩) — 不写就是 '将'（SSS）\n" +
+        "目标成绩不写时按 将（SSS）计算。\n" +
         "  · 将=SSS / 大将=SSS+\n" +
         "  · 神=AP / 理论值=AP+ / 极=FC\n" +
-        "  · 舞舞=FDX\n" +
-        "  · 也可以直接写 SSS+ / SS / FC+ / AP+ / FDX+ 等\n" +
-        "  · DX 分星档：一星~五星（或 1星~5星），对应 max DX 的 85/90/93/95/97%\n" +
+        "  · 舞舞=FDX，也可以直接写 SSS+ / SS / FC+ / AP+ / FDX+ 等\n" +
+        "  · DX 分星档：一星到五星，或 1星到5星\n" +
         "\n" +
-        "[难度] — 不写就是紫谱 + 白谱（MASTER + Re:MASTER）\n" +
-        "  · 绿谱 / 黄谱 / 红谱 / 紫谱 / 白谱（白谱 = Re:MASTER）\n" +
+        "难度不写时，普通版本代字默认只查紫谱；舞和其他范围默认查紫谱 + 白谱。\n" +
+        "只查宴会场时默认查全难度。可以显式指定：\n" +
+        "  · 绿谱 / 黄谱 / 红谱 / 紫谱 / 白谱\n" +
         "  · 或英文缩写 BSC / ADV / EXP / MST\n" +
         "\n" +
-        "其他例子（字段顺序可以随便换）：\n" +
-        "  mai 真完成表             ← 阈值省略，默认 '将'\n" +
+        "示例：\n" +
+        "  mai 真完成表\n" +
+        "  mai 舞将完成表\n" +
         "  mai 翠楼屋将完成表\n" +
         "  mai HIMEHINA神完成表\n" +
-        "  mai 14+大将完成表        ← 难度 label\n" +
-        "  mai 13.5神完成表         ← 定数\n" +
-        "  mai 紫谱将真完成表       ← 字段顺序随便换\n" +
-        "  mai 镜代13+AP完成表      ← 版本 + 难度 组合\n" +
-        "  mai 镜代V家将完成表      ← 版本 + 类别 组合\n" +
-        "  mai 14+翠楼屋将完成表    ← 难度 + 谱师 组合\n" +
-        "  mai 镜代5星完成表        ← DX 分 5★ 完成情况\n" +
-        "  mai 14+四星完成表        ← Lv14+ 全谱拿到 4★ 的情况";
+        "  mai 14+大将完成表\n" +
+        "  mai 13.5神完成表\n" +
+        "  mai 紫谱将真完成表\n" +
+        "  mai 镜代V家将完成表\n" +
+        "  mai 14+四星完成表";
 
     public static MarisaPluginTrigger.PluginTrigger PlateTrigger => (message, _) =>
         message.Command.EndsWith(PlateData.CommandSuffix);
@@ -1096,7 +1095,7 @@ public partial class MaiMaiDx
 
         List<(double Constant, int LevelIdx, MaiMaiSong Song)> SelectCharts(PlateData.Query q)
         {
-            // 完成表默认 MASTER + Re:MASTER；用户显式给难度（红谱/EXPERT/...）则单元素 list 限定。
+            // 默认难度由解析层决定；用户显式给难度（红谱/EXPERT/...）则单元素 list 限定。
             var levelIdxes = q.LevelIdxes;
             return SongDb.SongList
                 .SelectMany(song => song.Constants.Select((constant, i) => (constant, i, song)))
@@ -1109,8 +1108,7 @@ public partial class MaiMaiDx
         // 单 chart × 单 selector 的命中判断；handler 用 Selectors.All(...) 求 AND 交集。
         static bool MatchSelector(PlateData.Selector sel, double constant, int levelIdx, MaiMaiSong song) => sel switch
         {
-            PlateData.Selector.Plate p =>
-                p.Versions.Any(v => string.Equals(v, song.Version, StringComparison.OrdinalIgnoreCase)),
+            PlateData.Selector.Plate p => PlateData.MatchPlate(p, song, levelIdx),
 
             // substring 匹配：兼容 "サファ太 vs 翠楼屋" 这种合作谱师名义。
             PlateData.Selector.Charter c =>


### PR DESCRIPTION
## 背景

完成表在 PR #37 中引入了版本代字、谱师、类别、作曲家、等级、定数等选择条件。后续发现两个和版本代字相关的行为需要调整：

- 普通版本代字查询时，用户通常是在查某一代的正式 plate 进度，因此默认难度应只看 MASTER，而不是 MASTER + Re:MASTER。
- 版本代字列表缺少「舞」。这里的「舞」表示 maimai 到 maimai FiNALE 的旧框体范围，但不应包含 DX 时代才追加到旧曲上的 Re:MASTER 谱面。

## 变更内容

- 调整完成表默认难度逻辑：
  - 含普通版本代字时，未显式指定难度默认只查 MASTER。
  - 谱师、类别、作曲家、等级、定数等非普通版本范围，未显式指定难度仍默认查 MASTER + Re:MASTER。
  - 「舞」作为跨旧框体范围，未显式指定难度默认查 MASTER + Re:MASTER。
  - 用户显式指定红谱、紫谱、白谱等难度时，始终以用户指定为准。

- 新增「舞」版本代字：
  - 覆盖 `maimai` 到 `maimai FiNALE` 的版本范围。
  - BASIC 到 MASTER 直接按旧版本范围计入。
  - Re:MASTER 使用「计入舞的旧白谱」白名单；不在白名单内的旧版本 Re:MASTER 默认不计入舞。
  - 这样后续如果数据源新增 DX 时代追加到旧曲的白谱，例如日服已追加但国服尚未追加的 `YA･DA･YO [Reborn]`，不会因为歌曲版本属于旧框体而被自动计入舞。

- 重写完成表帮助文案：
  - 用中文说明范围、目标成绩、难度三部分的规则。
  - 明确普通版本代字、「舞」、宴会场、非版本范围的默认难度差异。
  - 保留常用示例，减少模板化表述。

- 补充完成表解析与匹配测试：
  - 覆盖普通版本代字默认 MASTER。
  - 覆盖「舞」默认 MASTER + Re:MASTER。
  - 覆盖「舞代」后缀解析。
  - 覆盖 `air's gravity`、`Beat of getting entangled`、`Death Scythe`、`YA･DA･YO [Reborn]` 等不在白名单内的 Re:MASTER 不计入舞。
  - 覆盖 `39`、`妄想感傷代償連盟`、`ヒバナ` 等白名单内 Re:MASTER 仍计入舞。

## 验证

- `dotnet test Marisa.Plugin.Test/Marisa.Plugin.Test.csproj --no-restore --filter MaiMaiDxPlateDataTest`

本 PR 由 GPT-5.5 xhigh 编写。