### PR TITLE
feat(maimai): 汇总/完成表统计条中心从百分比改为「已完成/总数」

### DIFF
--- a/Marisa.Frontend/src/components/maimai/partial/StatsBar.vue
+++ b/Marisa.Frontend/src/components/maimai/partial/StatsBar.vue
@@ -65,8 +65,8 @@ function pct(n: number, total: number): string {
     return `${total ? n / total * 100 : 0}%`
 }
 
-const overallPct = computed(() => {
-    // 中央完成率按命令的阈值维度动态算：
+const overallText = computed(() => {
+    // 中央完成度按命令的阈值维度动态算：
     // - plate.Dim = Achievement → 按达成率 (achievementOrdinal)
     // - plate.Dim = Fc          → 按 fc 字段 (fcOrdinal)
     // - plate.Dim = Fs          → 按 fs 字段 (fsOrdinal)
@@ -75,7 +75,6 @@ const overallPct = computed(() => {
     const dim       = props.plate?.Dim   ?? 'Achievement'
     const threshold = props.plate?.Level ?? 12   // 12 = SSS
     const total = props.charts.length
-    if (!total) return '0.00%'
 
     let done = 0
     for (const c of props.charts) {
@@ -87,7 +86,7 @@ const overallPct = computed(() => {
                 :                          dxScoreStar(sc.dxScore, c.Item3.MaxDx)
         if (lv >= threshold) done++
     }
-    return (done / total * 100).toFixed(2) + '%'
+    return `${done}/${total}`
 })
 </script>
 
@@ -122,7 +121,7 @@ const overallPct = computed(() => {
                 <div class="seg pl"   :style="{width: pct(fcStat.oth,    fcStat.total)}"></div>
                 <div class="seg np"   :style="{width: pct(fcStat.np,     fcStat.total)}"></div>
             </div>
-            <div class="overlay">{{ overallPct }}</div>
+            <div class="overlay">{{ overallText }}</div>
         </div>
 
         <div v-if="detail" class="detail-row">


### PR DESCRIPTION
用户反馈：统计条中心的百分比不够直观——看到 41.67% 还得心算一下才知道还差几首，不如直接写「5/12」。

改动只有一处：`StatsBar.vue` 中心 overlay 的 computed 由输出百分比改为输出 `<已完成数>/<总谱面数>`。完成表标题旁的大统计条、各分组的小统计条、`mai sum` 汇总系列用的都是这一个组件，一处改动全部生效。达成判定逻辑不变：完成表按命令的阈值维度算（达成率/FC/FS/DX星档），汇总沿用 SSS 兜底；NP 照旧计入分母。

前后对比（手搭 12 谱 fixture，含已达成/未达成/无游玩记录三种状态，计数可手工核对：总 5/12，三组分别 2/4、3/5、0/3）：

| | 改动前 | 改动后 |
|---|---|---|
| 完成表 | ![](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-statsbar-counts/statsbar-plate-before.png) | ![](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-statsbar-counts/statsbar-plate-after.png) |
| 汇总 | ![](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-statsbar-counts/statsbar-sum-before.png) | ![](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-statsbar-counts/statsbar-sum-after.png) |

`vite build` 通过。

*本 PR 的代码与文案由 Claude Fable 5 撰写。*