### PR TITLE
fix: 修复代码审计发现的安全与健壮性问题

### DIFF
--- a/Marisa.BotDriver/BotDriver.cs
+++ b/Marisa.BotDriver/BotDriver.cs
@@ -80,29 +80,39 @@ public abstract class BotDriver(
 
     protected async Task ProcMessageStep(Message message)
     {
-        var res = await Policy.TimeoutAsync(TimeSpan.FromMinutes(10), TimeoutStrategy.Pessimistic).ExecuteAndCaptureAsync(async () =>
+        try
         {
-            Logger.Info("{0}", message.ToString());
-            var toInvoke = MessageDispatcher.Dispatch(message);
-
-            foreach (var (plugin, method, m2) in toInvoke)
+            var res = await Policy.TimeoutAsync(TimeSpan.FromMinutes(10), TimeoutStrategy.Pessimistic).ExecuteAndCaptureAsync(async () =>
             {
-                var state = await MessageDispatcher.Invoke(plugin, method, m2);
+                Logger.Info("{0}", message.ToString());
+                var toInvoke = MessageDispatcher.Dispatch(message);
 
-                if (state == MarisaPluginTaskState.CompletedTask) break;
+                foreach (var (plugin, method, m2) in toInvoke)
+                {
+                    var state = await MessageDispatcher.Invoke(plugin, method, m2);
+
+                    if (state == MarisaPluginTaskState.CompletedTask) break;
+                }
+            });
+
+            if (res.Outcome != OutcomeType.Failure) return;
+
+            if (res.FinalException is TimeoutRejectedException)
+            {
+                message.Reply("Cancelled due to timeout (10min)");
+                Logger.Error("Handler timed out. Caused by message: {0}", message);
             }
-        });
-
-        if (res.Outcome != OutcomeType.Failure) return;
-
-        if (res.FinalException is TimeoutRejectedException)
-        {
-            message.Reply("Cancelled due to timeout (10min)");
-            Logger.Error("Handler timed out. Caused by message: {0}", message);
+            else
+            {
+                // 分发/触发匹配阶段（不在 DependencyInjectInvoke 的 try/catch 内）抛出的异常：
+                // 记录而非抛回无人 await 的任务，否则会被静默丢弃
+                Logger.Error(res.FinalException, "Dispatch failed. Caused by message: {0}", message);
+            }
         }
-        else
+        catch (Exception e)
         {
-            throw res.FinalException;
+            // 兜底：本任务是即发即弃的，任何逃逸异常都必须在此消化，避免成为未观测异常
+            Logger.Error(e, "Unexpected error while processing message: {0}", message);
         }
     }
 

--- a/Marisa.Plugin.Shared/Chunithm/DataFetcher/Entities/ScoreLouis.cs
+++ b/Marisa.Plugin.Shared/Chunithm/DataFetcher/Entities/ScoreLouis.cs
@@ -21,9 +21,10 @@ public record BestScoreLouis
     public long LastModified { get; set; }
 #pragma warning restore CS8618
 
-    public ChunithmScore ToChunithmScore(IndexerT indexer)
+    public ChunithmScore? ToChunithmScore(IndexerT indexer)
     {
-        var song = indexer[MusicId];
+        if (!indexer.TryGetValue(MusicId, out var song)) return null;
+        if (LevelIndex < 0 || LevelIndex >= song.Constants.Count || LevelIndex >= song.Levels.Count) return null;
 
         return new ChunithmScore
         {

--- a/Marisa.Plugin.Shared/Chunithm/DataFetcher/LouisDataFetcher.cs
+++ b/Marisa.Plugin.Shared/Chunithm/DataFetcher/LouisDataFetcher.cs
@@ -97,6 +97,8 @@ public class LouisDataFetcher(SongDb<ChunithmSong> songDb) : DataFetcher(songDb)
         var json = await response.GetJsonAsync<BestScoreLouis[]>();
 
         return json.Select(x => x.ToChunithmScore(Indexer))
+            .Where(x => x != null)
+            .Select(x => x!)
             .DistinctBy(x => (x.Id, (int)x.LevelIndex))
             .ToDictionary(x => (x.Id, (int)x.LevelIndex), x => x);
     }

--- a/Marisa.Plugin.Shared/Interface/IMarisaPluginWithRetrieve.cs
+++ b/Marisa.Plugin.Shared/Interface/IMarisaPluginWithRetrieve.cs
@@ -81,7 +81,12 @@ public interface IMarisaPluginWithRetrieve<TSong> where TSong : Song
         var name  = names[0].Trim();
         var alias = names[1].Trim();
 
-        message.Reply(SongDb.SetSongAlias(name, alias) ? "Success" : $"不存在的歌曲：{name}");
+        message.Reply(
+            alias.Span.IndexOfAny('\t', '\n', '\r') >= 0
+                ? "别名不能包含制表符或换行"
+                : SongDb.SetSongAlias(name, alias)
+                    ? "Success"
+                    : $"不存在的歌曲：{name}");
 
         return MarisaPluginTaskState.CompletedTask;
     }
@@ -382,9 +387,12 @@ public interface IMarisaPluginWithRetrieve<TSong> where TSong : Song
                 return false;
             }
 
