### PR TITLE
refactor(chunithm): 版本拆分统一用 ChunithmVersion

### DIFF
--- a/Marisa.Plugin.Shared/Chunithm/ChunithmVersion.cs
+++ b/Marisa.Plugin.Shared/Chunithm/ChunithmVersion.cs
@@ -1,0 +1,44 @@
+namespace Marisa.Plugin.Shared.Chunithm;
+
+/// <summary>
+///     国服中二节奏版本的有序编号（来自 lxns 权威版本表，DX 时代从 20000 起）。
+///     版本名是带空格的字符串，故用「名字 → 编号」表而非 enum；用编号比较替代散落各 fetcher 的
+///     硬编码「最新版本名集合」和按版本名字典序排序取最新的脆弱写法。
+/// </summary>
+public static class ChunithmVersion
+{
+    public static readonly IReadOnlyDictionary<string, int> NameToCode = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+    {
+        ["CHUNITHM"]               = 10000,
+        ["CHUNITHM PLUS"]          = 10500,
+        ["CHUNITHM AIR"]           = 11000,
+        ["CHUNITHM AIR PLUS"]      = 11500,
+        ["CHUNITHM STAR"]          = 12000,
+        ["CHUNITHM STAR PLUS"]     = 12500,
+        ["CHUNITHM AMAZON"]        = 13000,
+        ["CHUNITHM AMAZON PLUS"]   = 13500,
+        ["CHUNITHM CRYSTAL"]       = 14000,
+        ["CHUNITHM CRYSTAL PLUS"]  = 14500,
+        ["CHUNITHM PARADISE"]      = 15000,
+        ["CHUNITHM PARADISE LOST"] = 15500,
+        ["CHUNITHM NEW"]           = 20000,
+        ["CHUNITHM NEW PLUS"]      = 20500,
+        ["CHUNITHM SUN"]           = 21000,
+        ["CHUNITHM SUN PLUS"]      = 21500,
+        ["CHUNITHM LUMINOUS"]      = 22000,
+        ["CHUNITHM LUMINOUS PLUS"] = 22500,
+        ["CHUNITHM VERSE"]         = 23000,
+    };
+
+    /// <summary>
+    ///     「当前版本」下限：该版本及更新的算「新版本」（b30/recent 拆分用）。
+    ///     国服当前版本（中二节奏 2026）涵盖国际版 LUMINOUS PLUS + VERSE 两版，故取 LUMINOUS PLUS。
+    /// </summary>
+    public const int CurrentVersionCode = 22500;
+
+    public static int CodeOf(string? versionName) =>
+        versionName != null && NameToCode.TryGetValue(versionName, out var code) ? code : 0;
+
+    /// <summary>版本名是否属于「当前版本」（用于把成绩分到 recent 而非 best 池）。</summary>
+    public static bool IsCurrent(string? versionName) => CodeOf(versionName) >= CurrentVersionCode;
+}

