### PR TITLE
fix(maimai): 完成表带等级/定数时查全难度，不再被版本代字限成仅 MASTER

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -741,7 +741,13 @@ public static class PlateData
 
         if (diffAt < 0)
         {
-            if (selectors.Any(s => s is Selector.Revival))
+            if (selectors.Any(s => s is Selector.Level or Selector.Constant))
+            {
+                // 指定了等级/定数：该等级/定数的谱面可能分布在任意难度（如 6+ 只在 BASIC/ADVANCED，
+                // 13+ 在 EXPERT/MASTER/Re:MASTER），全难度都查——此时版本代字的「仅 MASTER」默认不适用。
+                levelIdxes = [0, 1, 2, 3, 4];
+            }
+            else if (selectors.Any(s => s is Selector.Revival))
             {
                 // 复活曲按类别处理：默认 MASTER + Re:MASTER（即便同时带版本代字也不用版本牌的单 MASTER 默认）。
                 levelIdxes = DefaultLevelIdxes;

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -654,25 +654,25 @@ public class MaiMaiDxPlateDataTest
     [Test]
     public void ParsesLevelLabel()
     {
-        // "14+神完成表" → Selector.Level("14+") + Fc=AP + 默认难度 [3, 4]
+        // "14+神完成表" → Selector.Level("14+") + Fc=AP + 指定等级 → 全难度 [0,1,2,3,4]
         var q = MustParse("14+神完成表");
         Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Level>());
         Assert.That(((PlateData.Selector.Level)q.Selectors.Single()).Label, Is.EqualTo("14+"));
         Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.Fc));
         Assert.That(q.Threshold.Level, Is.EqualTo(3));
-        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {0, 1, 2, 3, 4}));
     }
 
     [Test]
     public void ParsesConstant()
     {
-        // "14.9FDX完成表" → Selector.Constant(14.9) + Fs=FDX + 默认难度 [3, 4]
+        // "14.9FDX完成表" → Selector.Constant(14.9) + Fs=FDX + 指定定数 → 全难度 [0,1,2,3,4]
         var q = MustParse("14.9FDX完成表");
         Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Constant>());
         Assert.That(((PlateData.Selector.Constant)q.Selectors.Single()).Value, Is.EqualTo(14.9).Within(0.001));
         Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.Fs));
         Assert.That(q.Threshold.Level, Is.EqualTo(4));
-        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3, 4}));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {0, 1, 2, 3, 4}));
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -682,12 +682,22 @@ public class MaiMaiDxPlateDataTest
     [Test]
     public void MultiSelector_PlateAndLevel()
     {
-        // "镜代13+AP完成表" → Plate(镜) ∩ Level("13+") + Fc=AP
+        // "镜代13+AP完成表" → Plate(镜) ∩ Level("13+") + Fc=AP；指定等级 → 全难度 [0,1,2,3,4]
         var q = MustParse("镜代13+AP完成表");
         Assert.That(q.Selectors, Has.Exactly(2).Items);
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {0, 1, 2, 3, 4}));
+    }
+
+    [Test]
+    public void MultiSelector_PlateLevelExplicitDifficulty()
+    {
+        // 显式写难度时以难度 token 为准：镜代 紫谱(MASTER) 13+ → 仅 [MASTER]，覆盖「含等级 → 全难度」默认
+        var q = MustParse("镜代紫谱13+完成表");
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
         Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
     }
 
@@ -706,13 +716,13 @@ public class MaiMaiDxPlateDataTest
     [Test]
     public void MultiSelector_PlateAndConstant()
     {
-        // "镜代14.6神完成表" → Plate(镜) ∩ Constant(14.6) + AP
+        // "镜代14.6神完成表" → Plate(镜) ∩ Constant(14.6) + AP；指定定数 → 全难度 [0,1,2,3,4]
         var q = MustParse("镜代14.6神完成表");
         Assert.That(q.Selectors, Has.Exactly(2).Items);
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Constant>().Single().Value, Is.EqualTo(14.6).Within(0.001));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
-        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {0, 1, 2, 3, 4}));
     }
 
     [Test]
