### PR TITLE
fix(maimai): 修 mai song 标题降部（g/y/p 等）被截断

### DIFF
--- a/Marisa.Frontend/src/components/maimai/MaiSong.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiSong.vue
@@ -635,8 +635,10 @@ function break50Loss(chart: Chart): string {
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5), 0 4px 22px rgba(0, 0, 0, 0.4);
     white-space: nowrap;
     overflow: hidden;
-    padding-block: 8px 10px;
-    margin-block: -8px -10px;
+    /* overflow 在 padding 边裁切，故底部 padding 是给降部（g/y/p 等）留的安全区，margin 抵消其布局影响。
+       字号 auto-shrink 到 110px，固定 10px 不够会切掉降部，底部改用 em 随字号缩放。 */
+    padding-block: 8px 0.22em;
+    margin-block: -8px -0.22em;
 }
 
 .artist-line {


### PR DESCRIPTION
`mai song` 的图里，标题如果有 g、y、p 这类带下伸笔画的字母，下半截会被切掉。

标题用了 `overflow: hidden` 配 `line-height: 1`，下伸部分本来要靠底部 padding 留出来（再用等量的负 margin 抵消掉对下方布局的影响）。问题是这个 padding 写死成 10px，而标题字号是按宽度自动缩放的、最大到 110px，字号一大 10px 就兜不住下伸笔画，于是被 `overflow` 切平。

把底部的 padding / margin 从固定 10px 改成 `0.22em`，跟着字号一起缩放就行。负 margin 同样改成 `0.22em`，下方布局位置不变。

下图上面一行是改前（10px，降部被切），下面是改后（0.22em，完整），分别在 110px 和 72px 两个字号下对比：

![descender fix](https://github.com/NakashimaYuki/MarisaBot/releases/download/maisong-descender-fix/maisong-descender-fix.png)

本 PR 由 Claude Opus 4.8 编写。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
