### PR TITLE
fix(maimai): info 卡超长曲师名截断，不再顶到 PLAYER 昵称

### DIFF
--- a/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
@@ -232,7 +232,7 @@ watch(song, async () => {
 
 .cover-frame { padding: 5px; border-radius: 22px; background: rgba(255,255,255,0.78); box-shadow: 0 0 0 1px rgba(255,255,255,0.8), 0 8px 20px -12px rgba(0,0,0,0.5); }
 .mai-title { font-family: 'SEGA NewRodin','LXGW WenKai',sans-serif; font-weight: 700; line-height: 1; color: #fff; text-shadow: 0 2px 4px rgba(0,0,0,0.5); white-space: nowrap; overflow: hidden; padding-block: 6px 8px; margin-block: -6px -8px; }
-.artist-line { font-family: 'Torus','SEGA Maru Gothic','LXGW WenKai',sans-serif; font-size: 20px; font-weight: bold; color: rgba(255,255,255,0.8); margin-top: 12px; white-space: nowrap; overflow: hidden; }
+.artist-line { flex: 1; min-width: 0; font-family: 'Torus','SEGA Maru Gothic','LXGW WenKai',sans-serif; font-size: 20px; font-weight: bold; color: rgba(255,255,255,0.8); margin-top: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .player-inline { font-family: 'Torus','Microsoft YaHei',sans-serif; font-weight: bold; font-size: 21px; color: #fff; text-shadow: 0 2px 4px rgba(0,0,0,0.5); white-space: nowrap; }
 .player-label { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 12px; letter-spacing: 0.18em; color: rgba(255,255,255,0.45); }
 


### PR DESCRIPTION
`mai info` 单曲成绩卡里，曲师名过长时（例如 id 11837「シカ色デイズ」曲师有 67 字）会一直顶到右侧 `PLAYER <昵称>`、看起来像被昵称盖住；没有 PLAYER 时也会顶到卡片右缘、硬截断无省略号。

`.artist-line` 加 `flex: 1` + `min-width: 0` + `text-overflow: ellipsis`：曲师名在接近 PLAYER（或无 PLAYER 时接近卡片右缘）处以「…」截断，PLAYER 昵称完整正常显示。短曲师名布局不变。

**修复前**（硬截断、顶到 PLAYER）：

![before](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-artist-ellipsis/artist-ellipsis-before.png)

**修复后**（「…」截断，PLAYER 正常）：

![after](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-artist-ellipsis/artist-ellipsis-after.png)

**无 PLAYER 时超长曲师名同样以「…」截断：**

![after-nonick](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-artist-ellipsis/artist-ellipsis-after-nonick.png)