@@ -744,7 +754,7 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Genre>().Single().FullName, Is.EqualTo("niconico & VOCALOID"));
-        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {0, 1, 2, 3, 4}));   // 含 Level → 全难度
     }
 
     [TestCase("镜代13+AP完成表")]
@@ -760,7 +770,7 @@ public class MaiMaiDxPlateDataTest
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
         Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP"));
-        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {0, 1, 2, 3, 4}));   // 含 Level → 全难度
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -873,14 +883,14 @@ public class MaiMaiDxPlateDataTest
     [Test]
     public void DxScoreStar_WithLevel_MultiSelector()
     {
-        // multi-selector: Plate(镜) ∩ Level("14+") + DxScore=5
+        // multi-selector: Plate(镜) ∩ Level("14+") + DxScore=5；指定等级 → 全难度 [0,1,2,3,4]
         var q = MustParse("镜代14+5星完成表");
         Assert.That(q.Selectors, Has.Exactly(2).Items);
         Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("镜"));
         Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("14+"));
         Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.DxScore));
         Assert.That(q.Threshold.Level, Is.EqualTo(5));
-        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {3}));
+        Assert.That(q.LevelIdxes, Is.EquivalentTo(new[] {0, 1, 2, 3, 4}));
     }
 
     [Test]


### PR DESCRIPTION
## 背景

PR #63 调整了完成表默认难度：含版本代字时，未显式指定难度默认只查 MASTER（`DefaultPlateLevelIdxes = [3]`）。这对「彩将完成表」这类「查某一代正式 plate 进度」是对的。

但当查询**同时带等级或定数**时（如「彩代13+完成表」），版本代字的「仅 MASTER」默认仍然生效，把非 MASTER 的该等级/定数谱面排除了：

- 「彩代13+完成表」只出 MASTER 13+，漏掉 13+ 的 EXPERT / Re:MASTER；
- 纯等级查询也一样：「13+完成表」默认 `[3,4]`，同样漏掉 EXPERT；
- 极端例子：「彩代6+完成表」按旧逻辑**什么都查不到**（6+ 根本没有 MASTER/Re:MASTER）。

用户查「等级/定数完成表」时的预期是「该等级/定数的**所有谱面**」，不分难度。

## 变更

`PlateData.TryParse` 未显式指定难度（`diffAt < 0`）时的默认难度决策，新增一个最高优先级分支：

- **选择条件含 `Level` 或 `Constant` → 默认查全难度 `[0,1,2,3,4]`**，由等级/定数 selector 自然收窄到匹配谱面（6+ 落在 BASIC/ADVANCED，13+ 落在 EXPERT/MASTER/Re:MASTER）。
- 版本代字的「仅 MASTER」默认，仅在**不带**等级/定数时生效（「彩将完成表」不变）。
- 显式写难度仍以难度 token 为准（「镜代紫谱13+完成表」→ 仅 MASTER）。

## 行为对照

| 指令 | 改前 | 改后 |
|------|------|------|
| 彩将完成表（版本+档位） | `[3]` | `[3]`（不变） |
| 13+完成表（纯等级） | `[3,4]`（漏 EXPERT） | `[0,1,2,3,4]` |
| 彩代13+完成表（版本+等级） | `[3]`（只 MASTER） | `[0,1,2,3,4]` |
| 彩代6+完成表 | `[3]`（查不到） | `[0,1,2,3,4]`（→ BASIC/ADVANCED） |
| 定数13.5 / 彩代13.5 完成表 | `[3,4]` / `[3]` | `[0,1,2,3,4]` |
| 镜代紫谱13+完成表（显式难度） | `[3]` | `[3]`（不变） |

## 测试

更新受此行为影响的 7 条断言（等级/定数相关），并补 1 条显式难度覆盖用例。`MaiMaiDxPlateDataTest` 全部通过（217）。选歌层 `SelectCharts` 是遍历歌曲已有谱面再按难度过滤，`[0,1,2,3,4]` 对缺 Re:MASTER 的歌也不会越界。
