### PR TITLE
fix(maimai): 完成表排除国服复活曲（复活曲不计入版本姓名框）

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -162,6 +162,7 @@ public static class PlateData
     ];
 
     // diving-fish 只有歌曲级发布日期；「舞」的 Re:MASTER 采用白名单，避免后续 DX 时代追加旧曲白谱时自动误计入。
+    // 注：原列入的 39(146)/妄想感傷代償連盟(731)/ヒバナ(792) 是复活曲，已移至 RevivalSongEntries 整曲排除。
     private static readonly (long Id, string Title)[] FinaleAndEarlierRemasterEntries =
     [
         (17,  "Future"),
@@ -181,7 +182,6 @@ public static class PlateData
         (107, "ロミオとシンデレラ"),
         (143, "Fragrance"),
         (145, "Starlight Disco"),
-        (146, "39"),
         (198, "カゲロウデイズ"),
         (200, "Bad Apple!! feat nomico"),
         (204, "ナイト・オブ・ナイツ"),
@@ -205,13 +205,11 @@ public static class PlateData
         (513, "だんだん早くなる"),
         (532, "洗脳"),
         (589, "Panopticon"),
-        (731, "妄想感傷代償連盟"),
         (741, "インビジブル"),
         (756, "CYBER Sparks"),
         (759, "サドマミホリック"),
         (763, "はやくそれになりたい！"),
         (777, "花と、雪と、ドラムンベース。"),
-        (792, "ヒバナ"),
         (793, "ロキ"),
         (799, "QZKago Requiem"),
         (803, "Schwarzschild"),
@@ -230,6 +228,41 @@ public static class PlateData
 
     private static readonly HashSet<long> FinaleAndEarlierRemasterSongIds =
         FinaleAndEarlierRemasterEntries.Select(e => e.Id).ToHashSet();
+
+    /// <summary>
+    ///     复活曲：曾从国服删除、后又重新上线的歌。游戏不会把复活曲重新计入版本完成牌（姓名框），
+    ///     完成表同样整曲排除（所有难度，含「舞」）。来源：RemyWiki 舞萌DX 各版本(China)「Revived Songs」段
+    ///     ∩ diving-fish 现役曲库。仅收录在国服「删除→复活」过的；「首发缺席→后补」类（おこちゃま戦争 382 /
+    ///     拝啓ドッペルゲンガー 711）按难度档表现不一致，暂不收录。
+    /// </summary>
+    private static readonly (long Id, string Title)[] RevivalSongEntries =
+    [
+        (44,    "ハッピーシンセサイザ"),
+        (146,   "39"),
+        (185,   "＊ハロー、プラネット。"),
+        (189,   "弱虫モンブラン"),
+        (201,   "魔理沙は大変なものを盗んでいきました"),
+        (281,   "ダブルラリアット"),
+        (341,   "二息歩行"),
+        (419,   "ストリーミングハート"),
+        (451,   "頓珍漢の宴"),
+        (455,   "Counselor"),
+        (460,   "閃鋼のブリューナク"),
+        (524,   "Hand in Hand"),
+        (687,   "共感覚おばけ"),
+        (688,   "麒麟"),
+        (712,   "ミラクル・ショッピング"),
+        (731,   "妄想感傷代償連盟"),
+        (792,   "ヒバナ"),
+        (853,   "前前前世"),
+        (10146, "39"),
+        (11213, "Arty Party"),
+        (11253, "おジャ魔女カーニバル!!"),
+        (11267, "ディカディズム"),
+    ];
+
+    private static readonly HashSet<long> RevivalSongIds =
+        RevivalSongEntries.Select(e => e.Id).ToHashSet();
 
     /// <summary>
     ///     代字 → diving-fish 版本字符串集合。
@@ -277,6 +310,12 @@ public static class PlateData
     public static bool MatchPlate(Selector.Plate plate, MaiMaiSong song, int levelIdx)
     {
         if (!plate.Versions.Any(v => string.Equals(v, song.Version, StringComparison.OrdinalIgnoreCase)))
+        {
+            return false;
+        }
+
+        // 复活曲不计入任何版本完成牌（含「舞」），整曲排除。
+        if (RevivalSongIds.Contains(song.Id))
         {
             return false;
         }

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -251,9 +251,9 @@ public class MaiMaiDxPlateDataTest
         Assert.That(PlateData.MatchPlate(plate, song, 3), Is.True);
     }
 
-    [TestCase(146, "maimai PLUS")]   // 39
-    [TestCase(731, "MiLK PLUS")]     // 妄想感傷代償連盟
-    [TestCase(792, "maimai FiNALE")] // ヒバナ
+    [TestCase(17,  "maimai")]        // Future
+    [TestCase(204, "maimai GreeN")]  // ナイト・オブ・ナイツ
+    [TestCase(838, "maimai FiNALE")] // 最終鬼畜妹フランドール・S
     public void FinaleAndEarlierPlateKeepsWhitelistedRemaster(long songId, string version)
     {
         var plate = MustParse("舞完成表").Selectors.OfType<PlateData.Selector.Plate>().Single();
@@ -269,6 +269,44 @@ public class MaiMaiDxPlateDataTest
         var song = CreateSong(144, "maimai PLUS");
 
         Assert.That(PlateData.MatchPlate(plate, song, 4), Is.True);
+    }
+
+    // 复活曲：国服删后复活的歌不计入任何版本完成牌（所有难度，含「舞」）。
+    [TestCase("白", 688,   "maimai MiLK")]      // 麒麟
+    [TestCase("真", 146,   "maimai PLUS")]      // 39
+    [TestCase("熊", 10146, "maimai でらっくす")]  // 39（DX 谱）
+    [TestCase("菫", 853,   "maimai MURASAKi PLUS")] // 前前前世
+    public void RevivalSongExcludedFromItsVersionPlate(string plateKanji, long songId, string version)
+    {
+        var plate = MustParse($"{plateKanji}完成表").Selectors.OfType<PlateData.Selector.Plate>().Single();
+        var song = CreateSong(songId, version);
+
+        Assert.That(PlateData.MatchPlate(plate, song, 3), Is.False);
+        Assert.That(PlateData.MatchPlate(plate, song, 0), Is.False);
+    }
+
+    // 复活曲在「舞」牌同样整曲排除——含原本在 Re:MASTER 白名单里的 ヒバナ/妄想感傷代償連盟。
+    [TestCase(792, "maimai FiNALE")] // ヒバナ
+    [TestCase(731, "MiLK PLUS")]     // 妄想感傷代償連盟
+    [TestCase(688, "maimai MiLK")]   // 麒麟
+    public void RevivalSongExcludedFromFinaleAndEarlierPlate(long songId, string version)
+    {
+        var plate = MustParse("舞完成表").Selectors.OfType<PlateData.Selector.Plate>().Single();
+        var song = CreateSong(songId, version);
+
+        Assert.That(PlateData.MatchPlate(plate, song, 3), Is.False);
+        Assert.That(PlateData.MatchPlate(plate, song, 4), Is.False);
+    }
+
+    // 「首发缺席→后补」类（按难度档表现不一致）暂不收录，仍计入对应版本牌。
+    [TestCase("橙", 382, "maimai ORANGE")] // おこちゃま戦争
+    [TestCase("白", 711, "maimai MiLK")]   // 拝啓ドッペルゲンガー
+    public void LaunchAbsentSongStillCountsForPlate(string plateKanji, long songId, string version)
+    {
+        var plate = MustParse($"{plateKanji}完成表").Selectors.OfType<PlateData.Selector.Plate>().Single();
+        var song = CreateSong(songId, version);
+
+        Assert.That(PlateData.MatchPlate(plate, song, 3), Is.True);
     }
 
     [Test]


### PR DESCRIPTION
## 背景

PR #37 引入 `mai 完成表` 命令时，在「不在本次范围」中搁置了**复活曲**：diving-fish 只给现役曲库，无法识别「曾删除、后复活」的歌。

国服（舞萌DX）会因版权等原因将歌曲移除游戏，并同时将其移出对应版本姓名框（牌子，如 真极 / 白将 / 舞舞舞）的要求曲目。部分削除曲版权恢复后重新上线（**复活曲**），但游戏**不会**把它们重新计入牌子要求（不能要求已点亮牌子的人重打）。完成表此前直接按 diving-fish 现役曲库计入，会把这些复活曲多算进牌子分母，让玩家被要求打实际不需要的歌。

## 变更内容

- `PlateData` 新增 `RevivalSongEntries`（22 首 `(Id, Title)`）+ `RevivalSongIds`；`MatchPlate` 在版本匹配后命中即**整曲排除**（所有难度，含「舞」）。`MatchPlate` 是 handler 选谱的唯一入口，分子分母同时排除，完成率正确。
- 从「舞」Re:MASTER 白名单 `FinaleAndEarlierRemasterEntries` 移除 `39(146)` / `妄想感傷代償連盟(731)` / `ヒバナ(792)`——这三首是复活曲，连「舞」也不计入，原先（#63）把它们计入「舞」并不正确。
- 测试：新增复活曲排除（版本牌 /「舞」牌，含原白名单的 ヒバナ・妄想）与「382/711 仍计入」用例；`FinaleAndEarlierPlateKeepsWhitelistedRemaster` 改用非复活白名单曲（Future / ナイト・オブ・ナイツ / 最終鬼畜妹フランドール・S）。

## 排除名单（22 首）

| 牌子 | 曲（id） |
|---|---|
| 真 | ハッピーシンセサイザ(44)、39(146) |
| 超 | ＊ハロー、プラネット。(185)、弱虫モンブラン(189)、魔理沙は大変なものを盗んでいきました(201) |
| 檄 | 二息歩行(341) |
| 橙 | ダブルラリアット(281) |
| 暁 | ストリーミングハート(419) |
| 桃 | 頓珍漢の宴(451)、Counselor(455)、閃鋼のブリューナク(460) |
| 櫻 | Hand in Hand(524) |
| 菫 | 前前前世(853) |
| 白 | 共感覚おばけ(687)、麒麟(688)、ミラクル・ショッピング(712) |
| 雪 | 妄想感傷代償連盟(731) |
| 輝 | ヒバナ(792) |
| 熊/華 | 39 DX 谱(10146) |
| 爽/煌 | Arty Party(11213) |
| 宙/星 | おジャ魔女カーニバル!!(11253)、ディカディズム(11267) |

## 数据来源

RemyWiki 舞萌DX 各版本(China) 页的 `Revived Songs` / `Previously removed songs` 段 ∩ diving-fish 国服现役曲库交叉核实。RemyWiki `maimai DX:2022 (China)` 页明确注记：2021 删除、2022 复活的曲目「不计入 檄 / 櫻 / 輝 / 舞 姓名框」，即本 PR 依据。

## 不在本次范围

- **「上线即缺席→后补」类**（おこちゃま戦争 382 / 拝啓ドッペルゲンガー 711）：从未在国服删除过、仅首发缺席后补回。社区反馈这类按难度档表现不一致（极/将/神不计入、舞舞计入），无法用整曲排除建模，故保持原计入——多列一首属轻错，避免误报「已满」的重错。
- 完整性以 RemyWiki 收录为准；100% 核对需游戏内牌子分母实测。

## 验证

`dotnet test Marisa.Plugin.Test/Marisa.Plugin.Test.csproj --filter MaiMaiDxPlateDataTest` —— 187 全通过。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
