### PR TITLE
feat(maimai): mai info 单曲成绩卡 —— 显示某首歌各难度的个人成绩

### DIFF
--- a/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
@@ -274,5 +274,5 @@ watch(song, async () => {
 .vc-rank { display: block; }
 .vc-star { height: 28px; display: block; }
 .vc-mark { display: block; }
-.vc-unplayed { flex: 1; display: flex; align-items: center; padding-left: 20px; font-family: 'SEGA NewRodin', sans-serif; font-weight: bold; font-style: italic; font-size: 20px; color: rgba(255,255,255,0.3); letter-spacing: 0.22em; }
+.vc-unplayed { flex: 1; display: flex; align-items: center; padding-left: 20px; font-family: 'SEGA NewRodin', sans-serif; font-weight: bold; font-size: 20px; color: rgba(255,255,255,0.3); letter-spacing: 0.22em; }
 </style>

--- a/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
@@ -47,10 +47,10 @@
             <div class="vc-tbl">
                 <div class="vc-head">
                     <div class="vc-h-diff"></div>
-                    <div class="vc-cells">
+                    <div class="vc-cells" :class="{ 'vc-cells--utg': isUtage }">
                         <div class="vc-h vc-h-c">达成率</div>
                         <div class="vc-h vc-h-c">评级</div>
-                        <div class="vc-h vc-h-c">Ra</div>
+                        <div v-if="!isUtage" class="vc-h vc-h-c">Ra</div>
                         <div class="vc-h vc-h-c">DX SCORE</div>
                         <div class="vc-h vc-h-c">DX%</div>
                         <div class="vc-h vc-h-c">DX星级</div>
@@ -62,10 +62,10 @@
                         <span class="vc-chip-name" :style="isUtage ? { fontFamily: `'Microsoft YaHei', sans-serif` } : undefined">{{ diffName(c.LevelIndex) }}</span>
                         <span class="vc-chip-ds tabular-nums">{{ isUtage ? c.Level : c.Constant.toFixed(1) }}</span>
                     </div>
-                    <div v-if="c.Played" class="vc-cells">
+                    <div v-if="c.Played" class="vc-cells" :class="{ 'vc-cells--utg': isUtage }">
                         <div class="vc-ach tabular-nums"><span class="vc-ach-int">{{ achInt(c) }}</span>.{{ achDec(c) }}<span class="vc-ach-pct">%</span></div>
                         <div class="vc-cell vc-cell-c"><img :src="rankIcon(c)" alt="" :style="rankStyle(c)" class="vc-rank"></div>
-                        <div class="vc-cell vc-cell-c vc-cell-ra tabular-nums">{{ isUtage ? '-' : c.Ra }}</div>
+                        <div v-if="!isUtage" class="vc-cell vc-cell-c vc-cell-ra tabular-nums">{{ c.Ra }}</div>
                         <div class="vc-cell vc-cell-c vc-cell-dx tabular-nums">{{ c.DxScore }}/{{ c.MaxDx }}</div>
                         <div class="vc-cell vc-cell-c vc-cell-rate tabular-nums">{{ dxRate(c) }}%</div>
                         <div class="vc-cell vc-cell-c"><img v-if="starN(c)" :src="starIcon(c)" alt="" class="vc-star"></div>
@@ -257,6 +257,8 @@ watch(song, async () => {
 .vc-chip-name { font-family: 'SEGA NewRodin',sans-serif; font-weight: 900; font-size: 13px; }
 .vc-chip-ds { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 25px; line-height: 1; }
 .vc-cells { flex: 1; min-width: 0; display: grid; grid-template-columns: 110px 94px 32px 88px 54px 44px 76px; justify-content: space-between; align-items: center; padding-left: 16px; padding-right: 18px; }
+/* 宴会场谱面无定数、Ra 无意义，去掉 Ra 列（表头与单元格均不渲染），列模板同步收成 6 列 */
+.vc-cells--utg { grid-template-columns: 110px 94px 88px 54px 44px 76px; }
 .vc-row .vc-cells { align-items: flex-start; padding-top: 11px; }
 .vc-ach { display: flex; align-items: baseline; justify-content: flex-start; font-family: 'Torus',sans-serif; font-weight: bold; font-size: 19px; line-height: 1; }
 .vc-ach-int { font-weight: 900; font-size: 31px; }

--- a/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
@@ -31,7 +31,7 @@
                     <h1 ref="titleEl" class="mai-title" :style="{ fontSize: titleSize + 'px' }">{{ song.Title }}</h1>
                     <div class="flex items-baseline justify-between gap-4 mt-[10px]">
                         <div class="artist-line min-w-0">{{ song.Artist }}</div>
-                        <div class="player-inline shrink-0"><span class="player-label">PLAYER</span> {{ player.Nickname }}</div>
+                        <div v-if="player.Nickname" class="player-inline shrink-0"><span class="player-label">PLAYER</span> {{ player.Nickname }}</div>
                     </div>
                 </div>
             </div>
@@ -99,7 +99,7 @@ interface ChartScore {
 }
 interface ScoreData {
     Song: { Id: number; Title: string; Type: string; Artist: string; Genre: string; Bpm: number; From: string; IsNew: boolean }
-    Player: { Nickname: string; Rating: number }
+    Player: { Nickname: string }
     Charts: ChartScore[]
 }
 
@@ -107,7 +107,7 @@ const route = useRoute()
 const data  = ref<ScoreData | null>(null)
 
 const song   = computed(() => data.value?.Song ?? null)
-const player = computed(() => data.value?.Player ?? {Nickname: '', Rating: 0})
+const player = computed(() => data.value?.Player ?? {Nickname: ''})
 const charts = computed(() => data.value?.Charts ?? [])
 const isUtage = computed(() => (song.value?.Id ?? 0) > 100000)
 

--- a/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
@@ -1,0 +1,276 @@
+<template>
+    <div v-if="song" class="mai-score relative w-[840px] overflow-hidden antialiased" :style="rootStyle">
+        <div class="absolute inset-0 pointer-events-none stripe-layer"></div>
+        <div class="absolute inset-0 pointer-events-none" :style="glowStyle"></div>
+
+        <div class="relative px-12 pt-9 pb-10">
+            <!-- ── top meta bar ── -->
+            <header class="flex items-center gap-2 flex-nowrap whitespace-nowrap">
+                <img :src="versionLogo" :style="logoStyle" class="h-[50px] shrink-0 drop-shadow-[0_3px_8px_rgba(0,0,0,0.4)]">
+                <div class="flex-1"></div>
+                <img :src="typeBadge" class="h-9 drop-shadow-[0_3px_8px_rgba(0,0,0,0.4)]">
+                <span v-if="song.IsNew" class="new-chip">NEW</span>
+                <div class="bpm-pill">
+                    <svg class="w-[18px] h-[18px] translate-y-[1px]" viewBox="0 0 24 24" fill="none">
+                        <path d="M9.4 3h5.2c.5 0 .9.33 1 .8l3.1 14.6c.13.62-.34 1.2-1 1.2H6.3c-.66 0-1.13-.58-1-1.2L8.4 3.8c.1-.47.5-.8 1-.8z" stroke="currentColor" stroke-width="1.9" stroke-linejoin="round"/>
+                        <path d="M12 15.2 17.6 5.6" stroke="currentColor" stroke-width="1.9" stroke-linecap="round"/>
+                        <circle cx="12" cy="15.6" r="1.5" fill="currentColor"/>
+                    </svg>
+                    <span class="bpm-num tabular-nums">{{ song.Bpm }}</span>
+                </div>
+                <span class="meta-chip">{{ genreDisplay }}</span>
+                <div class="id-pill tabular-nums">ID {{ song.Id }}</div>
+            </header>
+
+            <!-- ── cover + 标题（标题占满封面右侧整宽，曲师 + 玩家名同行） ── -->
+            <div class="flex items-end gap-5 mt-7">
+                <div class="cover-frame shrink-0">
+                    <img :src="coverSrc" @error="onCoverErr" alt="" class="block w-[132px] h-[132px] object-cover rounded-[16px]">
+                </div>
+                <div class="flex-1 min-w-0 pb-1">
+                    <h1 ref="titleEl" class="mai-title" :style="{ fontSize: titleSize + 'px' }">{{ song.Title }}</h1>
+                    <div class="flex items-baseline justify-between gap-4 mt-[10px]">
+                        <div class="artist-line min-w-0">{{ song.Artist }}</div>
+                        <div class="player-inline shrink-0"><span class="player-label">PLAYER</span> {{ player.Nickname }}</div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- ── section tag ── -->
+            <div class="flex items-center gap-4 mt-8 mb-4">
+                <span class="section-tag">乐曲成绩</span>
+                <span class="font-rodin text-[18px] tracking-[0.28em] text-white/70 whitespace-nowrap">SONG INFO</span>
+                <div class="flex-1 h-[2px] rounded-full bg-white/20"></div>
+            </div>
+
+            <!-- ── 乐曲成绩表：左难度块 + 右侧单行平铺(列对齐) ── -->
+            <div class="vc-tbl">
+                <div class="vc-head">
+                    <div class="vc-h-diff"></div>
+                    <div class="vc-cells">
+                        <div class="vc-h vc-h-c">达成率</div>
+                        <div class="vc-h vc-h-c">评级</div>
+                        <div class="vc-h vc-h-c">Ra</div>
+                        <div class="vc-h vc-h-c">DX SCORE</div>
+                        <div class="vc-h vc-h-c">DX%</div>
+                        <div class="vc-h vc-h-c">DX星级</div>
+                        <div class="vc-h vc-h-c">FC / FS</div>
+                    </div>
+                </div>
+                <div v-for="c in charts" :key="c.LevelIndex" class="vc-row" :style="rowStyle(c.LevelIndex)">
+                    <div class="vc-chip" :style="{ color: diffColor(c.LevelIndex), borderColor: diffColor(c.LevelIndex) }">
+                        <span class="vc-chip-name" :style="isUtage ? { fontFamily: `'Microsoft YaHei', sans-serif` } : undefined">{{ diffName(c.LevelIndex) }}</span>
+                        <span class="vc-chip-ds tabular-nums">{{ isUtage ? c.Level : c.Constant.toFixed(1) }}</span>
+                    </div>
+                    <div v-if="c.Played" class="vc-cells">
+                        <div class="vc-ach tabular-nums"><span class="vc-ach-int">{{ achInt(c) }}</span>.{{ achDec(c) }}<span class="vc-ach-pct">%</span></div>
+                        <div class="vc-cell vc-cell-c"><img :src="rankIcon(c)" alt="" :style="rankStyle(c)" class="vc-rank"></div>
+                        <div class="vc-cell vc-cell-c vc-cell-ra tabular-nums">{{ isUtage ? '-' : c.Ra }}</div>
+                        <div class="vc-cell vc-cell-c vc-cell-dx tabular-nums">{{ c.DxScore }}/{{ c.MaxDx }}</div>
+                        <div class="vc-cell vc-cell-c vc-cell-rate tabular-nums">{{ dxRate(c) }}%</div>
+                        <div class="vc-cell vc-cell-c"><img v-if="starN(c)" :src="starIcon(c)" alt="" class="vc-star"></div>
+                        <div class="vc-cell vc-cell-mark">
+                            <span class="vc-mslot"><img v-if="c.Fc" :src="fcIcon(c)" alt="" :style="markStyle(c.Fc)" class="vc-mark"></span>
+                            <span class="vc-mslot"><img v-if="c.Fs" :src="fsIcon(c)" alt="" :style="markStyle(c.Fs)" class="vc-mark"></span>
+                        </div>
+                    </div>
+                    <div v-else class="vc-unplayed">无游玩记录</div>
+                </div>
+            </div>
+
+            <footer class="mt-7">
+                <span class="footer-text">MARISA BOT · SONG INFO</span>
+            </footer>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import {computed, nextTick, ref, watch} from 'vue'
+import axios from 'axios'
+import {useRoute} from 'vue-router'
+import {context_get} from '@/GlobalVars'
+import {dxScoreStar} from '@/components/maimai/utils/ordinal'
+
+interface ChartScore {
+    LevelIndex: number; Level: string; Constant: number; Charter: string; MaxDx: number
+    Played: boolean; Achievement: number | null; Rank: string | null; Ra: number | null
+    Fc: string | null; Fs: string | null; DxScore: number | null
+}
+interface ScoreData {
+    Song: { Id: number; Title: string; Type: string; Artist: string; Genre: string; Bpm: number; From: string; IsNew: boolean }
+    Player: { Nickname: string; Rating: number }
+    Charts: ChartScore[]
+}
+
+const route = useRoute()
+const data  = ref<ScoreData | null>(null)
+
+const song   = computed(() => data.value?.Song ?? null)
+const player = computed(() => data.value?.Player ?? {Nickname: '', Rating: 0})
+const charts = computed(() => data.value?.Charts ?? [])
+const isUtage = computed(() => (song.value?.Id ?? 0) > 100000)
+
+axios.get(context_get, {params: {id: route.query.id, name: 'SongScore'}}).then(res => {
+    data.value = typeof res.data === 'string' ? JSON.parse(res.data) : res.data
+})
+
+const DIFF_NAMES  = ['BASIC', 'ADVANCED', 'EXPERT', 'MASTER', 'Re:MASTER']
+const DIFF_COLORS = ['#52e72b', '#ffa801', '#ff5a66', '#c64fe4', '#dbaaff']
+function diffName(i: number) { return isUtage.value ? '宴' : DIFF_NAMES[Math.min(i, 4)] }
+function diffColor(i: number) { return isUtage.value ? '#f73ee0' : DIFF_COLORS[Math.min(i, 4)] }
+
+const PIC = '/assets/maimai/pic'
+function rankIcon(c: ChartScore) { return `${PIC}/rank_${c.Rank}.png` }
+function fcIcon(c: ChartScore) { return `${PIC}/icon_${c.Fc}.png` }
+function fsIcon(c: ChartScore) { return `${PIC}/icon_${c.Fs}.png` }
+function starN(c: ChartScore) { return dxScoreStar(c.DxScore ?? 0, c.MaxDx) }
+function starIcon(c: ChartScore) { return `${PIC}/music_icon_dxstar_${starN(c)}.png` }
+function dxRate(c: ChartScore) { return c.MaxDx ? ((c.DxScore ?? 0) / c.MaxDx * 100).toFixed(1) : '0.0' }
+function achInt(c: ChartScore) { return Math.floor(c.Achievement ?? 0) }
+function achDec(c: ChartScore) { return (c.Achievement ?? 0).toFixed(4).split('.')[1] }
+
+// FC/FS 标记与 rank 评级牌均已替换为游戏图集高分辨率版本（UI_MSS_MBase_Icon_* / UI_GAM_Rank_）并裁切到内容边界：
+// 内容铺满画布、垂直居中、无截断，故各图标按同一 CSS 高度显示即视觉等高，无需再做 per-icon 归一化或垂直校正。
+const MARK_BASE = 29, RANK_BASE = 32
+function markStyle(_name: string | null) { return {height: MARK_BASE + 'px'} }
+function rankStyle(_c: ChartScore) { return {height: RANK_BASE + 'px'} }
+
+const typeBadge = computed(() => song.value?.Type === 'DX'
+    ? `${PIC}/mode_dx.png` : `${PIC}/mode_standard.png`)
+
+const coverSrc = ref('')
+watch(song, s => { if (s) coverSrc.value = `/assets/maimai/cover/${s.Id}.png` }, {immediate: true})
+function onCoverErr() { coverSrc.value = '/assets/maimai/cover/0.png' }
+
+// genre 简中 → NewRodin 覆盖的日/西文（同 MaiSong）
+const GENRE_MAP: Record<string, string> = {
+    '流行&动漫': 'POPS&アニメ', '舞萌': 'maimai', '其他游戏': 'ゲーム&バラエティ',
+    '音击&中二节奏': 'オンゲキ&CHUNITHM', '东方Project': '東方Project',
+}
+const genreDisplay = computed(() => GENRE_MAP[song.value?.Genre ?? ''] ?? song.value?.Genre ?? '')
+
+// 版本 logo（同 MaiSong）
+const VERSION_CODE: Record<string, number> = {
+    'maimai': 100, 'maimai PLUS': 110, 'maimai GreeN': 120, 'maimai GreeN PLUS': 130,
+    'maimai ORANGE': 140, 'maimai ORANGE PLUS': 150, 'maimai PiNK': 160, 'maimai PiNK PLUS': 170,
+    'maimai MURASAKi': 180, 'maimai MURASAKi PLUS': 185, 'maimai MiLK': 190, 'MiLK PLUS': 195,
+    'maimai FiNALE': 199, 'maimai でらっくす': 200, 'maimai でらっくす Splash': 214,
+    'maimai でらっくす UNiVERSE': 220, 'maimai でらっくす FESTiVAL': 230, 'maimai でらっくす BUDDiES': 240,
+    'maimai でらっくす PRiSM': 250, 'maimai でらっくす PRiSM PLUS': 255,
+}
+const LOGO_BBOX_LEFT: Record<number, number> = {
+    100: 22, 110: 21, 120: 20, 130: 20, 140: 20, 150: 14, 160: 21, 170: 21, 180: 28, 185: 19,
+    190: 21, 195: 32, 199: 24, 200: 49, 214: 54, 220: 55, 230: 50, 240: 78, 250: 79, 255: 50,
+}
+const versionLogo = computed(() => {
+    const code = VERSION_CODE[song.value?.From ?? '']
+    return code ? `/assets/maimai/version/Ver${code}.png` : '/assets/maimai/version/maimaidx.png'
+})
+const logoStyle = computed(() => {
+    const code = VERSION_CODE[song.value?.From ?? '']
+    const trim = code ? (LOGO_BBOX_LEFT[code] ?? 0) * (60 / 160) : 0
+    return {marginLeft: `${(-trim).toFixed(1)}px`}
+})
+
+// 背景按最高难度上色（有 Re:MASTER 取白谱档、宴会场取宴），跟 mai song 一致
+const topIdx = computed(() => Math.max(0, charts.value.length - 1))
+const DIFF_KEYS = ['BSC', 'ADV', 'EXP', 'MST', 'MST_Re']
+const BG_GRADIENTS: Record<string, [string, string]> = {
+    BSC: ['#123a0a', '#04120a'], ADV: ['#3a2706', '#140d03'], EXP: ['#3d0d14', '#16060a'],
+    MST: ['#2c0b44', '#0e0418'], MST_Re: ['#33204f', '#120a20'], UTG: ['#3d0c35', '#150412'], DMY: ['#222633', '#0a0c12'],
+}
+const topKey = computed(() => isUtage.value ? 'UTG' : DIFF_KEYS[topIdx.value] ?? 'DMY')
+const themeMain = computed(() => isUtage.value ? '#f73ee0' : DIFF_COLORS[topIdx.value] ?? '#999')
+const rootStyle = computed(() => {
+    const [c1, c2] = BG_GRADIENTS[topKey.value] ?? BG_GRADIENTS['DMY']
+    return {background: `linear-gradient(168deg, ${c1} 0%, ${c2} 62%, #060309 100%)`}
+})
+const glowStyle = computed(() => ({
+    background: `radial-gradient(720px 520px at 18% 8%, ${themeMain.value}2e 0%, transparent 70%),
+                 radial-gradient(560px 480px at 92% 4%, ${themeMain.value}1c 0%, transparent 70%)`,
+}))
+
+function rowStyle(i: number) {
+    const c = diffColor(i)
+    return {
+        border: '1px solid rgba(255,255,255,0.08)',
+        boxShadow: `inset 5px 0 0 ${c}`,
+        background: `linear-gradient(90deg, ${c}24 0%, rgba(0,0,0,0.34) 26%, rgba(0,0,0,0.34) 100%)`,
+    }
+}
+
+// 标题真实测宽 auto-shrink（同 MaiSong 思路，简化）
+const TITLE_MAX = 84, TITLE_MIN = 28
+const titleEl = ref<HTMLElement | null>(null)
+const titleSize = ref(TITLE_MAX)
+watch(song, async () => {
+    if (!song.value) return
+    titleSize.value = TITLE_MAX
+    await nextTick()
+    try { await (document as any).fonts.ready } catch { /* ignore */ }
+    const el = titleEl.value
+    for (let p = 0; el && p < 5 && el.scrollWidth > el.clientWidth; p++) {
+        titleSize.value = Math.max(TITLE_MIN, Math.floor(titleSize.value * el.clientWidth / el.scrollWidth) - 1)
+        await nextTick()
+    }
+}, {flush: 'post'})
+</script>
+
+<style scoped lang="postcss">
+.mai-score { color: #fff; background-color: #0e0418; }
+.mai-score img { max-width: none; }
+.stripe-layer { background: repeating-linear-gradient(-38deg, rgba(255,255,255,0.025) 0 3px, transparent 3px 26px); }
+
+/* top meta pills */
+.id-pill, .bpm-pill { font-family: 'Torus', sans-serif; color: #fff; background: rgba(35,37,69,0.82); border-radius: 9999px; box-shadow: 0 4px 12px rgba(35,37,69,0.25); }
+.id-pill { font-weight: bold; font-size: 16px; letter-spacing: 0.06em; padding: 3px 12px; }
+.bpm-pill { display: inline-flex; align-items: center; gap: 6px; padding: 3px 12px 3px 10px; }
+.bpm-num { font-weight: bold; font-size: 16px; }
+.meta-chip { font-family: 'SEGA NewRodin','LXGW WenKai',sans-serif; font-weight: bold; font-size: 14px; color: #454867; padding: 4px 12px; border-radius: 9999px; background: rgba(255,255,255,0.72); box-shadow: 0 0 0 1px rgba(255,255,255,0.85); white-space: nowrap; }
+.new-chip { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 12px; letter-spacing: 0.18em; padding: 4px 11px 3px 13px; border-radius: 9999px; background: linear-gradient(135deg,#ffb02c,#ff5a66); box-shadow: 0 3px 10px rgba(255,90,102,0.45); }
+
+.cover-frame { padding: 5px; border-radius: 22px; background: rgba(255,255,255,0.78); box-shadow: 0 0 0 1px rgba(255,255,255,0.8), 0 8px 20px -12px rgba(0,0,0,0.5); }
+.mai-title { font-family: 'SEGA NewRodin','LXGW WenKai',sans-serif; font-weight: 700; line-height: 1; color: #fff; text-shadow: 0 2px 4px rgba(0,0,0,0.5); white-space: nowrap; overflow: hidden; padding-block: 6px 8px; margin-block: -6px -8px; }
+.artist-line { font-family: 'Torus','SEGA Maru Gothic','LXGW WenKai',sans-serif; font-size: 20px; font-weight: bold; color: rgba(255,255,255,0.8); margin-top: 12px; white-space: nowrap; overflow: hidden; }
+.player-inline { font-family: 'Torus','Microsoft YaHei',sans-serif; font-weight: bold; font-size: 21px; color: #fff; text-shadow: 0 2px 4px rgba(0,0,0,0.5); white-space: nowrap; }
+.player-label { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 12px; letter-spacing: 0.18em; color: rgba(255,255,255,0.45); }
+
+.section-tag { font-family: 'Microsoft YaHei',sans-serif; font-weight: bold; font-size: 21px; letter-spacing: 0.1em; border-radius: 9999px; padding: 4px 20px; background: #c64fe4; color: #fff; box-shadow: 0 0 0 2px rgba(255,255,255,0.8); white-space: nowrap; }
+.font-torus { font-family: 'Torus','LXGW WenKai',sans-serif; font-variant-numeric: tabular-nums; }
+.font-rodin { font-family: 'SEGA NewRodin','LXGW WenKai',sans-serif; font-weight: 900; }
+.footer-text { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 12px; letter-spacing: 0.4em; color: rgba(255,255,255,0.45); }
+
+/* shared row text */
+.tabular-nums { font-variant-numeric: tabular-nums; }
+.num { font-family: 'Torus',sans-serif; font-weight: bold; }
+
+/* ───── 乐曲成绩表：左侧难度块 + 右侧单行平铺（列对齐 + 图标按内容高归一） ───── */
+.vc-tbl { display: flex; flex-direction: column; gap: 9px; }
+.vc-head { display: flex; align-items: flex-end; padding-bottom: 2px; }
+.vc-head .vc-h-diff { width: 116px; flex-shrink: 0; }
+.vc-h { font-family: 'Torus','Microsoft YaHei',sans-serif; font-weight: bold; font-size: 13px; letter-spacing: 0.04em; color: rgba(255,255,255,0.5); }
+.vc-h-c { text-align: center; }
+.vc-row { display: flex; align-items: stretch; height: 54px; border-radius: 10px; overflow: hidden; }
+.vc-chip { width: 116px; flex-shrink: 0; position: relative; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 1px; background: rgba(8,8,16,0.34); }
+.vc-chip::after { content: ''; position: absolute; right: -1.5px; top: 11px; bottom: 11px; width: 4px; border-radius: 2px; background: currentColor; }
+.vc-chip-name { font-family: 'SEGA NewRodin',sans-serif; font-weight: 900; font-size: 13px; }
+.vc-chip-ds { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 25px; line-height: 1; }
+.vc-cells { flex: 1; min-width: 0; display: grid; grid-template-columns: 110px 94px 32px 88px 54px 44px 76px; justify-content: space-between; align-items: center; padding-left: 16px; padding-right: 18px; }
+.vc-row .vc-cells { align-items: flex-start; padding-top: 11px; }
+.vc-ach { display: flex; align-items: baseline; justify-content: flex-start; font-family: 'Torus',sans-serif; font-weight: bold; font-size: 19px; line-height: 1; }
+.vc-ach-int { font-weight: 900; font-size: 31px; }
+.vc-ach-pct { font-size: 14px; opacity: 0.62; margin-left: 1px; }
+.vc-cell { display: flex; align-items: center; }
+.vc-cell-c { justify-content: center; }
+.vc-cell-ra { font-family: 'Torus',sans-serif; font-weight: 800; font-size: 19px; }
+.vc-cell-dx { font-family: 'Torus',sans-serif; font-weight: 800; font-size: 19px; color: rgba(255,255,255,0.9); }
+.vc-cell-rate { font-family: 'Torus',sans-serif; font-weight: 800; font-size: 19px; color: rgba(255,255,255,0.65); }
+/* FC / FS 两个标记各占一个等宽槽位、在槽内左对齐：带「+」的图标更宽时只向右延伸，圆章左缘逐行对齐 */
+.vc-cell-mark { gap: 0; transform: translateX(5px); }
+.vc-mslot { flex: 1 1 0; min-width: 0; display: flex; align-items: center; justify-content: flex-start; }
+.vc-rank { display: block; }
+.vc-star { height: 28px; display: block; }
+.vc-mark { display: block; }
+.vc-unplayed { flex: 1; display: flex; align-items: center; padding-left: 20px; font-family: 'Torus','Microsoft YaHei',sans-serif; font-weight: bold; font-size: 20px; color: rgba(255,255,255,0.3); letter-spacing: 0.22em; }
+</style>

--- a/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
@@ -74,7 +74,7 @@
                             <span class="vc-mslot"><img v-if="c.Fs" :src="fsIcon(c)" alt="" :style="markStyle(c.Fs)" class="vc-mark"></span>
                         </div>
                     </div>
-                    <div v-else class="vc-unplayed">无游玩记录</div>
+                    <div v-else class="vc-unplayed">No Play Record</div>
                 </div>
             </div>
 
@@ -274,5 +274,5 @@ watch(song, async () => {
 .vc-rank { display: block; }
 .vc-star { height: 28px; display: block; }
 .vc-mark { display: block; }
-.vc-unplayed { flex: 1; display: flex; align-items: center; padding-left: 20px; font-family: 'Torus','Microsoft YaHei',sans-serif; font-weight: bold; font-size: 20px; color: rgba(255,255,255,0.3); letter-spacing: 0.22em; }
+.vc-unplayed { flex: 1; display: flex; align-items: center; padding-left: 20px; font-family: 'SEGA NewRodin', sans-serif; font-weight: bold; font-style: italic; font-size: 20px; color: rgba(255,255,255,0.3); letter-spacing: 0.22em; }
 </style>

--- a/Marisa.Frontend/src/main.ts
+++ b/Marisa.Frontend/src/main.ts
@@ -24,6 +24,7 @@ import OpVersion from "@/components/chunithm/op/OpVersion.vue";
 import {default as ChunithmPreview} from "@/components/chunithm/Preview.vue";
 import ChunithmSong from "@/components/chunithm/ChunithmSong.vue";
 import MaiSong from "@/components/maimai/MaiSong.vue";
+import MaiSongScore from "@/components/maimai/MaiSongScore.vue";
 
 
 const routes = [
@@ -33,6 +34,7 @@ const routes = [
     {path: '/maimai/recommend', component: Recommend},
     {path: '/maimai/summary', component: MaiMaiSummary},
     {path: '/maimai/song', component: MaiSong},
+    {path: '/maimai/song-score', component: MaiSongScore},
     {path: '/chunithm/best', component: ChuBestScores},
     {path: '/chunithm/summary', component: ChunithmSummary},
     {path: '/chunithm/overpower', component: OverPowerAll},

--- a/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/DataFetcher.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/DataFetcher.cs
@@ -14,4 +14,17 @@ public abstract class DataFetcher(SongDb<MaiMaiSong> songDb)
     public abstract Task<DxRating> GetRating(Message message);
 
     public abstract Task<Dictionary<(long Id, int LevelIdx), SongScore>> GetScores(Message message);
+
+    /// <summary>
+    ///     获取某一首歌各难度的个人成绩（单曲成绩卡用）。返回 (昵称, 按难度索引的成绩)；昵称拿不到时为 null。
+    ///     默认实现回退为「拉取整个成绩表再筛选」；具体查分器可覆写为各自的「单曲成绩接口」以避免全量拉取。
+    /// </summary>
+    public virtual async Task<(string? Nickname, Dictionary<int, SongScore> Scores)> GetSongScore(Message message, MaiMaiSong song)
+    {
+        var rating = await GetRating(message);
+        var scores = (await GetScores(message))
+            .Where(kv => kv.Key.Id == song.Id)
+            .ToDictionary(kv => kv.Key.LevelIdx, kv => kv.Value);
+        return (rating.Nickname, scores);
+    }
 }

--- a/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/DivingFishDataFetcher.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/DivingFishDataFetcher.cs
@@ -55,6 +55,36 @@ public class DivingFishDataFetcher : DataFetcher
             .ToDictionary(x => (x.Id, x.LevelIdx), x => x);
     }
 
+    public override async Task<(string? Nickname, Dictionary<int, SongScore> Scores)> GetSongScore(Message message, MaiMaiSong song)
+    {
+        var (username, qq) = Chunithm.DataFetcher.DataFetcher.AtOrSelf(message, false);
+
+        var body = new Dictionary<string, object> { ["music_id"] = new[] { song.Id } };
+        if (username.IsWhiteSpace()) body["qq"] = qq;
+        else body["username"]                   = username;
+
+        var response = await "https://www.diving-fish.com/api/maimaidxprober/dev/player/record"
+            .WithHeader("Developer-Token", ConfigurationManager.Configuration.DivingFish.DevToken)
+            .AllowHttpStatus("400,401,403")
+            .PostJsonAsync(body);
+
+        if (response.StatusCode is 400 or 401 or 403)
+        {
+            var errBody = await response.GetStringAsync();
+            throw new HttpRequestException(HttpRequestError.Unknown, ProberError.DivingFish(response.StatusCode, errBody));
+        }
+
+        // 单曲接口返回 { "<music_id>": [ 各难度成绩 ] }，只含已游玩难度，且不含昵称
+        var byMusic = await response.GetJsonAsync<Dictionary<string, List<SongScore>>>();
+
+        var scores = byMusic.Values
+            .SelectMany(x => x)
+            .GroupBy(x => x.LevelIdx)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        return (null, scores);
+    }
+
     protected virtual async Task<DivingFishDxRatingResponse> FetchScores(Message message, bool qqOnly)
     {
         var (username, qq) = Chunithm.DataFetcher.DataFetcher.AtOrSelf(message, qqOnly);

--- a/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/LxnsDataFetcher.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/DataFetcher/LxnsDataFetcher.cs
@@ -98,6 +98,78 @@ public class LxnsDataFetcher(SongDb<MaiMaiSong> songDb) : DataFetcher(songDb)
         return result;
     }
 
+    public override async Task<(string? Nickname, Dictionary<int, SongScore> Scores)> GetSongScore(Message message, MaiMaiSong song)
+    {
+        var (_, qq) = Shared.Chunithm.DataFetcher.DataFetcher.AtOrSelf(message, true);
+        var empty   = new Dictionary<int, SongScore>();
+
+        // 玩家信息：拿昵称 + friend_code（单曲成绩接口按 friend_code 查，dev token 即可，无需 OAuth）
+        var playerResponse = await $"{BaseUrl}/player/qq/{qq}"
+            .WithHeader("Authorization", ConfigurationManager.Configuration.Lxns.DevToken)
+            .AllowHttpStatus("400,401,403,404")
+            .GetAsync();
+
+        if (playerResponse.StatusCode is 400 or 401 or 403 or 404)
+        {
+            var body = await playerResponse.GetStringAsync();
+            throw new HttpRequestException(HttpRequestError.Unknown, ProberError.Lxns(playerResponse.StatusCode, body));
+        }
+
+        var playerJson = await playerResponse.GetStringAsync();
+        using var playerDoc = JsonDocument.Parse(playerJson);
+        var data       = playerDoc.RootElement.GetProperty("data");
+        var friendCode = data.GetProperty("friend_code").GetInt64().ToString();
+        var playerName = data.GetProperty("name").GetString() ?? "";
+
+        // 宴会场（id > 100000）落雪单曲接口无对应，直接返回空成绩（卡片显示未游玩）
+        if (song.Id > 100000) return (playerName, empty);
+
+        var isDx     = song.Id >= 10000;                       // DX 谱 id 形如 1xxxx
+        var rawId    = isDx ? (int)(song.Id - 10000) : (int)song.Id;
+        var songType = isDx ? "dx" : "standard";
+
+        var response = await $"{BaseUrl}/player/{friendCode}/bests?song_id={rawId}&song_type={songType}"
+            .WithHeader("Authorization", ConfigurationManager.Configuration.Lxns.DevToken)
+            .AllowHttpStatus("400,401,403,404")
+            .GetAsync();
+
+        if (response.StatusCode is 404) return (playerName, empty);   // 该曲无成绩
+        if (response.StatusCode is 400 or 401 or 403)
+        {
+            var body = await response.GetStringAsync();
+            throw new HttpRequestException(HttpRequestError.Unknown, ProberError.Lxns(response.StatusCode, body));
+        }
+
+        var jsonString = await response.GetStringAsync();
+        using var doc  = JsonDocument.Parse(jsonString);
+        var root       = doc.RootElement.TryGetProperty("data", out var d) ? d : doc.RootElement;
+
+        var scores = new Dictionary<int, SongScore>();
+        if (root.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var s in root.EnumerateArray())
+            {
+                var lvlIdx = s.TryGetProperty("level_index", out var li) ? li.GetInt32() : -1;
+                if (lvlIdx < 0) continue;
+
+                scores[lvlIdx] = new SongScore
+                {
+                    Id          = song.Id,
+                    LevelIdx    = lvlIdx,
+                    Level       = s.TryGetProperty("level", out var lv) ? lv.GetString() ?? "" : "",
+                    Achievement = s.TryGetProperty("achievements", out var ach) ? ach.GetDouble() : 0,
+                    DxScore     = s.TryGetProperty("dx_score", out var dx) ? dx.GetInt32() : 0,
+                    Fc          = s.TryGetProperty("fc", out var fc) ? fc.GetString() ?? "" : "",
+                    Fs          = s.TryGetProperty("fs", out var fs) ? fs.GetString() ?? "" : "",
+                    Type        = isDx ? "DX" : "SD",
+                    Constant    = lvlIdx < song.Constants.Count ? song.Constants[lvlIdx] : 0
+                };
+            }
+        }
+
+        return (playerName, scores);
+    }
+
     private async Task<DxRating> FetchScores(Message message)
     {
         var (_, qq) = Shared.Chunithm.DataFetcher.DataFetcher.AtOrSelf(message, true);

--- a/Marisa.Plugin.Shared/Util/WebApi.cs
+++ b/Marisa.Plugin.Shared/Util/WebApi.cs
@@ -189,6 +189,11 @@ public static class WebApi
         return await RenderUrl("/maimai/song?id=" + contextId);
     }
 
+    public static async Task<string> MaiMaiSongScore(Guid contextId)
+    {
+        return await RenderUrl("/maimai/song-score?id=" + contextId);
+    }
+
     public static async Task<string> OngekiSong(int id)
     {
         return await RenderUrl($"/ongeki/song/{id}");

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -718,19 +718,9 @@ public partial class MaiMaiDx
 
         var fetcher = GetDataFetcher(message);
         var self    = message with { Command = "".AsMemory() };
-        var rating  = await fetcher.GetRating(self);
 
-        Dictionary<(long Id, int LevelIdx), SongScore> scores;
-        try
-        {
-            scores = await fetcher.GetScores(self);
-        }
-        catch (NotSupportedException)
-        {
-            scores = rating.OldScores.Concat(rating.NewScores)
-                .GroupBy(s => (s.Id, s.LevelIdx))
-                .ToDictionary(g => g.Key, g => g.First());
-        }
+        // 只取这一首歌各难度的成绩：各查分器优先走自己的「单曲成绩接口」，避免拉取整个成绩表
+        var (nickname, scores) = await fetcher.GetSongScore(self, song);
 
         var context = new WebContext();
         context.Put("SongScore", new
@@ -742,11 +732,11 @@ public partial class MaiMaiDx
             },
             Player = new
             {
-                rating.Nickname, rating.Rating
+                Nickname = nickname ?? ""
             },
             Charts = song.Levels.Select((level, i) =>
             {
-                var played = scores.TryGetValue((song.Id, i), out var sc);
+                var played = scores.TryGetValue(i, out var sc);
                 return new
                 {
                     LevelIndex  = i,

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -706,6 +706,70 @@ public partial class MaiMaiDx
         return MarisaPluginTaskState.CompletedTask;
     }
 
+    /// <summary>
+    ///     单曲各难度成绩
+    /// </summary>
+    [MarisaPluginDoc("查询某首歌各个难度的个人成绩", "`歌名`/`别名`/`id`")]
+    [MarisaPluginCommand("info", "信息")]
+    private async Task<MarisaPluginTaskState> SongInfo(Message message)
+    {
+        var song = await SongDb.MultiPageSelectResult(SongDb.SearchSong(message.Command.Trim()), message, false, true);
+        if (song == null) return MarisaPluginTaskState.CompletedTask;
+
+        var fetcher = GetDataFetcher(message);
+        var self    = message with { Command = "".AsMemory() };
+        var rating  = await fetcher.GetRating(self);
+
+        Dictionary<(long Id, int LevelIdx), SongScore> scores;
+        try
+        {
+            scores = await fetcher.GetScores(self);
+        }
+        catch (NotSupportedException)
+        {
+            scores = rating.OldScores.Concat(rating.NewScores)
+                .GroupBy(s => (s.Id, s.LevelIdx))
+                .ToDictionary(g => g.Key, g => g.First());
+        }
+
+        var context = new WebContext();
+        context.Put("SongScore", new
+        {
+            Song = new
+            {
+                song.Id, song.Title, song.Type,
+                song.Info.Artist, song.Info.Genre, song.Info.Bpm, song.Info.From, song.Info.IsNew
+            },
+            Player = new
+            {
+                rating.Nickname, rating.Rating
+            },
+            Charts = song.Levels.Select((level, i) =>
+            {
+                var played = scores.TryGetValue((song.Id, i), out var sc);
+                return new
+                {
+                    LevelIndex  = i,
+                    Level       = level,
+                    Constant    = song.Constants[i],
+                    Charter     = song.Charters[i],
+                    MaxDx       = song.Charts[i].Notes.Sum() * 3,
+                    Played      = played,
+                    Achievement = played ? sc!.Achievement : (double?)null,
+                    Rank        = played ? sc!.Rank : null,
+                    Ra          = played ? sc!.Rating : (int?)null,
+                    Fc          = played ? sc!.Fc : null,
+                    Fs          = played ? sc!.Fs : null,
+                    DxScore     = played ? sc!.DxScore : (int?)null
+                };
+            }).ToList()
+        });
+
+        message.Reply(MessageDataImage.FromBase64(await WebApi.MaiMaiSongScore(context.Id)));
+
+        return MarisaPluginTaskState.CompletedTask;
+    }
+
     #endregion
 
     #region 锐评 / roast

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -709,7 +709,7 @@ public partial class MaiMaiDx
     /// <summary>
     ///     单曲各难度成绩
     /// </summary>
-    [MarisaPluginDoc("查询某首歌各个难度的个人成绩", "`歌名`/`别名`/`id`")]
+    [MarisaPluginDoc("查询某首歌各个难度的个人成绩", "`歌曲名` 或 `歌曲别名` 或 `歌曲id` 或表达式（例如`const>10`）")]
     [MarisaPluginCommand("info", "信息")]
     private async Task<MarisaPluginTaskState> SongInfo(Message message)
     {


### PR DESCRIPTION
## 这个 PR 做了什么

新增 `mai info <歌名/别名/id>` 命令：返回一张图，列出某首歌各个难度的个人成绩（达成率 / 评级 / 单谱 Ra / DX 分 / DX% / DX 星级 / FC·FS）。多结果时和 `mai song` 一样走对话选歌。

## 预览

真实数据（超神when 的「愛包ダンスホール」4 难度全 SSS+）：

![preview](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-song-info/song-info-preview.png)

## 机制

- **后端 `SongInfo` 命令**：选歌后取当前用户（或 `@` 对象）的 rating + 全谱成绩；落雪不支持 `GetScores` 时回退到 b50 数据（与 b35 同款回退），再投影成 per-chart payload 交前端渲染。
- **前端 `MaiSongScore.vue`**：表格式成绩卡，背景按最高难度上色；宴会场谱面特判（难度块显「宴」+ 等级、不显定数、Ra 留空、背景取宴色）。

## 说明

评级 / FC·FS 图标复用 repo 现有素材；预览图里用的是图标/评级牌高清升级（另一个 PR）那套素材，两者合并后即最终效果。
