### PR TITLE
chore(maimai): 清理完成表两处过时注释，前端 Plate 维度类型补上 DxScore

### DIFF
--- a/Marisa.Frontend/src/components/maimai/utils/summary_t.ts
+++ b/Marisa.Frontend/src/components/maimai/utils/summary_t.ts
@@ -38,8 +38,8 @@ export interface GroupedSong {
 
 /** plate 模式下 server 传过来的查询信息。sum 模式时为 null。 */
 export interface PlateInfo {
-    /** "Achievement" / "Fc" / "Fs" */
-    Dim: 'Achievement' | 'Fc' | 'Fs'
+    /** "Achievement" / "Fc" / "Fs" / "DxScore" */
+    Dim: 'Achievement' | 'Fc' | 'Fs' | 'DxScore'
     /** 比较时的 ordinal level（≥ 这个值算达成） */
     Level: number
     /** 标题里显示的阈值名（"SSS+" / "AP" / "FDX" 等） */

--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -76,8 +76,6 @@ public static class PlateData
 
     /// <summary>
     ///     完整查询：一组 Selectors（AND 合取——所有 selector 都命中的 chart 才入选）+ 阈值 + 难度。
-    ///     当前 TryParse 阶段返回 Selectors.Count == 1（与历史单 selector 行为等价）；
-    ///     multi-selector 解析在后续 commit 启用。
     /// </summary>
     public sealed record Query(IReadOnlyList<Selector> Selectors, Threshold Threshold, IReadOnlyList<int> LevelIdxes);
 
@@ -637,7 +635,7 @@ public static class PlateData
             }
             else if (pErr != null)
             {
-                error = pErr;       // 丸/彩 这种已知不支持，立刻返回
+                error = pErr;       // 丸 这种已知不支持，立刻返回
                 return false;
             }
 


### PR DESCRIPTION
通读完成表实现时发现三处注释/类型与现状脱节。都不影响运行行为，但留着会误导后来读代码的人，本 PR 一并清掉：

1. **`PlateData.Query` 的 doc 注释**还停留在 #39 分阶段开发时的中间态，写着「当前 TryParse 阶段返回 Selectors.Count == 1；multi-selector 解析在后续 commit 启用」。multi-selector 解析早已实装（如「镜代13+V家将完成表」会解析出三个 selector），删去这两句，保留仍然正确的 AND 合取语义说明。

2. **代字黑名单报错处的注释**（`// 丸/彩 这种已知不支持，立刻返回`）写于「彩」尚未支持的时期；#50 起彩已加入 `PlateVersionMap`，黑名单只剩丸（CiRCLE）。举例改成只提丸。

3. **前端 `PlateInfo.Dim` 的联合类型**只声明了 `'Achievement' | 'Fc' | 'Fs'`，缺 #40 引入、后端 `DrawPlateProgress` 实际会下发的 `'DxScore'`。运行时代码一直处理正确（Summary.vue 里已有 `Dim === 'DxScore'` 分支），只是类型没跟上——今后若有人照类型声明写穷举分支，会静默漏掉星档维度。补全类型与注释。

无行为改动：`MaiMaiDxPlateDataTest` 217 个测试全过，`vite build` 正常。

*本 PR 的代码与文案由 Claude Fable 5 撰写。*