### PR TITLE
refactor(maimai): 抽取 mai song / info 卡片公用常量与样式

### DIFF
--- a/Marisa.Frontend/src/assets/css/maimai/song_card.pcss
+++ b/Marisa.Frontend/src/assets/css/maimai/song_card.pcss
@@ -1,0 +1,31 @@
+/* MaiSong / MaiSongScore 卡片公用样式。
+   两卡尺寸体系各自独立，此处只放公用颜色变量与取值完全一致的基础类；
+   各卡通过 <style scoped src> 引入，作用域互不泄漏。 */
+
+.mai-card {
+    color: #fff;
+    background-color: #0e0418;
+
+    /* 顶栏 pill / chip 配色 */
+    --pill-bg: rgba(35, 37, 69, 0.82);
+    --pill-shadow: 0 4px 12px rgba(35, 37, 69, 0.25);
+    --chip-ink: #454867;
+    --chip-bg: rgba(255, 255, 255, 0.72);
+    --chip-ring: 0 0 0 1px rgba(255, 255, 255, 0.85);
+    --new-chip-bg: linear-gradient(135deg, #ffb02c 0%, #ff5a66 100%);
+    --new-chip-shadow: 0 3px 10px rgba(255, 90, 102, 0.45);
+}
+
+.mai-card img {
+    max-width: none;
+}
+
+.font-torus {
+    font-family: 'Torus', 'LXGW WenKai', sans-serif;
+    font-variant-numeric: tabular-nums;
+}
+
+.font-rodin {
+    font-family: 'SEGA NewRodin', 'LXGW WenKai', sans-serif;
+    font-weight: 900;
+}

--- a/Marisa.Frontend/src/components/maimai/MaiSong.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiSong.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="song" class="mai-song relative w-[1240px] overflow-hidden antialiased"
+    <div v-if="song" class="mai-song mai-card relative w-[1240px] overflow-hidden antialiased"
          :class="{ 'is-utage': isUtage }" :style="rootStyle">
         <!-- 机台斜纹 + 难度主题色辉光 -->
         <div class="absolute inset-0 pointer-events-none stripe-layer"></div>
@@ -139,6 +139,11 @@ import {computed, nextTick, ref, watch, watchEffect} from 'vue'
 import axios from 'axios'
 import {useRoute} from 'vue-router'
 import {context_get} from '@/GlobalVars'
+import {
+    DIFF_NAMES, DIFF_COLORS, UTAGE, isUtageId, themeMainOf, genreDisplayOf,
+    VERSION_CODE, LOGO_BBOX_LEFT, versionLogoSrc, typeBadgeSrc,
+    coverSrcOf, COVER_FALLBACK, bgKeyOf, cardBackground,
+} from '@/components/maimai/utils/song_card'
 
 interface Chart {
     Level: string
@@ -160,16 +165,9 @@ interface Song {
     Charts: Chart[]
 }
 
-const DIFF_NAMES  = ['BASIC', 'ADVANCED', 'EXPERT', 'MASTER', 'Re:MASTER']
-const DIFF_COLORS = ['#52e72b', '#ffa801', '#ff5a66', '#c64fe4', '#dbaaff']
-const DIFF = [
-    {name: 'BASIC',     main: '#52e72b', deep: '#2f9e12'},
-    {name: 'ADVANCED',  main: '#ffa801', deep: '#c77f00'},
-    {name: 'EXPERT',    main: '#ff5a66', deep: '#e02b3a'},
-    {name: 'MASTER',    main: '#c64fe4', deep: '#9a2dbb'},
-    {name: 'Re:MASTER', main: '#dbaaff', deep: '#8e4ed1'},
-] as const
-const UTAGE = {name: '宴', main: '#f73ee0', deep: '#c41fb4'} as const
+// 难度深色（描边/阴影用），main 色沿用公用 DIFF_COLORS
+const DIFF_DEEP = ['#2f9e12', '#c77f00', '#e02b3a', '#9a2dbb', '#8e4ed1']
+const DIFF = DIFF_NAMES.map((name, i) => ({name, main: DIFF_COLORS[i], deep: DIFF_DEEP[i]}))
 
 const route = useRoute()
 const song  = ref<Song | null>(null)
@@ -178,11 +176,11 @@ axios.get(context_get, {params: {id: route.query.id, name: 'SongData'}}).then(re
     song.value = res.data
 })
 
-const isUtage = computed(() => (song.value?.Id ?? 0) > 100000)
+const isUtage = computed(() => isUtageId(song.value?.Id ?? 0))
 const topIdx  = computed(() => (song.value?.Charts.length ?? 1) - 1)
 
 const theme = computed(() => {
-    const main = isUtage.value ? UTAGE.main : DIFF_COLORS[topIdx.value] ?? '#999'
+    const main = themeMainOf(topIdx.value, isUtage.value)
     const onMain = !isUtage.value && topIdx.value === 4 ? '#4a1d78' : '#ffffff'
     return {main, onMain}
 })
@@ -191,47 +189,12 @@ function DiffOf(i: number) {
     return isUtage.value ? UTAGE : DIFF[Math.min(i, DIFF.length - 1)]
 }
 
-// genre：简中类别名映射成 NewRodin 字库覆盖的日/西文
-const GENRE_MAP: Record<string, string> = {
-    '流行&动漫':          'POPS&アニメ',
-    '舞萌':               'maimai',
-    '其他游戏':           'ゲーム&バラエティ',
-    '音击&中二节奏':      'オンゲキ&CHUNITHM',
-    '东方Project':        '東方Project',
-}
-const genreDisplay = computed(() => GENRE_MAP[song.value?.Genre ?? ''] ?? song.value?.Genre ?? '')
+const genreDisplay = computed(() => genreDisplayOf(song.value?.Genre))
 
-// 版本 logo：diving-fish from 字符串 → 游戏内版本标题素材编号。
-// DX 时代本传与 PLUS 共用一张（国服 from 已并代）；特例 Splash 用 214
-const VERSION_CODE: Record<string, number> = {
-    'maimai': 100,                  'maimai PLUS': 110,
-    'maimai GreeN': 120,            'maimai GreeN PLUS': 130,
-    'maimai ORANGE': 140,           'maimai ORANGE PLUS': 150,
-    'maimai PiNK': 160,             'maimai PiNK PLUS': 170,
-    'maimai MURASAKi': 180,         'maimai MURASAKi PLUS': 185,
-    'maimai MiLK': 190,             'MiLK PLUS': 195,
-    'maimai FiNALE': 199,
-    'maimai でらっくす': 200,        'maimai でらっくす Splash': 214,
-    'maimai でらっくす UNiVERSE': 220, 'maimai でらっくす FESTiVAL': 230,
-    'maimai でらっくす BUDDiES': 240, 'maimai でらっくす PRiSM': 250,
-    'maimai でらっくす PRiSM PLUS': 255,
-}
+const versionLogo = computed(() => versionLogoSrc(song.value?.From))
 
-const versionLogo = computed(() => {
-    const code = VERSION_CODE[song.value?.From ?? '']
-    return code
-        ? `/assets/maimai/version/Ver${code}.png`
-        : '/assets/maimai/version/maimaidx.png'
-})
-
-// 版本 logo 视觉左对齐：素材内部左侧透明留白（像素实测 alpha bbox）按显示倍率补偿，
+// 版本 logo 视觉左对齐：素材左侧透明留白按显示倍率（68px 高 / 素材 160px）补偿，
 // 使可见字形左缘 = 标题左缘 92px
-const LOGO_BBOX_LEFT: Record<number, number> = {
-    100: 22, 110: 21, 120: 20, 130: 20, 140: 20, 150: 14, 160: 21, 170: 21,
-    180: 28, 185: 19, 190: 21, 195: 32, 199: 24, 200: 49, 210: 15, 214: 54,
-    215: 10, 220: 55, 225: 24, 230: 50, 235: 78, 240: 78, 245: 46, 250: 79, 255: 50,
-}
-
 const logoStyle = computed(() => {
     const code = VERSION_CODE[song.value?.From ?? '']
     const trim = code ? (LOGO_BBOX_LEFT[code] ?? 0) * (68 / 160) : 5 * (68 / 292)
@@ -254,17 +217,15 @@ async function FitHeader() {
     }
 }
 
-const typeBadge = computed(() => song.value?.Type === 'DX'
-    ? '/assets/maimai/pic/mode_dx.png'
-    : '/assets/maimai/pic/mode_standard.png')
+const typeBadge = computed(() => typeBadgeSrc(song.value?.Type))
 
 const coverSrc = ref('')
 watchEffect(() => {
-    if (song.value) coverSrc.value = `/assets/maimai/cover/${song.value.Id}.png`
+    if (song.value) coverSrc.value = coverSrcOf(song.value.Id)
 })
 
 function OnCoverError() {
-    coverSrc.value = '/assets/maimai/cover/0.png'
+    coverSrc.value = COVER_FALLBACK
 }
 
 // 标题真实测宽 auto-shrink
@@ -396,24 +357,10 @@ const starInfos = computed(() => {
     return charts.length === 5 ? [starOf(3), starOf(4)] : [starOf(charts.length - 1)]
 })
 
-// ── 难度主题暗色背景 ──
-const DIFF_KEYS = ['BSC', 'ADV', 'EXP', 'MST', 'MST_Re']
-const BG_GRADIENTS: Record<string, [string, string]> = {
-    BSC:    ['#123a0a', '#04120a'],
-    ADV:    ['#3a2706', '#140d03'],
-    EXP:    ['#3d0d14', '#16060a'],
-    MST:    ['#2c0b44', '#0e0418'],
-    MST_Re: ['#33204f', '#120a20'],
-    UTG:    ['#3d0c35', '#150412'],
-    DMY:    ['#222633', '#0a0c12'],
-}
+// ── 难度主题暗色背景（公用 bgKeyOf / cardBackground）──
+const topKey = computed(() => bgKeyOf(topIdx.value, isUtage.value))
 
-const topKey = computed(() => isUtage.value ? 'UTG' : DIFF_KEYS[topIdx.value] ?? 'DMY')
-
-const rootStyle = computed(() => {
-    const [c1, c2] = BG_GRADIENTS[topKey.value] ?? BG_GRADIENTS['DMY']
-    return {background: `linear-gradient(168deg, ${c1} 0%, ${c2} 62%, #060309 100%)`}
-})
+const rootStyle = computed(() => cardBackground(topKey.value))
 
 const glowStyle = computed(() => ({
     background: `radial-gradient(620px 620px at 24% 30%, ${theme.value.main}30 0%, transparent 70%),
@@ -432,7 +379,7 @@ function starBlockStyle(i: number) {
 
 // 行主题色：宴谱粉、普通难度按 index
 function rowColor(i: number) {
-    return isUtage.value ? '#f73ee0' : DIFF_COLORS[i] ?? '#999'
+    return themeMainOf(i, isUtage.value)
 }
 
 function rowStyle(i: number) {
@@ -535,16 +482,9 @@ function break50Loss(chart: Chart): string {
 
 </script>
 
+<style scoped lang="postcss" src="@/assets/css/maimai/song_card.pcss"/>
+
 <style scoped lang="postcss">
-.mai-song {
-    color: #fff;
-    background-color: #0e0418;
-}
-
-.mai-song img {
-    max-width: none;
-}
-
 /* 机台斜纹 */
 .stripe-layer {
     background: repeating-linear-gradient(
@@ -561,10 +501,10 @@ function break50Loss(chart: Chart): string {
     font-size: 22px;
     letter-spacing: 0.08em;
     color: #fff;
-    background: rgba(35, 37, 69, 0.82);
+    background: var(--pill-bg);
     padding: 5px 18px;
     border-radius: 9999px;
-    box-shadow: 0 4px 12px rgba(35, 37, 69, 0.25);
+    box-shadow: var(--pill-shadow);
 }
 
 .bpm-pill {
@@ -572,10 +512,10 @@ function break50Loss(chart: Chart): string {
     align-items: center;
     gap: 9px;
     color: #fff;
-    background: rgba(35, 37, 69, 0.82);
+    background: var(--pill-bg);
     padding: 5px 18px 5px 14px;
     border-radius: 9999px;
-    box-shadow: 0 4px 12px rgba(35, 37, 69, 0.25);
+    box-shadow: var(--pill-shadow);
 }
 
 .bpm-num {
@@ -606,8 +546,8 @@ function break50Loss(chart: Chart): string {
     color: #fff;
     padding: 5px 14px 4px 16px;
     border-radius: 9999px;
-    background: linear-gradient(135deg, #ffb02c 0%, #ff5a66 100%);
-    box-shadow: 0 3px 10px rgba(255, 90, 102, 0.45);
+    background: var(--new-chip-bg);
+    box-shadow: var(--new-chip-shadow);
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 }
 
@@ -616,11 +556,11 @@ function break50Loss(chart: Chart): string {
     font-weight: bold;
     font-size: 17px;
     letter-spacing: 0.05em;
-    color: #454867;
+    color: var(--chip-ink);
     padding: 5px 16px;
     border-radius: 9999px;
-    background: rgba(255, 255, 255, 0.72);
-    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.85),
+    background: var(--chip-bg);
+    box-shadow: var(--chip-ring),
                 0 3px 10px rgba(90, 40, 120, 0.15);
     backdrop-filter: blur(8px);
 }
@@ -662,16 +602,6 @@ function break50Loss(chart: Chart): string {
     border-radius: 9999px;
     padding: 4px 22px;
     box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.8), 0 4px 12px rgba(90, 40, 120, 0.25);
-}
-
-.font-torus {
-    font-family: 'Torus', 'LXGW WenKai', sans-serif;
-    font-variant-numeric: tabular-nums;
-}
-
-.font-rodin {
-    font-family: 'SEGA NewRodin', 'LXGW WenKai', sans-serif;
-    font-weight: 900;
 }
 
 /* 行头双层 chip：左段难度色放难度名，右段淡化同色放等级（定数已移到徽章）。

--- a/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiSongScore.vue
@@ -1,5 +1,5 @@
 <template>
-    <div v-if="song" class="mai-score relative w-[840px] overflow-hidden antialiased" :style="rootStyle">
+    <div v-if="song" class="mai-score mai-card relative w-[840px] overflow-hidden antialiased" :style="rootStyle">
         <div class="absolute inset-0 pointer-events-none stripe-layer"></div>
         <div class="absolute inset-0 pointer-events-none" :style="glowStyle"></div>
 
@@ -91,6 +91,11 @@ import axios from 'axios'
 import {useRoute} from 'vue-router'
 import {context_get} from '@/GlobalVars'
 import {dxScoreStar} from '@/components/maimai/utils/ordinal'
+import {
+    DIFF_NAMES, DIFF_COLORS, UTAGE, isUtageId, themeMainOf, genreDisplayOf,
+    VERSION_CODE, LOGO_BBOX_LEFT, versionLogoSrc, typeBadgeSrc,
+    coverSrcOf, COVER_FALLBACK, bgKeyOf, cardBackground,
+} from '@/components/maimai/utils/song_card'
 
 interface ChartScore {
     LevelIndex: number; Level: string; Constant: number; Charter: string; MaxDx: number
@@ -109,16 +114,14 @@ const data  = ref<ScoreData | null>(null)
 const song   = computed(() => data.value?.Song ?? null)
 const player = computed(() => data.value?.Player ?? {Nickname: ''})
 const charts = computed(() => data.value?.Charts ?? [])
-const isUtage = computed(() => (song.value?.Id ?? 0) > 100000)
+const isUtage = computed(() => isUtageId(song.value?.Id ?? 0))
 
 axios.get(context_get, {params: {id: route.query.id, name: 'SongScore'}}).then(res => {
     data.value = typeof res.data === 'string' ? JSON.parse(res.data) : res.data
 })
 
-const DIFF_NAMES  = ['BASIC', 'ADVANCED', 'EXPERT', 'MASTER', 'Re:MASTER']
-const DIFF_COLORS = ['#52e72b', '#ffa801', '#ff5a66', '#c64fe4', '#dbaaff']
 function diffName(i: number) { return isUtage.value ? '宴' : DIFF_NAMES[Math.min(i, 4)] }
-function diffColor(i: number) { return isUtage.value ? '#f73ee0' : DIFF_COLORS[Math.min(i, 4)] }
+function diffColor(i: number) { return isUtage.value ? UTAGE.main : DIFF_COLORS[Math.min(i, 4)] }
 
 const PIC = '/assets/maimai/pic'
 function rankIcon(c: ChartScore) { return `${PIC}/rank_${c.Rank}.png` }
@@ -136,37 +139,16 @@ const MARK_BASE = 29, RANK_BASE = 32
 function markStyle(_name: string | null) { return {height: MARK_BASE + 'px'} }
 function rankStyle(_c: ChartScore) { return {height: RANK_BASE + 'px'} }
 
-const typeBadge = computed(() => song.value?.Type === 'DX'
-    ? `${PIC}/mode_dx.png` : `${PIC}/mode_standard.png`)
+const typeBadge = computed(() => typeBadgeSrc(song.value?.Type))
 
 const coverSrc = ref('')
-watch(song, s => { if (s) coverSrc.value = `/assets/maimai/cover/${s.Id}.png` }, {immediate: true})
-function onCoverErr() { coverSrc.value = '/assets/maimai/cover/0.png' }
+watch(song, s => { if (s) coverSrc.value = coverSrcOf(s.Id) }, {immediate: true})
+function onCoverErr() { coverSrc.value = COVER_FALLBACK }
 
-// genre 简中 → NewRodin 覆盖的日/西文（同 MaiSong）
-const GENRE_MAP: Record<string, string> = {
-    '流行&动漫': 'POPS&アニメ', '舞萌': 'maimai', '其他游戏': 'ゲーム&バラエティ',
-    '音击&中二节奏': 'オンゲキ&CHUNITHM', '东方Project': '東方Project',
-}
-const genreDisplay = computed(() => GENRE_MAP[song.value?.Genre ?? ''] ?? song.value?.Genre ?? '')
+const genreDisplay = computed(() => genreDisplayOf(song.value?.Genre))
 
-// 版本 logo（同 MaiSong）
-const VERSION_CODE: Record<string, number> = {
-    'maimai': 100, 'maimai PLUS': 110, 'maimai GreeN': 120, 'maimai GreeN PLUS': 130,
-    'maimai ORANGE': 140, 'maimai ORANGE PLUS': 150, 'maimai PiNK': 160, 'maimai PiNK PLUS': 170,
-    'maimai MURASAKi': 180, 'maimai MURASAKi PLUS': 185, 'maimai MiLK': 190, 'MiLK PLUS': 195,
-    'maimai FiNALE': 199, 'maimai でらっくす': 200, 'maimai でらっくす Splash': 214,
-    'maimai でらっくす UNiVERSE': 220, 'maimai でらっくす FESTiVAL': 230, 'maimai でらっくす BUDDiES': 240,
-    'maimai でらっくす PRiSM': 250, 'maimai でらっくす PRiSM PLUS': 255,
-}
-const LOGO_BBOX_LEFT: Record<number, number> = {
-    100: 22, 110: 21, 120: 20, 130: 20, 140: 20, 150: 14, 160: 21, 170: 21, 180: 28, 185: 19,
-    190: 21, 195: 32, 199: 24, 200: 49, 214: 54, 220: 55, 230: 50, 240: 78, 250: 79, 255: 50,
-}
-const versionLogo = computed(() => {
-    const code = VERSION_CODE[song.value?.From ?? '']
-    return code ? `/assets/maimai/version/Ver${code}.png` : '/assets/maimai/version/maimaidx.png'
-})
+const versionLogo = computed(() => versionLogoSrc(song.value?.From))
+// 版本 logo 视觉左对齐（60px 高 / 素材 160px）
 const logoStyle = computed(() => {
     const code = VERSION_CODE[song.value?.From ?? '']
     const trim = code ? (LOGO_BBOX_LEFT[code] ?? 0) * (60 / 160) : 0
@@ -175,17 +157,9 @@ const logoStyle = computed(() => {
 
 // 背景按最高难度上色（有 Re:MASTER 取白谱档、宴会场取宴），跟 mai song 一致
 const topIdx = computed(() => Math.max(0, charts.value.length - 1))
-const DIFF_KEYS = ['BSC', 'ADV', 'EXP', 'MST', 'MST_Re']
-const BG_GRADIENTS: Record<string, [string, string]> = {
-    BSC: ['#123a0a', '#04120a'], ADV: ['#3a2706', '#140d03'], EXP: ['#3d0d14', '#16060a'],
-    MST: ['#2c0b44', '#0e0418'], MST_Re: ['#33204f', '#120a20'], UTG: ['#3d0c35', '#150412'], DMY: ['#222633', '#0a0c12'],
-}
-const topKey = computed(() => isUtage.value ? 'UTG' : DIFF_KEYS[topIdx.value] ?? 'DMY')
-const themeMain = computed(() => isUtage.value ? '#f73ee0' : DIFF_COLORS[topIdx.value] ?? '#999')
-const rootStyle = computed(() => {
-    const [c1, c2] = BG_GRADIENTS[topKey.value] ?? BG_GRADIENTS['DMY']
-    return {background: `linear-gradient(168deg, ${c1} 0%, ${c2} 62%, #060309 100%)`}
-})
+const topKey = computed(() => bgKeyOf(topIdx.value, isUtage.value))
+const themeMain = computed(() => themeMainOf(topIdx.value, isUtage.value))
+const rootStyle = computed(() => cardBackground(topKey.value))
 const glowStyle = computed(() => ({
     background: `radial-gradient(720px 520px at 18% 8%, ${themeMain.value}2e 0%, transparent 70%),
                  radial-gradient(560px 480px at 92% 4%, ${themeMain.value}1c 0%, transparent 70%)`,
@@ -217,18 +191,18 @@ watch(song, async () => {
 }, {flush: 'post'})
 </script>
 
+<style scoped lang="postcss" src="@/assets/css/maimai/song_card.pcss"/>
+
 <style scoped lang="postcss">
-.mai-score { color: #fff; background-color: #0e0418; }
-.mai-score img { max-width: none; }
 .stripe-layer { background: repeating-linear-gradient(-38deg, rgba(255,255,255,0.025) 0 3px, transparent 3px 26px); }
 
 /* top meta pills */
-.id-pill, .bpm-pill { font-family: 'Torus', sans-serif; color: #fff; background: rgba(35,37,69,0.82); border-radius: 9999px; box-shadow: 0 4px 12px rgba(35,37,69,0.25); }
+.id-pill, .bpm-pill { font-family: 'Torus', sans-serif; color: #fff; background: var(--pill-bg); border-radius: 9999px; box-shadow: var(--pill-shadow); }
 .id-pill { font-weight: bold; font-size: 16px; letter-spacing: 0.06em; padding: 3px 12px; }
 .bpm-pill { display: inline-flex; align-items: center; gap: 6px; padding: 3px 12px 3px 10px; }
 .bpm-num { font-weight: bold; font-size: 16px; }
-.meta-chip { font-family: 'SEGA NewRodin','LXGW WenKai',sans-serif; font-weight: bold; font-size: 14px; color: #454867; padding: 4px 12px; border-radius: 9999px; background: rgba(255,255,255,0.72); box-shadow: 0 0 0 1px rgba(255,255,255,0.85); white-space: nowrap; }
-.new-chip { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 12px; letter-spacing: 0.18em; padding: 4px 11px 3px 13px; border-radius: 9999px; background: linear-gradient(135deg,#ffb02c,#ff5a66); box-shadow: 0 3px 10px rgba(255,90,102,0.45); }
+.meta-chip { font-family: 'SEGA NewRodin','LXGW WenKai',sans-serif; font-weight: bold; font-size: 14px; color: var(--chip-ink); padding: 4px 12px; border-radius: 9999px; background: var(--chip-bg); box-shadow: var(--chip-ring); white-space: nowrap; }
+.new-chip { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 12px; letter-spacing: 0.18em; padding: 4px 11px 3px 13px; border-radius: 9999px; background: var(--new-chip-bg); box-shadow: var(--new-chip-shadow); }
 
 .cover-frame { padding: 5px; border-radius: 22px; background: rgba(255,255,255,0.78); box-shadow: 0 0 0 1px rgba(255,255,255,0.8), 0 8px 20px -12px rgba(0,0,0,0.5); }
 .mai-title { font-family: 'SEGA NewRodin','LXGW WenKai',sans-serif; font-weight: 700; line-height: 1; color: #fff; text-shadow: 0 2px 4px rgba(0,0,0,0.5); white-space: nowrap; overflow: hidden; padding-block: 6px 8px; margin-block: -6px -8px; }
@@ -237,8 +211,6 @@ watch(song, async () => {
 .player-label { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 12px; letter-spacing: 0.18em; color: rgba(255,255,255,0.45); }
 
 .section-tag { font-family: 'Microsoft YaHei',sans-serif; font-weight: bold; font-size: 21px; letter-spacing: 0.1em; border-radius: 9999px; padding: 4px 20px; background: #c64fe4; color: #fff; box-shadow: 0 0 0 2px rgba(255,255,255,0.8); white-space: nowrap; }
-.font-torus { font-family: 'Torus','LXGW WenKai',sans-serif; font-variant-numeric: tabular-nums; }
-.font-rodin { font-family: 'SEGA NewRodin','LXGW WenKai',sans-serif; font-weight: 900; }
 .footer-text { font-family: 'Torus',sans-serif; font-weight: bold; font-size: 12px; letter-spacing: 0.4em; color: rgba(255,255,255,0.45); }
 
 /* shared row text */

--- a/Marisa.Frontend/src/components/maimai/utils/song_card.ts
+++ b/Marisa.Frontend/src/components/maimai/utils/song_card.ts
@@ -1,0 +1,101 @@
+import {maimai_levelColors} from '@/GlobalVars'
+
+/**
+ * MaiSong（歌曲信息卡）与 MaiSongScore（单曲成绩卡）的公用常量与工具。
+ * 两卡布局尺寸各自独立，此处只放取值必须一致的部分：难度名色、类别显示、
+ * 版本 logo 素材映射、类型章、曲绘路径与难度主题背景。
+ */
+
+export const DIFF_NAMES = ['BASIC', 'ADVANCED', 'EXPERT', 'MASTER', 'Re:MASTER']
+
+/** 难度色与 b50 ScoreCard 同源（GlobalVars.maimai_levelColors），改一处全部生效。 */
+export const DIFF_COLORS = maimai_levelColors
+
+export const UTAGE = {name: '宴', main: '#f73ee0', deep: '#c41fb4'} as const
+
+export function isUtageId(id: number) {
+    return id > 100000
+}
+
+/** 卡片主题色：宴谱粉、普通谱按难度 index 取色。 */
+export function themeMainOf(idx: number, isUtage: boolean) {
+    return isUtage ? UTAGE.main : DIFF_COLORS[idx] ?? '#999'
+}
+
+// genre：简中类别名映射成 NewRodin 字库覆盖的日/西文
+const GENRE_MAP: Record<string, string> = {
+    '流行&动漫':          'POPS&アニメ',
+    '舞萌':               'maimai',
+    '其他游戏':           'ゲーム&バラエティ',
+    '音击&中二节奏':      'オンゲキ&CHUNITHM',
+    '东方Project':        '東方Project',
+}
+
+export function genreDisplayOf(genre: string | undefined) {
+    return GENRE_MAP[genre ?? ''] ?? genre ?? ''
+}
+
+// 版本 logo：diving-fish from 字符串 → 游戏内版本标题素材编号。
+// DX 时代本传与 PLUS 共用一张（国服 from 已并代）；特例 Splash 用 214
+export const VERSION_CODE: Record<string, number> = {
+    'maimai': 100,                  'maimai PLUS': 110,
+    'maimai GreeN': 120,            'maimai GreeN PLUS': 130,
+    'maimai ORANGE': 140,           'maimai ORANGE PLUS': 150,
+    'maimai PiNK': 160,             'maimai PiNK PLUS': 170,
+    'maimai MURASAKi': 180,         'maimai MURASAKi PLUS': 185,
+    'maimai MiLK': 190,             'MiLK PLUS': 195,
+    'maimai FiNALE': 199,
+    'maimai でらっくす': 200,        'maimai でらっくす Splash': 214,
+    'maimai でらっくす UNiVERSE': 220, 'maimai でらっくす FESTiVAL': 230,
+    'maimai でらっくす BUDDiES': 240, 'maimai でらっくす PRiSM': 250,
+    'maimai でらっくす PRiSM PLUS': 255,
+}
+
+// 版本 logo 素材内部左侧透明留白（像素实测 alpha bbox）。
+// 各卡按自己的显示倍率补偿，使可见字形左缘与标题左缘对齐。
+export const LOGO_BBOX_LEFT: Record<number, number> = {
+    100: 22, 110: 21, 120: 20, 130: 20, 140: 20, 150: 14, 160: 21, 170: 21,
+    180: 28, 185: 19, 190: 21, 195: 32, 199: 24, 200: 49, 210: 15, 214: 54,
+    215: 10, 220: 55, 225: 24, 230: 50, 235: 78, 240: 78, 245: 46, 250: 79, 255: 50,
+}
+
+export function versionLogoSrc(from: string | undefined) {
+    const code = VERSION_CODE[from ?? '']
+    return code
+        ? `/assets/maimai/version/Ver${code}.png`
+        : '/assets/maimai/version/maimaidx.png'
+}
+
+export function typeBadgeSrc(type: string | undefined) {
+    return type === 'DX'
+        ? '/assets/maimai/pic/mode_dx.png'
+        : '/assets/maimai/pic/mode_standard.png'
+}
+
+export function coverSrcOf(id: number) {
+    return `/assets/maimai/cover/${id}.png`
+}
+
+export const COVER_FALLBACK = '/assets/maimai/cover/0.png'
+
+// ── 难度主题暗色背景 ──
+const DIFF_KEYS = ['BSC', 'ADV', 'EXP', 'MST', 'MST_Re']
+const BG_GRADIENTS: Record<string, [string, string]> = {
+    BSC:    ['#123a0a', '#04120a'],
+    ADV:    ['#3a2706', '#140d03'],
+    EXP:    ['#3d0d14', '#16060a'],
+    MST:    ['#2c0b44', '#0e0418'],
+    MST_Re: ['#33204f', '#120a20'],
+    UTG:    ['#3d0c35', '#150412'],
+    DMY:    ['#222633', '#0a0c12'],
+}
+
+export function bgKeyOf(topIdx: number, isUtage: boolean) {
+    return isUtage ? 'UTG' : DIFF_KEYS[topIdx] ?? 'DMY'
+}
+
+/** 卡片根背景：最高难度主题色的深色对角渐变。 */
+export function cardBackground(topKey: string) {
+    const [c1, c2] = BG_GRADIENTS[topKey] ?? BG_GRADIENTS['DMY']
+    return {background: `linear-gradient(168deg, ${c1} 0%, ${c2} 62%, #060309 100%)`}
+}


### PR DESCRIPTION
## 背景

MaiSong（歌曲信息卡）与 MaiSongScore（单曲成绩卡）各自复制了一份公用常量、函数与配色：难度名色、genre 显示映射、版本 logo 素材表（VERSION_CODE / LOGO_BBOX_LEFT）、类型章与曲绘路径、难度主题背景渐变；样式里的顶栏 pill / chip 配色也是两份字面量。改一处就要同步改另一处。

## 变更

**新增 `utils/song_card.ts`（公用常量与函数）**

- 难度色不再自带一份，直接沿用 `GlobalVars.maimai_levelColors`（b50 ScoreCard 同源）——难度色现在全前端只有一份。
- `DIFF_NAMES`、宴谱色 `UTAGE`、`isUtageId`、`themeMainOf`（宴粉/按难度取色）。
- genre 简中→日/西文映射（`genreDisplayOf`）。
- `VERSION_CODE` / `LOGO_BBOX_LEFT`（两卡原先的表有细微出入，统一为并集；差异键均为素材实测数据，不影响任一卡的取值路径）与 `versionLogoSrc`。
- `typeBadgeSrc` / `coverSrcOf` + `COVER_FALLBACK`。
- 难度主题背景：`bgKeyOf` + `cardBackground`（168deg 深色渐变公式两卡本就一致）。

**新增 `assets/css/maimai/song_card.pcss`（公用样式）**

- 卡片基底 `.mai-card`（前景/底色 + `img { max-width: none }`）。
- 公用配色以 CSS 变量声明：`--pill-bg` / `--pill-shadow` / `--chip-ink` / `--chip-bg` / `--chip-ring` / `--new-chip-bg` / `--new-chip-shadow`，两卡的 pill/chip 规则改引变量，尺寸留在各卡。
- 取值完全一致的 `.font-torus` / `.font-rodin`。
- 按仓库现有惯例（Summary / Preview 的 `<style scoped src>`）引入，样式作用域仍隔离在各卡内部，不影响其它组件（如 ScoreCard 里另一份同名 `.mai-title`）。

**刻意保留在各卡的部分**（取值本就不同，不是重复）：尺寸体系（两卡是 1240/840 两套缩放）、logo 缩放系数、辉光/行底渐变参数、标题 auto-shrink、`.artist-line`（#76 尚在改它）。

## 验证

重构前后各渲染 6 组卡片（两卡 × 常规 DX / 五谱含 Re:MASTER / 宴会场），软件光栅（`--disable-gpu`）下逐像素比对**全部逐字节一致**。附注：GPU 光栅化对带 text-shadow 的文字有间歇性 ±1~2/255 的反锯齿抖动（同代码重渲亦复现、布局与字号完全确定，软件光栅无此现象），像素回归以软件光栅为准。`vite build` 通过。

后续候选（本 PR 未动）：Summary.vue 里还有一份难度色字面量和第三份标题缩放实现，可在合并后单独收拢。

---

*本 PR 的代码与文案由 Claude Fable 5 撰写。*