-            var cmp  = GetComparer<int>(op);
-            var aInt = a.Last() == '+' ? int.Parse(a[..^1]) : int.Parse(a);
-            var bInt = b.Last() == '+' ? int.Parse(b[..^1]) : int.Parse(b);
+            var cmp = GetComparer<int>(op);
+            if (!int.TryParse(a.Last() == '+' ? a[..^1] : a, out var aInt) ||
+                !int.TryParse(b.Last() == '+' ? b[..^1] : b, out var bInt))
+            {
+                return false;
+            }
             if (aInt != bInt)
             {
                 return cmp(aInt, bInt);

--- a/Marisa.Plugin.Shared/Osu/OsuApi.cs
+++ b/Marisa.Plugin.Shared/Osu/OsuApi.cs
@@ -383,7 +383,7 @@ public static partial class OsuApi
                 var lines = File.ReadLines(f)
                     .SkipWhile(l => !l.Trim().Equals("[Metadata]", StringComparison.OrdinalIgnoreCase))
                     .Skip(1)
-                    .TakeWhile(l => l.Trim()[0] != '[');
+                    .TakeWhile(l => !l.Trim().StartsWith('['));
                 foreach (var line in lines)
                 {
                     if (!line.Trim().StartsWith("BeatmapID:", StringComparison.OrdinalIgnoreCase)) continue;

--- a/Marisa.Plugin.Shared/Util/SongDb/SearchSongInDb.cs
+++ b/Marisa.Plugin.Shared/Util/SongDb/SearchSongInDb.cs
@@ -168,14 +168,14 @@ public static class SearchSongInDb
     {
         try
         {
-            var regex = new Regex(artist.ToString(), RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            var regex = UserRegex.Create(artist.ToString());
 
             var res = db.SongList.Where(s => regex.IsMatch(s.Artist)).ToList();
 
             if (res.Count != 0)
                 return res.ToList();
         }
-        catch (RegexParseException)
+        catch (Exception e) when (e is RegexParseException or RegexMatchTimeoutException)
         {
         }
 

--- a/Marisa.Plugin.Shared/Util/SongDb/SongDb.cs
+++ b/Marisa.Plugin.Shared/Util/SongDb/SongDb.cs
@@ -198,10 +198,10 @@ public class SongDb<TSong> : ICanReset where TSong : Song
 
         try
         {
-            var regex = new Regex(alias.ToString(), RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            var regex = UserRegex.Create(alias.ToString());
             key = SongAlias.Keys.Where(a => regex.IsMatch(a.Span)).ToList();
         }
-        catch (RegexParseException) {}
+        catch (Exception e) when (e is RegexParseException or RegexMatchTimeoutException) {}
 
         return Result();
 
@@ -259,6 +259,9 @@ public class SongDb<TSong> : ICanReset where TSong : Song
     /// <returns>成功与否</returns>
     public bool SetSongAlias(ReadOnlyMemory<char> name, ReadOnlyMemory<char> alias)
     {
+        // 别名不允许含制表符/换行，否则会破坏别名 TSV 文件的行/列结构
+        if (alias.Span.IndexOfAny('\t', '\n', '\r') >= 0) return false;
+
         lock (SongAlias)
         {
             ReadOnlyMemory<char> title;

--- a/Marisa.Plugin.Shared/Util/SongDb/UserRegex.cs
+++ b/Marisa.Plugin.Shared/Util/SongDb/UserRegex.cs
@@ -1,0 +1,16 @@
+using System.Text.RegularExpressions;
+
+namespace Marisa.Plugin.Shared.Util.SongDb;
+
+internal static class UserRegex
+{
+    private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    ///     用用户输入构造正则。带匹配超时以防止灾难性回溯（ReDoS）；不使用 Compiled，一次性模式无从摊销编译开销。
+    /// </summary>
+    public static Regex Create(string pattern)
+    {
+        return new Regex(pattern, RegexOptions.IgnoreCase, MatchTimeout);
+    }
+}

--- a/Marisa.Plugin/Chi.cs
+++ b/Marisa.Plugin/Chi.cs
@@ -322,7 +322,7 @@ public class Chi : MarisaPluginBase
             {
                 return value.RandomTake(1).First();
             }
-            return _data.Values.SelectMany(x => x).RandomTake(1).First();
+            return _data.Values.SelectMany(x => x).RandomTake(1).FirstOrDefault() ?? "还没有可选的，先给我加点吃的吧";
         }
     }
 

--- a/Marisa.Plugin/Chunithm/Chunithm.MessageHandler.cs
+++ b/Marisa.Plugin/Chunithm/Chunithm.MessageHandler.cs
@@ -790,7 +790,7 @@ public partial class Chunithm
             var command = next.Command.Trim();
 
             // 第一位是idx，后面是预期达成率
-            if (!int.TryParse(command[..1].Span, out var levelIdx) || levelIdx < 0 || levelIdx >= song.Levels.Count)
+            if (command.Length == 0 || !int.TryParse(command[..1].Span, out var levelIdx) || levelIdx < 0 || levelIdx >= song.Levels.Count)
             {
                 next.Reply("错误的选择，请选择前面的编号。会话已关闭");
                 return Task.FromResult(MarisaPluginTaskState.Canceled);

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -1313,10 +1313,14 @@ public partial class MaiMaiDx
         var current = new
         {
             OldScores = rating.OldScores
-                .Select(x => (SongDb.GetSongById(x.Id)!, x.LevelIdx, x.Achievement, x.Rating))
+                .Select(x => (Song: SongDb.GetSongById(x.Id), x.LevelIdx, x.Achievement, x.Rating))
+                .Where(x => x.Song != null)
+                .Select(x => (x.Song!, x.LevelIdx, x.Achievement, x.Rating))
                 .OrderByDescending(x => x.Item4),
             NewScores = rating.NewScores
-                .Select(x => (SongDb.GetSongById(x.Id)!, x.LevelIdx, x.Achievement, x.Rating))
+                .Select(x => (Song: SongDb.GetSongById(x.Id), x.LevelIdx, x.Achievement, x.Rating))
+                .Where(x => x.Song != null)
+                .Select(x => (x.Song!, x.LevelIdx, x.Achievement, x.Rating))
                 .OrderByDescending(x => x.Item4)
         };
 
@@ -1489,6 +1493,11 @@ public partial class MaiMaiDx
             }
 
             var levelIdx = levelName.IndexOf(level) % MaiMaiSong.LevelNameAll.Count;
+            if (levelIdx >= song.Charts.Count)
+            {
+                next.Reply("该谱面没有这个难度，会话已关闭");
+                return Task.FromResult(MarisaPluginTaskState.CompletedTask);
+            }
             var (x, y) = song.NoteScore(levelIdx);
 
             var tolerance = (int)((101 - achievement) / (0.2 * x));

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.Utils.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.Utils.cs
@@ -27,10 +27,14 @@ public partial class MaiMaiDx
         GetRecommend(DxRating rating, int targetRating)
     {
         var listOld = rating.OldScores
-            .Select(score => (SongDb.GetSongById(score.Id)!, score.LevelIdx, score.Achievement, score.Rating))
+            .Select(score => (Song: SongDb.GetSongById(score.Id), score.LevelIdx, score.Achievement, score.Rating))
+            .Where(x => x.Song != null)
+            .Select(x => (x.Song!, x.LevelIdx, x.Achievement, x.Rating))
             .ToList();
         var listNew = rating.NewScores
-            .Select(score => (SongDb.GetSongById(score.Id)!, score.LevelIdx, score.Achievement, score.Rating))
+            .Select(score => (Song: SongDb.GetSongById(score.Id), score.LevelIdx, score.Achievement, score.Rating))
+            .Where(x => x.Song != null)
+            .Select(x => (x.Song!, x.LevelIdx, x.Achievement, x.Rating))
             .ToList();
 
         var raOld = rating.OldScores.Sum(s => s.Ra());
@@ -128,6 +132,8 @@ public partial class MaiMaiDx
         bool Update1(IList<(MaiMaiSong Song, int Idx, double Achievement, int Rating)> list, ref int raSum,
             IEnumerable<MaiMaiSong> songList, int cap)
         {
+            if (list.Count == 0) return false;
+
             var (oldSong, oldIdx, oldAchievement, oldRa) = list.MinBy(x => x.Rating);
 
             idSet.Remove((oldSong.Id, oldIdx));

--- a/Marisa.Plugin/Osu/Osu.MessageHandler.cs
+++ b/Marisa.Plugin/Osu/Osu.MessageHandler.cs
@@ -81,7 +81,8 @@ public partial class Osu
     [MarisaPluginCommand("info")]
     private async Task<MarisaPluginTaskState> Info(Message message)
     {
-        if (!TryParseCommand(message, false, false, out var command)) return MarisaPluginTaskState.CompletedTask;
+        var command = await ResolveCommand(message, false, false);
+        if (command == null) return MarisaPluginTaskState.CompletedTask;
 
         if (DebounceCheck(message, command!.Name))
         {
@@ -115,9 +116,10 @@ public partial class Osu
     [MarisaPluginCommand("recommend", "什么推分", "打什么推分", "打什么歌推分")]
     private async Task<MarisaPluginTaskState> Recommend(Message message)
     {
-        if (!TryParseCommand(message, false, false, out var command)) return MarisaPluginTaskState.CompletedTask;
+        var command = await ResolveCommand(message, false, false);
+        if (command == null) return MarisaPluginTaskState.CompletedTask;
 
-            if (command!.Mode is not (0 or 3))
+        if (command.Mode is not (0 or 3))
         {
             message.Reply("目前只支持 osu 和 mania 模式");
             return MarisaPluginTaskState.CompletedTask;
@@ -139,7 +141,8 @@ public partial class Osu
     [MarisaPluginCommand("pr")]
     private async Task<MarisaPluginTaskState> RecentPass(Message message)
     {
-        if (!TryParseCommand(message, true, false, out var command)) return MarisaPluginTaskState.CompletedTask;
+        var command = await ResolveCommand(message, true, false);
+        if (command == null) return MarisaPluginTaskState.CompletedTask;
 
         message.Reply(MessageDataImage.FromBase64(await WebApi.OsuScore(command!.Name, command.Mode!.Value,
             command.Rank?.Start, true, false)));
@@ -151,7 +154,8 @@ public partial class Osu
     [MarisaPluginCommand("recent", "rec", "re")]
     private async Task<MarisaPluginTaskState> Recent(Message message)
     {
-        if (!TryParseCommand(message, true, false, out var command)) return MarisaPluginTaskState.CompletedTask;
+        var command = await ResolveCommand(message, true, false);
+        if (command == null) return MarisaPluginTaskState.CompletedTask;
 
         message.Reply(MessageDataImage.FromBase64(await WebApi.OsuScore(command!.Name, command.Mode!.Value,
             command.Rank?.Start, true, true)));
@@ -163,7 +167,8 @@ public partial class Osu
     [MarisaPluginCommand("bp")]
     private async Task<MarisaPluginTaskState> BestPerformance(Message message)
     {
-        if (!TryParseCommand(message, true, true, out var command)) return MarisaPluginTaskState.CompletedTask;
+        var command = await ResolveCommand(message, true, true);
+        if (command == null) return MarisaPluginTaskState.CompletedTask;
 
         if (command!.Rank?.End == null)
         {
@@ -222,7 +227,8 @@ public partial class Osu
     [MarisaPluginCommand("todaybp", "tdbp")]
     private async Task<MarisaPluginTaskState> TodayBp(Message message)
     {
-        if (!TryParseCommand(message, true, false, out var command)) return MarisaPluginTaskState.CompletedTask;
+        var command = await ResolveCommand(message, true, false);
+        if (command == null) return MarisaPluginTaskState.CompletedTask;
 
         var recentScores =
             (await OsuApi.GetScores(await GetOsuIdByName(command!.Name), OsuApi.OsuScoreType.Best,
@@ -233,7 +239,7 @@ public partial class Osu
 
         if (!(recentScores?.Any() ?? false))
         {
-            message.Reply($"最近24小时内在 {OsuApi.GetModeName(command.Mode!.Value)} 上未恰到分");
+            message.Reply($"最近{command.Rank?.Start ?? 24}小时内在 {OsuApi.GetModeName(command.Mode!.Value)} 上未恰到分");
         }
         else
         {
@@ -262,7 +268,8 @@ public partial class Osu
 
         if (message.Command.IsWhiteSpace())
         {
-            if (!TryParseCommand(message, false, false, out var command)) return MarisaPluginTaskState.CompletedTask;
+            var command = await ResolveCommand(message, false, false);
+            if (command == null) return MarisaPluginTaskState.CompletedTask;
 
             var id = await GetOsuIdByName(command!.Name);
             var scores = await OsuApi.GetScores(

--- a/Marisa.Plugin/Osu/Osu.cs
+++ b/Marisa.Plugin/Osu/Osu.cs
@@ -36,20 +36,20 @@ public partial class Osu : MarisaPluginBase, IMarisaPluginWithHelp, IHandleCommo
         }
     }
 
-    private static bool TryParseCommand(Message message, bool withBpRank, bool allowRange, out OsuCommandParser.OsuCommand? command)
+    private static async Task<OsuCommandParser.OsuCommand?> ResolveCommand(Message message, bool withBpRank, bool allowRange)
     {
-        command = ParseCommand(message, withBpRank, allowRange);
+        var command = await ParseCommand(message, withBpRank, allowRange);
 
         if (command == null)
         {
             message.Reply("错误的命令格式");
-            return false;
+            return null;
         }
 
         if (string.IsNullOrWhiteSpace(command.Name))
         {
             message.Reply("未绑定，请使用 `osu! bind 用户名` 绑定");
-            return false;
+            return null;
         }
 
         if (command.Rank == null)
@@ -59,10 +59,10 @@ public partial class Osu : MarisaPluginBase, IMarisaPluginWithHelp, IHandleCommo
                 : new OsuCommandParser.OsuCommand(command.Name, null, command.Mode);
         }
 
-        return true;
+        return command;
     }
 
-    private static OsuCommandParser.OsuCommand? ParseCommand(Message message, bool withBpRank, bool allowRange)
+    private static async Task<OsuCommandParser.OsuCommand?> ParseCommand(Message message, bool withBpRank, bool allowRange)
     {
         var command = OsuCommandParser.Parse(message.Command.ToString());
 
@@ -81,11 +81,11 @@ public partial class Osu : MarisaPluginBase, IMarisaPluginWithHelp, IHandleCommo
             return null;
         }
 
-        using var realm = BotDbContext.OpenRealm();
-
         // 没设置名字，那就是查自己或者查@的人
         if (string.IsNullOrWhiteSpace(command.Name))
         {
+            using var realm = BotDbContext.OpenRealm();
+
             OsuBind? bind;
             // @了人
             if (message.MessageChain?.Messages.FirstOrDefault(m => m.Type == MessageDataType.At) is MessageDataAt at)
@@ -108,23 +108,26 @@ public partial class Osu : MarisaPluginBase, IMarisaPluginWithHelp, IHandleCommo
 
             return new OsuCommandParser.OsuCommand(bind.OsuUserName, command.Rank, mode);
         }
+
         // 有设置名字，那么要检查GameMode
-        else
+        // 设置了mode的话就直接返回
+        if (command.Mode != null) return command;
+
+        // 从数据库取该用户名的 GameMode（在 await 前关闭 realm，避免跨线程访问 Realm）
+        string? gameMode;
+        using (var realm = BotDbContext.OpenRealm())
         {
-            // 设置了mode的话就直接返回
-            if (command.Mode != null) return command;
-
-            var bind = realm.All<OsuBind>().FirstOrDefault(o => o.OsuUserName == command.Name);
-
-            // 没被绑定，说明我们不知道这个人的GameMode，需要请求OsuApi来拿
-            if (bind == null)
-            {
-                var u = OsuApi.GetUserInfoByName(command.Name).Result;
-                return new OsuCommandParser.OsuCommand(command.Name, command.Rank, OsuApi.ModeList.IndexOf(u.Playmode.ToLower()));
-            }
-
-            return new OsuCommandParser.OsuCommand(command.Name, command.Rank, OsuApi.ModeList.IndexOf(bind.GameMode));
+            gameMode = realm.All<OsuBind>().FirstOrDefault(o => o.OsuUserName == command.Name)?.GameMode;
         }
+
+        // 没被绑定，说明我们不知道这个人的GameMode，需要请求OsuApi来拿
+        if (gameMode == null)
+        {
+            var u = await OsuApi.GetUserInfoByName(command.Name);
+            return new OsuCommandParser.OsuCommand(command.Name, command.Rank, OsuApi.ModeList.IndexOf(u.Playmode.ToLower()));
+        }
+
+        return new OsuCommandParser.OsuCommand(command.Name, command.Rank, OsuApi.ModeList.IndexOf(gameMode));
     }
 
     /// <summary>
@@ -134,11 +137,14 @@ public partial class Osu : MarisaPluginBase, IMarisaPluginWithHelp, IHandleCommo
     /// <returns></returns>
     private static async Task<long> GetOsuIdByName(string name)
     {
-        using var realm = BotDbContext.OpenRealm();
+        // 在 await 前关闭 realm，避免续体在别的线程 dispose Realm（Realm 线程亲和）
+        long? boundId;
+        using (var realm = BotDbContext.OpenRealm())
+        {
+            boundId = realm.All<OsuBind>().FirstOrDefault(o => o.OsuUserName == name)?.OsuUserId;
+        }
 
-        var u = realm.All<OsuBind>().FirstOrDefault(o => o.OsuUserName == name);
-
-        if (u != null) return u.OsuUserId;
+        if (boundId != null) return boundId.Value;
 
         var id = await OsuApi.GetUserInfoByName(name);
 

--- a/Marisa.StartUp/Controllers/GoController.cs
+++ b/Marisa.StartUp/Controllers/GoController.cs
@@ -16,26 +16,4 @@ public class GoController : Controller
         if (url == null) return NotFound("链接已过期或不存在");
         return Redirect(url);
     }
-
-    /// <summary>
-    /// 创建短链
-    /// </summary>
-    [HttpPost("/api/go")]
-    public IActionResult Create([FromBody] CreateRequest request)
-    {
-        if (string.IsNullOrWhiteSpace(request.Url))
-            return BadRequest("url is required");
-
-        var code = ShortUrlStore.CreateShortUrl(request.Url,
-            request.TtlMinutes.HasValue ? TimeSpan.FromMinutes(request.TtlMinutes.Value) : null);
-
-        return Ok(new
-        {
-            code,
-            shortUrl = ShortUrlStore.GetShortUrl(code),
-            fullUrl = request.Url
-        });
-    }
-
-    public record CreateRequest(string Url, int? TtlMinutes);
 }


### PR DESCRIPTION
一次代码审计的后续修复。范围按你的意见确定（正则加超时 / `/go` 仅转发、不允许通过 web 创建 / 健壮性修了）。下面逐条说明「问题」与「修复」。

---

## 安全

### 1. ReDoS：用户输入的正则无匹配超时（搜歌 & 曲师搜索）
**问题**：`SongDb.SearchSongByAlias` 与 `SearchSongInDb.SelectSongByArtist` 把用户输入（`message.Command`）直接 `new Regex(..., RegexOptions.Compiled)` 编译并对全部别名/曲师做 `IsMatch`，没有匹配超时，且只 `catch (RegexParseException)`（拦不住灾难性回溯）。任意群成员发一条构造过的正则（如 `a (.*a){20}b`）对语料里较长的别名/曲师串就会指数级回溯，同步打满一个 CPU 核；反复发几条即可占满消息处理线程，让 bot 对所有群失去响应。入口命令：`搜索`/`song`/`search`、`artist`/`a`/`random`，以及猜曲答题路径。
**修复**：新增 `UserRegex.Create(pattern)` 统一构造正则——带 200ms `matchTimeout`、去掉一次性 pattern 的 `Compiled`（编译开销无从摊销，反而放大攻击）。两个调用点的 catch 扩为 `RegexParseException or RegexMatchTimeoutException`，超时即优雅回落（别名搜索返回空、曲师搜索落到 `Contains`），不再崩。

### 2. 开放重定向：`POST /api/go` 无鉴权
**问题**：`GoController` 的 `POST /api/go` 无鉴权，接受任意 URL 存下，`GET /go/{code}` 302 跳转且不校验 scheme/host。若反代把 `/api/*` 也暴露出去，任何人都能在 bot 可信域名下造出跳往任意站点的短链（钓鱼），且无速率/大小限制可撑大内存字典。
**修复**：删除 `POST /api/go` 与 `CreateRequest`，只保留 `GET /go/{code}`。短链仍由 mai/chu 的 lxns OAuth 流程在内部 `CreateShortUrl` + `GetShortUrl` 生成（已确认内部调用点不受影响）——即你说的「/go 仅转发、不允许通过 web 创建」。

---

## 健壮性（消除「构造输入即崩到 “出现异常，已上报开发者”」的多处路径）

### 3. maimai 容错模式：选不存在的难度会数组越界
**问题**：容错模式里 `levelIdx = 难度名.IndexOf(level) % 5` 恒为 0–4，但多数曲只有 4 个谱面（无 Re:Master）。用户对无白谱的曲回答「白 99」→ `song.NoteScore(4)` 即 `Charts[4]` 越界。
**修复**：`NoteScore` 前加 `if (levelIdx >= song.Charts.Count)` 守卫，回「该谱面没有这个难度」并关闭会话。

### 4. chunithm 容错模式：空/纯图片回复会越界
**问题**：容错对话回调用 `command[..1]` 取序号，当回复为空或纯图片（Trim 后长度 0）时，`Slice(0,1)` 在 `int.TryParse` 之前就抛越界。
**修复**：前置 `command.Length == 0 ||` 短路，直接走「错误的选择」提示。

### 5. 搜歌等级约束：非整数值会抛未捕获异常
**问题**：`LevelComparer` 只校验首字符是数字（`char.IsDigit(b[0])`），却用 `int.Parse` 解析整串。用户发 `search level>13.5` 或 `>10a` → `int.Parse("13.")` 抛 `FormatException`（不属于上游的 `catch (ArgumentOutOfRangeException)`），冒泡成通用错误并写一份异常 dump。
**修复**：改 `int.TryParse`，解析失败即视为不匹配（无结果），不再抛异常。

### 6. mai howto/recommend：曲库缺曲时空引用
**问题**：`GetRecommend`/`HowTo` 用 `SongDb.GetSongById(id)!` 抑制空值，若查分器返回本地曲库没有的谱（如新增谱在 bot 曲表刷新前），`GetSongById` 返回 null，随后 `Update1` 的 `MinBy` 取到该项再访问 `.Id` → 空引用。
**修复**：两处投影加 `.Where(x => x.Song != null)` 过滤未匹配曲（不影响 raOld/idSet 的额度统计，未匹配曲仍作为固定贡献计入）；并在 `Update1` 开头加 `if (list.Count == 0) return false;`，过滤后列表为空时不再对空集 `MinBy`。

### 7. Louis 数据源：单条坏记录崩掉整个 b30
**问题**：`BestScoreLouis.ToChunithmScore` 直接 `indexer[MusicId]` + `song.Constants[LevelIndex]`。只要 Louis 返回一首本地曲库没有的曲（删除/活动/新增曲，或 Louis 资源不可用回落时）或越界难度，`ReqScores` 就在 `DistinctBy` 前抛异常 → 整个 b30/summary 崩。AllNet/DivingFish 都有跳过守卫，唯独 Louis 没有。
**修复**：`ToChunithmScore` 改返回 `ChunithmScore?`，`TryGetValue` 未命中或 `LevelIndex` 越界（对 `Constants.Count`/`Levels.Count`）时返回 null；`ReqScores` 过滤 null 后再 `DistinctBy`，对齐另外两个 fetcher。

### 8. 「吃啥」：地点被删空后崩
**问题**：地点为空时回落 `_data.Values.SelectMany(x=>x).RandomTake(1).First()`；若所有地点都被删空，空序列 `.First()` 抛异常，且默认餐只播种一次不再补，「吃啥」对所有人失效。
**修复**：改 `FirstOrDefault() ?? "还没有可选的，先给我加点吃的吧"`。

### 9. 别名设置：制表符/换行会破坏别名 TSV
**问题**：`SetSongAlias` 把 `"{title}\t{alias}\n"` 未转义写入别名 TSV；alias 里的 tab/换行在重载时会被按列/行拆开，污染整张别名表。
**修复**：`SetSongAlias` 拒绝含 `\t`/`\n`/`\r` 的别名；调用处对该情况给出「别名不能包含制表符或换行」的正确提示（不再误报「不存在的歌曲」）。

### 10. osu todaybp：空结果文案写死「24 小时」
**问题**：`todaybp` 的时间窗随参数变（`tdbp 48` = 48 小时），但空结果文案硬编码「最近24小时」，任何非 24 的参数都会显示错误的窗口。
**修复**：文案按实际的 `command.Rank?.Start ?? 24` 插值。

### 11. osu 谱面解析：空行导致越界
**问题**：`GetBeatmapPathByBeatmapId` 里 `.TakeWhile(l => l.Trim()[0] != '[')`，遇到空行时 `""[0]` 越界。无 `BeatmapID:` 字段的老谱在最后的回落路径会一直读到 Metadata 段后的空行而崩，而不是干净地「未找到」。
**修复**：改 `.TakeWhile(l => !l.Trim().StartsWith('['))`，空行安全。

### 12. osu 查询：同步阻塞的 `.Result`
**问题**：`ParseCommand` 对「未在本地绑定、且未指定 mode 的用户名」查询会同步 `.Result` 阻塞在 osu API 的网络往返上，且当时持有打开的 Realm。高并发下会占用线程池线程。
**修复**：`ParseCommand` 与 `TryParseCommand`（改名 `ResolveCommand`）改为 async，7 个调用点随之 `await`。重构 Realm 作用域：把需要的字段（`GameMode`/`OsuUserId`）在 `using` 块内物化成普通值后关闭 Realm，再 `await`，避免续体在别的线程访问/释放 Realm（Realm 线程亲和）。连带修了 `GetOsuIdByName` 的同类隐患。

### 13. 消息派发：匹配阶段的异常被静默吞掉
**问题**：`Dispatch` 是惰性迭代器，触发/命令匹配阶段（自定义 trigger、`TryMatch`）抛出的异常发生在 `DependencyInjectInvoke` 的 try/catch 之外，冒泡到 `throw res.FinalException`；而 `ProcMessageStep` 是即发即弃（`_ = ProcMessageStep(...)`），这一 throw 变成无人观测的任务异常被静默丢弃——不写 dump、不回复、operator 也看不到。
**修复**：把 `throw res.FinalException` 改为 `Logger.Error` 记录，并给整个 body 套兜底 catch，确保即发即弃的任务不再有未观测异常逃逸。

---

## 未包含的项（说明）

- **无界并发（低危硬化项）**：曾尝试用 `SemaphoreSlim` 限制同时处理的消息数，但复查发现它会在**交互式对话**（选曲翻页 `MultiPageSelectResult(waitRes:true)`、猜曲等需要等待用户下一条消息的场景）下占用并发名额——那条回复本身也要抢同一名额，形成环形等待，导致 bot 假死（最长到 10 分钟超时才解开），比原问题更严重。故本 PR **未包含**该项；正确修法是让 handler 在等待用户输入期间先交还名额（协作式取消），改动较大，留待日后。

---

## 验证

- 全解决方案编译通过（0 警告 0 错误）。
- `DispatcherTest` 13/13 通过（直接覆盖派发路径的改动）。
- `Marisa.Plugin.Test` 相对基线无新增真实失败：既有失败均为缺 token / 缺网络的集成测试；满跑时多出的几例为 DivingFish 相关网络抖动，单独重跑即通过，且本 PR 未触及 DivingFish 代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