--- a/Marisa.Plugin.Shared/Chunithm/DataFetcher/AllNetBasedNetDataFetcher.cs
+++ b/Marisa.Plugin.Shared/Chunithm/DataFetcher/AllNetBasedNetDataFetcher.cs
@@ -24,15 +24,9 @@ public class AllNetBasedNetDataFetcher(SongDb<ChunithmSong> songDb, string short
         var songList = GetSongList();
         var versionMap = songList.ToDictionary(s => s.Id, s => s.Version);
 
-        var newest = songList
-            .Select(s => s.Version)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderDescending(StringComparer.OrdinalIgnoreCase)
-            .Take(1)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
-
+        // 统一用 ChunithmVersion.IsCurrent（与 divingfish/Louis 一致），替代原先按版本名字典序取最新一版的脆弱写法。
         var div = scores.Values
-            .GroupBy(x => newest.Contains(versionMap.GetValueOrDefault(x.Id, "")))
+            .GroupBy(x => ChunithmVersion.IsCurrent(versionMap.GetValueOrDefault(x.Id)))
             .ToList();
 
         var userData = await (await $"{ServerUri}ChuniServlet/GetUserDataApi".PostJsonAsync(new

--- a/Marisa.Plugin.Shared/Chunithm/DataFetcher/DivingFishDataFetcher.cs
+++ b/Marisa.Plugin.Shared/Chunithm/DataFetcher/DivingFishDataFetcher.cs
@@ -26,13 +26,8 @@ public class DivingFishDataFetcher(SongDb<ChunithmSong> songDb) : DataFetcher(so
         var songList = GetSongList();
         var versionMap = songList.ToDictionary(s => s.Id, s => s.Version);
 
-        var newest = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "CHUNITHM LUMINOUS PLUS", "CHUNITHM VERSE"
-        };
-
         var div = allScores
-            .GroupBy(x => newest.Contains(versionMap.GetValueOrDefault(x.Id, "")))
+            .GroupBy(x => ChunithmVersion.IsCurrent(versionMap.GetValueOrDefault(x.Id)))
             .ToList();
 
         return new ChunithmRating

--- a/Marisa.Plugin.Shared/Chunithm/DataFetcher/LouisDataFetcher.cs
+++ b/Marisa.Plugin.Shared/Chunithm/DataFetcher/LouisDataFetcher.cs
@@ -51,13 +51,8 @@ public class LouisDataFetcher(SongDb<ChunithmSong> songDb) : DataFetcher(songDb)
         var songList = GetSongList();
         var versionMap = songList.ToDictionary(s => s.Id, s => s.Version);
 
-        var newest = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-        {
-            "CHUNITHM LUMINOUS PLUS", "CHUNITHM VERSE"
-        };
-
         var div = scores.Values
-            .GroupBy(x => newest.Contains(versionMap.GetValueOrDefault(x.Id, "")))
+            .GroupBy(x => ChunithmVersion.IsCurrent(versionMap.GetValueOrDefault(x.Id)))
             .ToList();
 
         return new ChunithmRating

--- a/Marisa.Plugin.Test/ChunithmVersionTest.cs
+++ b/Marisa.Plugin.Test/ChunithmVersionTest.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Marisa.Plugin.Shared.Chunithm;
+using NUnit.Framework;
+
+namespace Marisa.Plugin.Test;
+
+public class ChunithmVersionTest
+{
+    [TestCase("CHUNITHM VERSE", true)]
+    [TestCase("CHUNITHM LUMINOUS PLUS", true)]    // 国服当前版本(2026)涵盖 LUMINOUS PLUS + VERSE 两版
+    [TestCase("CHUNITHM LUMINOUS", false)]
+    [TestCase("CHUNITHM SUN PLUS", false)]
+    [TestCase("CHUNITHM NEW", false)]
+    [TestCase("CHUNITHM", false)]
+    [TestCase("unknown version", false)]
+    [TestCase(null, false)]
+    public void IsCurrent_Boundaries(string? name, bool expected)
+    {
+        Assert.That(ChunithmVersion.IsCurrent(name), Is.EqualTo(expected));
+    }
+
+    // 当前版本涵盖 LUMINOUS PLUS 与 VERSE 两版（国服中二节奏 2026）。
+    [Test]
+    public void CurrentSpansLuminousPlusAndVerse()
+    {
+        var current = new HashSet<string> { "CHUNITHM LUMINOUS PLUS", "CHUNITHM VERSE" };
+        foreach (var name in ChunithmVersion.NameToCode.Keys)
+        {
+            Assert.That(ChunithmVersion.IsCurrent(name), Is.EqualTo(current.Contains(name)), $"mismatch for {name}");
+        }
+    }
+}


### PR DESCRIPTION
## 背景

chunithm 的 rating 展示分两段：**Best 30**（全版本最佳）+ **New 20**（当前版本「新曲」最佳，与 lxns 的 `new_bests` 对齐）。判断一首歌算不算「当前版本新曲」，原本在三个数据源 fetcher 里各自用一套实现，互不一致：

| Fetcher | 原本怎么判「当前版本」 | 实际取到的版本集 |
|---|---|---|
| `DivingFishDataFetcher` | 硬编码 `{"CHUNITHM LUMINOUS PLUS", "CHUNITHM VERSE"}` | 两版 |
| `LouisDataFetcher` | 同上硬编码 | 两版 |
| `AllNetBasedNetDataFetcher` | 按版本名**字典序**降序 `.Take(1)` | **一版**（`{VERSE}`） |

问题：

- 三处重复，新版本上线要改三个地方，易漏改、易漂移。
- AllNet 那处靠 "VERSE" 恰好字典序排在最后才「碰巧」正确，且只取一版，与另两者（两版）**结果不一致**——同一玩家在 AllNet 源与水鱼源下，New 20 的取曲范围会不同。

## 为什么「当前版本」是两个国际版本

国服当前版本 **中二节奏 2026**（2025-09-16 上线）在国际版谱面上**横跨 CHUNITHM LUMINOUS PLUS 与 VERSE 两个版本**：据 [RemyWiki](https://silentblue.remywiki.com/CHUNITHM:2026_%28China%29)，2026 机制基于 VERSE，曲目从 LUMINOUS ep.IV（上线日）一路追加到 VERSE 曲（2026-03 起）。所以国服「当前版本新曲」= 国际版 LUMINOUS PLUS + VERSE 两版的曲目——这也是 divingfish/Louis 原本就硬编码两版的原因，AllNet 取一版是 bug。

## 变更

新建 `Marisa.Plugin.Shared/Chunithm/ChunithmVersion.cs`：

- `NameToCode`：版本名 → 有序编号，取自 lxns 权威版本表（`CHUNITHM`=10000 … `LUMINOUS`=22000、`LUMINOUS PLUS`=22500、`VERSE`=23000）。
- `CurrentVersionCode = 22500`（LUMINOUS PLUS）：`code >= 22500` 即 `{LUMINOUS PLUS, VERSE}`，与国服 2026 一致。
- `IsCurrent(name)`：是否属当前版本。

`DivingFishDataFetcher` / `LouisDataFetcher` / `AllNetBasedNetDataFetcher` 三处 b30/recent 拆分统一改用 `ChunithmVersion.IsCurrent`，删掉各自的硬编码集合与 AllNet 的字典序排序。

### 行为影响

| Fetcher | 改前 | 改后 |
|---|---|---|
| DivingFish / Louis | `{LUMINOUS PLUS, VERSE}` | 不变（仍两版，本就正确） |
| AllNet | `{VERSE}`（一版） | **修正为 `{LUMINOUS PLUS, VERSE}`**，与另两者一致 |

即：对原本正确的源是**纯重构**，对 AllNet 是顺带的**一致性修复**；不改变正确源的行为。

> 维护：下次国服版本更新（收录到下一国际版本时），只需把 `CurrentVersionCode` 调到新的下限**一处**，不再需要改三个 fetcher。

## 验证

```
dotnet test Marisa.Plugin.Test/Marisa.Plugin.Test.csproj --filter "FullyQualifiedName~ChunithmVersionTest"
```

`ChunithmVersionTest` 9/9 通过：

- 边界值：VERSE / LUMINOUS PLUS = 新版本；LUMINOUS 及更早 = 旧版本；未知版本名 / null = 旧版本。
- 全集断言：对版本表所有 19 个版本，`IsCurrent` 恰好等于 `{LUMINOUS PLUS, VERSE}`。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
