### PR TITLE
feat(maimai): 完成表谱师中文别名 + 标题字号自适应

### DIFF
--- a/Marisa.Frontend/src/assets/css/maimai/summary.pcss
+++ b/Marisa.Frontend/src/assets/css/maimai/summary.pcss
@@ -39,7 +39,7 @@
 }
 
 .title {
-    /* font-size 由 JS computed titleFontSize 按字符数自适应 */
+    /* font-size 由 JS 真实测宽 auto-shrink（titleSize）控制 */
     font-weight: bold;
     line-height: 1.2;          /* 1 太紧，配合 overflow:hidden 会把 CJK descender 切掉 */
     flex: 1 1 auto;

--- a/Marisa.Frontend/src/components/maimai/Summary.vue
+++ b/Marisa.Frontend/src/components/maimai/Summary.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import {useRoute} from 'vue-router'
-import {ref, computed} from 'vue'
+import {ref, computed, nextTick, watch} from 'vue'
 import axios from 'axios'
 import {context_get} from '@/GlobalVars'
 import type {GroupedSong, Score, PlateInfo} from '@/components/maimai/utils/summary_t'
@@ -40,16 +40,30 @@ axios.all([
 
 const allCharts = computed(() => grouped.value.flatMap(g => g.x))
 
-// 标题字号按字符数自适应 — 防止长标题被 stats-bar 挤出而截断
-// title-row 总宽 1250px (grid 1240 + border-overflow 10) - stats-bar 720px - gap 30px = 500px 给 title
-const titleFontSize = computed(() => {
-    const n = title.value?.length ?? 0
-    if (n <= 5)  return '72px'   // 5×72=360
-    if (n <= 7)  return '60px'   // 7×60=420
-    if (n <= 9)  return '50px'   // 9×50=450
-    if (n <= 11) return '42px'   // 11×42=462
-    return '36px'                // 12×36=432
-})
+// 标题真实测宽 auto-shrink：从 TITLE_MAX 起，按 scrollWidth/clientWidth 迭代缩到塞进 title
+// 弹性槽（title-row 1250px − stats-bar 720px − gap 30px ≈ 500px）。短标题保持 MAX、不再像按
+// 字符数估算那样把西文/短标题过度缩小留出空隙；长标题缩到刚好填满，与右侧 stats-bar 之间不留缝。
+const TITLE_MAX = 100
+const TITLE_MIN = 32
+const titleEl   = ref<HTMLElement | null>(null)
+const titleSize = ref(TITLE_MAX)
+
+async function fitTitle() {
+    const el = titleEl.value
+    if (!el) return
+    titleSize.value = TITLE_MAX
+    await nextTick()
+    try { await document.fonts.ready } catch { /* 测量兜底 */ }
+    await nextTick()
+    for (let pass = 0; pass < 5 && el.scrollWidth > el.clientWidth; pass++) {
+        const next = Math.floor(titleSize.value * el.clientWidth / el.scrollWidth)
+        titleSize.value = Math.max(TITLE_MIN, Math.min(next, titleSize.value - 1))
+        await nextTick()
+        if (titleSize.value <= TITLE_MIN) break
+    }
+}
+
+watch(data_fetched, v => { if (v) fitTitle() }, {flush: 'post'})
 
 function getScore(songId: number, levelIdx: number): Score | undefined {
     return scores.value[`(${songId}, ${levelIdx})`]
@@ -174,7 +188,7 @@ function formatAch(a: number): {intPart: string, fracPart: string} {
 <template>
     <div class="mai-summary" v-if="data_fetched">
         <div class="title-row">
-            <span class="title" :style="{fontSize: titleFontSize}">{{ title }}</span>
+            <span class="title" ref="titleEl" :style="{fontSize: titleSize + 'px'}">{{ title }}</span>
             <StatsBar :charts="allCharts" :scores="scores" :detail="true" :plate="plate" class="title-stats"/>
         </div>
         <div class="groups">

--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -392,7 +392,7 @@ public static class PlateData
     ///     纯假名 / 难打的日文谱师名，给中文意译、昵称、罗马音、繁简等别名。值是多个 substring：
     ///     合并同一谱师的本名、高难马甲、合作名义——substring 一侧用 OrdinalIgnoreCase，
     ///     故大小写不敏感，且合作名义（"X vs サファ太"）会一并命中。别名内容由群友提供。
-    ///     注：「7.3」与定数 7.3 同形，此处按谱师别名优先（定数 7.3 完成表不再可查）。
+    ///     注：「7.3」与定数 7.3 同形，裸「7.3」按谱师别名；定数 7.3 用「定数7.3」消歧。
     /// </summary>
     public static readonly Dictionary<string, string[]> CharterAliasMap = new()
     {
@@ -1064,9 +1064,9 @@ public static class PlateData
         string s, out int start, out int length, out Selector? selector)
     {
         start = -1; length = 0; selector = null;
-        // 可选「定数」/「定」前缀强制按定数解析，用于与同形谱师别名（如「7.3」）消歧：
+        // 可选「定数」前缀强制按定数解析，用于与同形谱师别名（如「7.3」）消歧：
         // 「7.3完成表」走别名，「定数7.3完成表」走定数。前缀计入 token 长度，靠 longest-first 压过别名。
-        var matches = System.Text.RegularExpressions.Regex.Matches(s, @"(?:定数|定)?((?:1[0-5]|[1-9])\.\d)");
+        var matches = System.Text.RegularExpressions.Regex.Matches(s, @"(?:定数)?((?:1[0-5]|[1-9])\.\d)");
         for (var i = matches.Count - 1; i >= 0; i--)
         {
             var m   = matches[i];

--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -40,6 +40,15 @@ public static class PlateData
         /// <summary>谱师。Name 与 song.Charters[i] substring 匹配。</summary>
         public sealed record Charter(string Name) : Selector(Name);
 
+        /// <summary>
+        ///     谱师别名：用户输中文 / 罗马音别名 → 一组 canonical 谱师 substring，与 song.Charters[i] 做 OR substring 匹配。
+        ///     一个别名映射多个 substring，用于合并同一谱师的本名、高难马甲与合作名义
+        ///     （如「沙发太」同时覆盖 サファ太 与马甲 -ZONE- SaFaRi）。Input 是用户输入的别名（用于显示）。
+        ///     Exclude：尽管含某 Name substring、但不属于本人的署名（如「サファ太 respects for 小鳥遊さん」
+        ///     含「小鳥遊」却是 サファ太 的致敬独谱），命中 Exclude 的 chart 不计入。
+        /// </summary>
+        public sealed record CharterAlias(IReadOnlyList<string> Names, IReadOnlyList<string> Exclude, string Input) : Selector(Input);
+
         /// <summary>类别。FullName 与 song.Info.Genre 精确匹配；Alias 是用户输入的别名（用于显示）。</summary>
         public sealed record Genre(string FullName, string Alias) : Selector(Alias);
 
@@ -379,6 +388,69 @@ public static class PlateData
     };
 
     /// <summary>
+    ///     谱师别名 → 一组 canonical 谱师 substring（与 song.Charters[i] 做 OR substring 匹配）。
+    ///     纯假名 / 难打的日文谱师名，给中文意译、昵称、罗马音、繁简等别名。值是多个 substring：
+    ///     合并同一谱师的本名、高难马甲、合作名义——substring 一侧用 OrdinalIgnoreCase，
+    ///     故大小写不敏感，且合作名义（"X vs サファ太"）会一并命中。别名内容由群友提供。
+    ///     注：「7.3」与定数 7.3 同形，此处按谱师别名优先（定数 7.3 完成表不再可查）。
+    /// </summary>
+    public static readonly Dictionary<string, string[]> CharterAliasMap = new()
+    {
+        ["哈皮"]       = ["はっぴー", "緑風 犬三郎", "原田ひろゆき", "シチミッピー", "鳩ホルぴー", "いぬっくまとボコっくま", "たかなっぴー", "Luxiいぬ", "“H”ack", "“H”ack underground", "PANDORA PARADOXXX", "Sukiyaki vs Happy"],
+        ["沙发太"]     = ["サファ太", "さふぁた", "Safari", "-ZONE- SaFaRi", "-ZONE-Phoenix", "Safata", "ボコ太", "鳩サファzhel", "サぴぴぴぴちネファ太太太太コ", "ﾚよ†ょ／∪ヽ”┠  (十,3､了ﾅﾆ", "PANDORA BOXXX", "Ruby", "project raputa", "Safazhel"],
+        ["maistar"]    = ["mai-Star"],
+        ["小鸟游"]     = ["小鳥遊", "Phoenix", "たかなっぴー", "Anomaly Labyrinth", "ネコトリサーカス団"],
+        ["谱面-100号"] = ["譜面-100号"],
+        ["谱面100号"]  = ["譜面-100号"],
+        ["100号"]      = ["譜面-100号"],
+        ["鸠"]         = ["鳩ホルダー", "The Dove", "鳩ホルぴー", "鳩サファzhel"],
+        ["鸽子"]       = ["鳩ホルダー", "The Dove", "鳩ホルぴー", "鳩サファzhel"],
+        ["企鹅"]       = ["ペンギン", "ものくロシェ"],
+        ["泸溪河"]     = ["Luxizhel", "BELiZHEL", "Luxiいぬ", "鳩サファzhel", "LuxiHertz", "Safazhel"],
+        ["二大爷"]     = ["ニャイン"],
+        ["7.3"]        = ["シチミヘルツ", "7.3", "Safata.Hz", "Safata.GHz", "超七味星人", "七味星人", "小鳥遊チミ", "シチミッピー", "あまくちヘルツ", "しちみりこりす", "SHICHIMI☆CAT", "Hz-R.Arrow", "LuxiHertz"],
+        ["隅田川"]     = ["隅田川星人", "The ALiEN", "超七味星人", "七味星人", "隅田川華火大会", "はっぴー星人"],
+        ["川哥"]       = ["隅田川星人", "The ALiEN", "超七味星人", "七味星人", "隅田川華火大会", "はっぴー星人"],
+        ["华火职人"]   = ["華火職人", "7.3連発華火", "ﾚよ†ょ／∪ヽ”┠  (十,3､了ﾅﾆ", "“Carpe diem” ＊ HAN∀BI", "隅田川華火大会"],
+        ["桃子猫"]     = ["ぴちネコ", "ロシアンブラック", "BLaCK rOSE dIsEASe pATiENT", "サぴぴぴぴちネファ太太太太コ", "チェシャ猫とハートのジャック", "SHICHIMI☆CAT", "ネコトリサーカス団", "R-blacX of JacQ", "SAFARi☆CAT"],
+        ["阿玛莉莉丝"] = ["アマリリス"],
+        ["柠檬"]       = ["じゃこレモン", "僕の檸檬本当上手"],
+        ["DP皆传"]     = ["チャン@DP皆伝", "Garakuta Scramble!", "舞舞10年ズ（チャンとはっぴー）"],
+        ["科技厨房"]   = ["Techno Kitchen"],
+        ["Revo"]       = ["Revo@LC"],
+        ["蟹棒君"]     = ["カマボコ", "ボコ太", "いぬっくまとボコっくま"],
+        ["蟹棒男"]     = ["カマボコ", "ボコ太", "いぬっくまとボコっくま"],
+        ["寿喜烧"]     = ["すきやき", "Sukiyaki vs Happy"],
+        ["叠返"]       = ["畳返し"],
+        ["红箭"]       = ["Redarrow", "red phoenix", "Hz-R.Arrow"],
+        ["甜口姜"]     = ["あまくちジンジャー", "あまくちヘルツ", "EL DiABLO"],
+        ["habakiri"]   = ["アミノハバキリ"],
+        ["hbkr"]       = ["アミノハバキリ"],
+        ["melonpop"]   = ["メロンポップ", "ずんだポップ"],
+    };
+
+    /// <summary>
+    ///     谱师别名的反向排除：某署名虽含别名的 Name substring，却不属于该谱师，命中即排除。
+    ///     如「サファ太 respects for 小鳥遊さん」含「小鳥遊」却是 サファ太 的致敬独谱，不计入「小鸟游」。
+    /// </summary>
+    public static readonly Dictionary<string, string[]> CharterAliasExclude = new()
+    {
+        ["小鸟游"] = ["サファ太 respects for 小鳥遊さん"],
+    };
+
+    /// <summary>
+    ///     可直接打出的谱师本名 → 其高难马甲等额外 substring。命中本名（精确 Charter）时一并匹配马甲，
+    ///     无需把本名设成别名（设成别名会改变其 selector 类型、撞坏既有用例）。
+    /// </summary>
+    public static readonly Dictionary<string, string[]> CharterAlterEgoMap = new()
+    {
+        ["翠楼屋"] = ["翡翠マナ"],
+    };
+
+    public static IEnumerable<string> CharterAlterEgos(string charterName) =>
+        CharterAlterEgoMap.TryGetValue(charterName, out var egos) ? egos : [];
+
+    /// <summary>
     ///     阈值表。第一项是用户输入的字符串（中文别名 + ASCII rank/fc/fs 缩写），第二项是阈值定义。
     ///     字符串后缀匹配走 longest match，所以排序时 longer-first。
     /// </summary>
@@ -575,6 +647,14 @@ public static class PlateData
                 { matchStart = gStart; matchLen = gLen; matched = gSel; }
             }
 
+            // 谱师别名作为一等 token，且在 Constant 之前检查：多字别名「华火职人」靠长度压过单字代字「华」，
+            // 同长度同位置时（「7.3」vs 定数 7.3）按先检查者胜出 → 别名优先。
+            if (TryFindRightmostCharterAliasInString(workingPart, out var caStart, out var caLen, out var caSel))
+            {
+                if (caLen > matchLen || (caLen == matchLen && caStart > matchStart))
+                { matchStart = caStart; matchLen = caLen; matched = caSel; }
+            }
+
             if (TryFindRightmostConstantInString(workingPart, out var cStart, out var cLen, out var cSel))
             {
                 if (cLen > matchLen || (cLen == matchLen && cStart > matchStart))
@@ -595,8 +675,9 @@ public static class PlateData
 
             if (matchStart < 0) break;
 
-            // 反查保护：版本代字/类别单字若嵌在更长且能对上某谱师/曲师名的片段里（如"隅田川星人"的"星"、"超七味"的"超"），它是名字的一部分而非 selector，否决匹配让整段落到下面 Charter/Artist
-            if (matched is Selector.Plate or Selector.Genre
+            // 反查保护：版本代字/类别/谱师别名若只是某真谱师/曲师名的一部分（如"隅田川星人"的"星"、
+            // "超七味"的"超"，或别名"Revo"嵌在真名"Revo@LC"里），它不是 selector，否决匹配让整段落到下面 Charter/Artist。
+            if (matched is Selector.Plate or Selector.Genre or Selector.CharterAlias
                 && workingPart.Length > matchLen
                 && (TryResolveCharterPrecise(workingPart, knownCharters, out _)
                     || TryResolveArtist(workingPart, knownArtists, out _)))
@@ -945,6 +1026,36 @@ public static class PlateData
     }
 
     /// <summary>
+    ///     找 workingPart 内最佳（length DESC, rightmost）谱师别名 key 匹配。
+    ///     OrdinalIgnoreCase：别名含 ASCII（maistar / Revo / 7.3）时大小写不敏感。
+    /// </summary>
+    private static bool TryFindRightmostCharterAliasInString(
+        string s, out int start, out int length, out Selector? selector)
+    {
+        start = -1; length = 0; selector = null;
+
+        int bestStart = -1, bestLen = 0;
+        string[]? bestNames = null;
+        string? bestKey = null;
+
+        foreach (var (alias, names) in CharterAliasMap)
+        {
+            var idx = s.LastIndexOf(alias, StringComparison.OrdinalIgnoreCase);
+            if (idx < 0) continue;
+            if (alias.Length > bestLen || (alias.Length == bestLen && idx > bestStart))
+            {
+                bestStart = idx; bestLen = alias.Length; bestNames = names; bestKey = alias;
+            }
+        }
+
+        if (bestStart < 0) return false;
+        start = bestStart; length = bestLen;
+        var exclude = CharterAliasExclude.GetValueOrDefault(bestKey!, []);
+        selector = new Selector.CharterAlias(bestNames!, exclude, s.Substring(bestStart, bestLen));
+        return true;
+    }
+
+    /// <summary>
     ///     找 workingPart 内 rightmost Constant（X.Y 格式，1-15.x 范围）。
     ///     两侧不能是 ASCII 字母 / 数字 / 点号，避免吃到 charter/artist 名里的偶然数字（如 "DECO*27"）。
     ///     正则 alternation 顺序 (1[0-5]|[1-9]) 优先匹更长以保证 "14" 不被 "1" 吃。
@@ -953,12 +1064,15 @@ public static class PlateData
         string s, out int start, out int length, out Selector? selector)
     {
         start = -1; length = 0; selector = null;
-        var matches = System.Text.RegularExpressions.Regex.Matches(s, @"(1[0-5]|[1-9])\.\d");
+        // 可选「定数」/「定」前缀强制按定数解析，用于与同形谱师别名（如「7.3」）消歧：
+        // 「7.3完成表」走别名，「定数7.3完成表」走定数。前缀计入 token 长度，靠 longest-first 压过别名。
+        var matches = System.Text.RegularExpressions.Regex.Matches(s, @"(?:定数|定)?((?:1[0-5]|[1-9])\.\d)");
         for (var i = matches.Count - 1; i >= 0; i--)
         {
-            var m = matches[i];
-            if (!IsCompleteNumberToken(s, m.Index, m.Length)) continue;
-            if (!double.TryParse(m.Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v)) continue;
+            var m   = matches[i];
+            var num = m.Groups[1];   // 数字部分（不含前缀）；边界检查只针对数字两侧。
+            if (!IsCompleteNumberToken(s, num.Index, num.Length)) continue;
+            if (!double.TryParse(num.Value, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var v)) continue;
             start = m.Index; length = m.Length;
             selector = new Selector.Constant(v);
             return true;

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -1084,11 +1084,10 @@ public class MaiMaiDxPlateDataTest
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // 「定数」/「定」前缀：强制定数解析，与同形谱师别名「7.3」消歧。
+    // 「定数」前缀：强制定数解析，与同形谱师别名「7.3」消歧。
     // ──────────────────────────────────────────────────────────────────────
 
     [TestCase("定数7.3完成表")]
-    [TestCase("定7.3完成表")]
     public void ConstantPrefixForcesConstantOverAlias(string raw)
     {
         var q = MustParse(raw);

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -14,6 +14,8 @@ public class MaiMaiDxPlateDataTest
     [
         "翠楼屋", "サファ太 vs 翠楼屋", "Jack", "はっぴー", "ロシェ@ペンギン", "rioN", "rintaro soma",
         "超七味星人", "隅田川星人", // 名字含版本代字（超=GreeN / 星=UNiVERSE），验证反查保护
+        "Revo@LC",                 // 别名"Revo"是它的子串，验证 CharterAlias 反查保护
+        "JAQ", "Jack & Licorice Gunjyo", "群青リコリス", // Jack/群青リコリス 未设别名（可打），验证解析正确
     ];
 
     // 含合作名义"sasakure.UK x DECO*27"，验证 substring 命中；"HIMEHINA" 验证纯 artist 单边命中。
@@ -991,5 +993,165 @@ public class MaiMaiDxPlateDataTest
         Assert.That(query.Selectors, Has.None.InstanceOf<PlateData.Selector.Plate>());
         Assert.That(query.Selectors.OfType<PlateData.Selector.Charter>().Single().Name, Is.EqualTo("超七味星人"));
         Assert.That(query.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("14"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // 谱师别名（CharterAlias）：中文 / 罗马音别名 → 一组 canonical 谱师 substring（OR 命中）。
+    // 别名内容是静态表，与 knownCharters 无关，故这些用例不依赖上面的 Charters fixture。
+    // ──────────────────────────────────────────────────────────────────────
+
+    [TestCase("沙发太完成表",   "沙发太", "サファ太")]
+    [TestCase("沙发太将完成表", "沙发太", "サファ太")]
+    [TestCase("企鹅完成表",     "企鹅",   "ペンギン")]
+    [TestCase("柠檬神完成表",   "柠檬",   "じゃこレモン")]
+    [TestCase("二大爷完成表",   "二大爷", "ニャイン")]
+    public void ParsesCharterAlias(string raw, string input, string expectedName)
+    {
+        var q = MustParse(raw);
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.CharterAlias>());
+        var ca = (PlateData.Selector.CharterAlias)q.Selectors.Single();
+        Assert.That(ca.Input, Is.EqualTo(input));
+        Assert.That(ca.Names, Has.Member(expectedName));
+    }
+
+    [Test]
+    public void CharterAliasMergesAlterEgos()
+    {
+        // "沙发太" 合并本名 + 高难马甲；"哈皮" 合并 はっぴー + 緑風 犬三郎。
+        var sa = (PlateData.Selector.CharterAlias)MustParse("沙发太完成表").Selectors.Single();
+        Assert.That(sa.Names, Is.SupersetOf(new[] { "サファ太", "-ZONE- SaFaRi" }));
+
+        var happy = (PlateData.Selector.CharterAlias)MustParse("哈皮完成表").Selectors.Single();
+        Assert.That(happy.Names, Is.SupersetOf(new[] { "はっぴー", "緑風 犬三郎" }));
+    }
+
+    [Test]
+    public void CharterAliasCarriesExclusions()
+    {
+        // 「小鸟游」带反向排除：含「小鳥遊」却属 サファ太 的致敬独谱要剔除（匹配层用）。
+        var ca = (PlateData.Selector.CharterAlias)MustParse("小鸟游完成表").Selectors.Single();
+        Assert.That(ca.Names, Has.Member("Phoenix"));
+        Assert.That(ca.Exclude, Has.Member("サファ太 respects for 小鳥遊さん"));
+    }
+
+    [TestCase("华火职人完成表", "华火职人")] // 别名含版本代字「华」(= 熊華 でらっくす)
+    [TestCase("桃子猫完成表",   "桃子猫")]   // 别名含版本代字「桃」(= PiNK)
+    public void CharterAliasContainingPlateKanjiBeatsPlate(string raw, string input)
+    {
+        // 别名作为更长 token 靠长度压过单字代字，不被切成 Plate + 残字。
+        var q = MustParse(raw);
+        Assert.That(q.Selectors, Has.None.InstanceOf<PlateData.Selector.Plate>());
+        Assert.That(q.Selectors.OfType<PlateData.Selector.CharterAlias>().Single().Input, Is.EqualTo(input));
+    }
+
+    [Test]
+    public void CharterAliasSevenThreeBeatsConstant()
+    {
+        // "7.3" 与定数 7.3 同形，按谱师别名优先。
+        var q = MustParse("7.3完成表");
+        Assert.That(q.Selectors, Has.None.InstanceOf<PlateData.Selector.Constant>());
+        Assert.That(q.Selectors.OfType<PlateData.Selector.CharterAlias>().Single().Names, Has.Member("シチミヘルツ"));
+    }
+
+    [Test]
+    public void RealConstantStillParsesWhenNotAnAlias()
+    {
+        // 非别名的定数照常解析（回归：别名优先只影响 "7.3"）。
+        var q = MustParse("14.6完成表");
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Constant>());
+        Assert.That(((PlateData.Selector.Constant)q.Selectors.Single()).Value, Is.EqualTo(14.6).Within(0.001));
+    }
+
+    [Test]
+    public void CharterAliasCombinesWithVersionPlate()
+    {
+        // "真桃子猫将完成表" → Plate(真) ∩ CharterAlias(桃子猫)；「桃」不被当版本。
+        var q = MustParse("真桃子猫将完成表");
+        Assert.That(q.Selectors, Has.Exactly(2).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("真"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.CharterAlias>().Single().Input, Is.EqualTo("桃子猫"));
+        Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS"));
+    }
+
+    [Test]
+    public void CharterAliasYieldsToRealCharterNameItIsSubstringOf()
+    {
+        // 别名 "Revo" 是真名 "Revo@LC" 的子串：用户输完整真名时反查保护让整段走 precise Charter，
+        // 不切成 CharterAlias("Revo") + 残段。
+        var q = MustParse("Revo@LC完成表");
+        Assert.That(q.Selectors, Has.None.InstanceOf<PlateData.Selector.CharterAlias>());
+        Assert.That(((PlateData.Selector.Charter)q.Selectors.Single()).Name, Is.EqualTo("Revo@LC"));
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
+    // 「定数」/「定」前缀：强制定数解析，与同形谱师别名「7.3」消歧。
+    // ──────────────────────────────────────────────────────────────────────
+
+    [TestCase("定数7.3完成表")]
+    [TestCase("定7.3完成表")]
+    public void ConstantPrefixForcesConstantOverAlias(string raw)
+    {
+        var q = MustParse(raw);
+        Assert.That(q.Selectors, Has.None.InstanceOf<PlateData.Selector.CharterAlias>());
+        Assert.That(((PlateData.Selector.Constant)q.Selectors.Single()).Value, Is.EqualTo(7.3).Within(0.001));
+    }
+
+    [Test]
+    public void ConstantPrefixWorksForOrdinaryConstants()
+    {
+        // 普通定数加前缀也可（一般无需，但不应报错）。
+        var q = MustParse("定数14.6神完成表");
+        Assert.That(((PlateData.Selector.Constant)q.Selectors.Single()).Value, Is.EqualTo(14.6).Within(0.001));
+        Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
+    }
+
+    [Test]
+    public void BareSevenThreeStillResolvesToCharterAliasNotConstant()
+    {
+        // 回归：无前缀的「7.3」仍按谱师别名（别名优先于同形定数）。
+        var q = MustParse("7.3完成表");
+        Assert.That(q.Selectors, Has.None.InstanceOf<PlateData.Selector.Constant>());
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.CharterAlias>());
+    }
+
+    // Jack / 群青リコリス 未设别名（本身可打）。验证其相关署名仍正确解析为 Charter。
+    [Test]
+    public void JaqParsesAsCharterNotThresholdA()
+    {
+        // 「JAQ」是 Jack 变体署名；中间「A」不能被当 Achievement 阈值剥成「JQ」。
+        var q = MustParse("JAQ完成表");
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(((PlateData.Selector.Charter)q.Selectors.Single()).Name, Is.EqualTo("JAQ"));
+        Assert.That(q.Threshold.DisplayName, Is.EqualTo("SSS")); // 默认阈值，未误吞 A
+    }
+
+    [Test]
+    public void JackResolvesAsCharterAndMatchesCollab()
+    {
+        // 打「Jack」按 Charter 解析（小写 a/c 不被当阈值），substring 命中合作署名「Jack & Licorice Gunjyo」。
+        var q = MustParse("Jack完成表");
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        var c = (PlateData.Selector.Charter)q.Selectors.Single();
+        Assert.That(c.Name, Is.EqualTo("Jack"));
+        Assert.That(Charters.Any(x => x.Contains(c.Name)), Is.True); // 含 "Jack & Licorice Gunjyo"
+    }
+
+    [Test]
+    public void GunjyoTypeableResolvesAsCharter()
+    {
+        // 群青リコリス 未设别名但可打：直接打名字按 Charter 解析（不被代字/别名误吞）。
+        var q = MustParse("群青リコリス完成表");
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(((PlateData.Selector.Charter)q.Selectors.Single()).Name, Is.EqualTo("群青リコリス"));
+    }
+
+    [Test]
+    public void CharterAlterEgoMapResolvesShisui()
+    {
+        // 打本名「翠楼屋」时 handler 会并查马甲「翡翠マナ」（匹配层）；解析层仍是普通 Charter。
+        Assert.That(PlateData.CharterAlterEgos("翠楼屋"), Has.Member("翡翠マナ"));
+        Assert.That(PlateData.CharterAlterEgos("Jack"), Is.Empty);
+        var q = MustParse("翠楼屋将完成表");
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
     }
 }

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -1117,9 +1117,19 @@ public partial class MaiMaiDx
             PlateData.Selector.Revival => PlateData.IsRevivalSong(song.Id),
 
             // substring 匹配：兼容 "サファ太 vs 翠楼屋" 这种合作谱师名义。
+            // 本名命中后再并查其高难马甲（如打"翠楼屋"也带出"翡翠マナ"）。
             PlateData.Selector.Charter c =>
                 levelIdx < song.Charters.Count
-                && song.Charters[levelIdx].Contains(c.Name, StringComparison.OrdinalIgnoreCase),
+                && (song.Charters[levelIdx].Contains(c.Name, StringComparison.OrdinalIgnoreCase)
+                    || PlateData.CharterAlterEgos(c.Name).Any(e =>
+                        song.Charters[levelIdx].Contains(e, StringComparison.OrdinalIgnoreCase))),
+
+            // 谱师别名：任一 canonical substring 命中即可（OR），覆盖本名 / 高难马甲 / 合作名义；
+            // 但命中 Exclude 的署名（含 substring 却不属本人）要剔除。
+            PlateData.Selector.CharterAlias ca =>
+                levelIdx < song.Charters.Count
+                && ca.Names.Any(n => song.Charters[levelIdx].Contains(n, StringComparison.OrdinalIgnoreCase))
+                && !ca.Exclude.Any(x => song.Charters[levelIdx].Contains(x, StringComparison.OrdinalIgnoreCase)),
 
             // song-level substring 匹配，兼容 "sasakure.UK x DECO*27" 这种合作作曲名义。
             PlateData.Selector.Artist a =>


### PR DESCRIPTION
本 PR 有两块改动，都是围绕 `mai ... 完成表`。

## 谱师别名

完成表可以按谱师筛选，但谱师名基本都是日文（`サファ太`、`はっぴー` 这类），不会打日文的用户其实用不上这个维度。这次给主要谱师补了一批中文 / 罗马音别名，输入别名就能代替日文原名。

做法是加一张别名表，每个别名对应该谱师在数据里出现过的一组署名（本名、各种合作名义，以及个别「高难马甲」），命中其中任意一个就算这位谱师。有几处需要单独处理：

- 别名作为一个完整 token 参与解析，避免和版本代字冲突。比如 `华火职人` 里的「华」本身是版本代字，但更长的别名会优先匹配，不会被拆成「华」+「火职人」。
- `7.3` 既是谱师别名又是一个合法定数。默认按谱师处理；要查定数 7.3，写成 `定数7.3`。
- 翠楼屋这种本名能直接打、但马甲（翡翠マナ）打不出来的，输入本名时会把马甲的谱面也一并算上。
- 个别署名字面上包含某谱师、实际却不是他的谱（比如 `サファ太 respects for 小鳥遊さん` 是 サファ太 致敬小鸟游的独谱），这类会从对应谱师里排除。

完整别名对照见下方评论的表格。别名内容由群友提供，并对照 diving-fish 数据逐条核对过。

下图是 `沙发太神完成表` 的实际渲染，成绩取自 TamakoZz 的真实数据：

![沙发太神完成表](https://github.com/NakashimaYuki/MarisaBot/releases/download/charter-alias-preview/charter-alias-safata-showcase.png)

## 标题字号

完成表标题原先按字数分几档定字号，而且是按最宽的中文字来估的，所以遇到西文或较短的标题时字号偏小，标题和右边的统计条之间总空着一截。

改成渲染后实测标题宽度、再缩放到正好填满可用空间，跟 `MaiSong.vue` 里歌名的处理方式一致：长标题缩到刚好放得下，短标题保持较大字号。下图每组上面是改前、下面是改后，虚线框表示标题能用的宽度：

![标题字号前后对比](https://github.com/NakashimaYuki/MarisaBot/releases/download/charter-alias-preview/plate-title-autofit.png)

## 验证

`dotnet test Marisa.Plugin.Test/Marisa.Plugin.Test.csproj --filter MaiMaiDxPlateDataTest`（216 个用例全过）

本 PR 由 Claude Opus 4.8 编写。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
