### PR TITLE
fix(maimai): 完成表谱师真名查询与别名查询结果不一致

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -449,7 +449,7 @@ public static class PlateData
     /// </summary>
     public static readonly Dictionary<string, string[]> CharterAliasMap = new()
     {
-        ["哈皮"]       = ["はっぴー", "緑風 犬三郎", "原田ひろゆき", "シチミッピー", "鳩ホルぴー", "いぬっくまとボコっくま", "たかなっぴー", "Luxiいぬ", "“H”ack", "“H”ack underground", "PANDORA PARADOXXX", "Sukiyaki vs Happy"],
+        ["哈皮"]       = ["はっぴー", "緑風 犬三郎", "原田ひろゆき", "シチミッピー", "鳩ホルぴー", "いぬっくまとボコっくま", "たかなっぴー", "Luxiいぬ", "“H”ack", "“H”ack underground", "PANDORA PARADOXXX", "Sukiyaki vs Happy", "舞舞10年ズ"],
         ["沙发太"]     = ["サファ太", "さふぁた", "Safari", "-ZONE- SaFaRi", "-ZONE-Phoenix", "Safata", "ボコ太", "鳩サファzhel", "サぴぴぴぴちネファ太太太太コ", "ﾚよ†ょ／∪ヽ”┠  (十,3､了ﾅﾆ", "PANDORA BOXXX", "Ruby", "project raputa", "Safazhel"],
         ["maistar"]    = ["mai-Star"],
         ["小鸟游"]     = ["小鳥遊", "Phoenix", "たかなっぴー", "Anomaly Labyrinth", "ネコトリサーカス団"],
@@ -468,7 +468,7 @@ public static class PlateData
         ["桃子猫"]     = ["ぴちネコ", "ロシアンブラック", "BLaCK rOSE dIsEASe pATiENT", "サぴぴぴぴちネファ太太太太コ", "チェシャ猫とハートのジャック", "SHICHIMI☆CAT", "ネコトリサーカス団", "R-blacX of JacQ", "SAFARi☆CAT"],
         ["阿玛莉莉丝"] = ["アマリリス"],
         ["柠檬"]       = ["じゃこレモン", "僕の檸檬本当上手"],
-        ["DP皆传"]     = ["チャン@DP皆伝", "Garakuta Scramble!", "舞舞10年ズ（チャンとはっぴー）"],
+        ["DP皆传"]     = ["チャン@DP皆伝", "Garakuta Scramble!", "舞舞10年ズ"],
         ["科技厨房"]   = ["Techno Kitchen"],
         ["Revo"]       = ["Revo@LC"],
         ["蟹棒君"]     = ["カマボコ", "ボコ太", "いぬっくまとボコっくま"],
@@ -492,16 +492,59 @@ public static class PlateData
     };
 
     /// <summary>
-    ///     可直接打出的谱师本名 → 其高难马甲等额外 substring。命中本名（精确 Charter）时一并匹配马甲，
-    ///     无需把本名设成别名（设成别名会改变其 selector 类型、撞坏既有用例）。
+    ///     谱师身份名（本名/独立马甲）→ 该谱师全部名义 + 反向排除，仅匹配层使用（解析层不感知）。
+    ///     合作名义（七味星人、鳩サファzhel 等）不收——精确打合作名义仍只查该署名。
     /// </summary>
-    public static readonly Dictionary<string, string[]> CharterAlterEgoMap = new()
-    {
-        ["翠楼屋"] = ["翡翠マナ"],
-    };
+    public static readonly Dictionary<string, (string[] Names, string[] Exclude)> CharterIdentityMap = BuildCharterIdentityMap();
 
-    public static IEnumerable<string> CharterAlterEgos(string charterName) =>
-        CharterAlterEgoMap.TryGetValue(charterName, out var egos) ? egos : [];
+    private static Dictionary<string, (string[] Names, string[] Exclude)> BuildCharterIdentityMap()
+    {
+        // (别名 key, 身份名列表)。无中文别名的谱师（翠楼屋），名义组即身份列表。
+        (string AliasKey, string[] Identities)[] groups =
+        [
+            ("哈皮",     ["はっぴー", "緑風 犬三郎", "原田ひろゆき", "“H”ack", "“H”ack underground", "PANDORA PARADOXXX"]),
+            ("沙发太",   ["サファ太", "さふぁた", "Safari", "-ZONE- SaFaRi", "Safata", "PANDORA BOXXX", "Ruby", "project raputa"]),
+            ("小鸟游",   ["小鳥遊", "小鳥遊さん", "Phoenix", "Anomaly Labyrinth"]),
+            ("鸠",       ["鳩ホルダー", "The Dove"]),
+            ("企鹅",     ["ペンギン", "ロシェ@ペンギン", "ロシェ＠ペンギン"]),
+            ("泸溪河",   ["Luxizhel", "BELiZHEL"]),
+            ("7.3",      ["シチミヘルツ", "7.3Hz", "7.3GHz"]),
+            ("隅田川",   ["隅田川星人", "The ALiEN"]),
+            ("华火职人", ["華火職人", "“Carpe diem” ＊ HAN∀BI"]),
+            ("桃子猫",   ["ぴちネコ", "ロシアンブラック", "BLaCK rOSE dIsEASe pATiENT"]),
+            ("柠檬",     ["じゃこレモン", "僕の檸檬本当上手"]),
+            ("DP皆传",   ["チャン@DP皆伝", "Garakuta Scramble!"]),
+            ("蟹棒君",   ["カマボコ", "カマボコ君"]),
+            ("寿喜烧",   ["すきやき", "すきやき奉行"]),
+            ("红箭",     ["Redarrow"]),
+            ("甜口姜",   ["あまくちジンジャー", "EL DiABLO"]),
+            ("melonpop", ["メロンポップ", "ずんだポップ"]),
+            ("翠楼屋",   ["翠楼屋", "翡翠マナ"]),
+        ];
+
+        var map = new Dictionary<string, (string[], string[])>(StringComparer.OrdinalIgnoreCase);
+        foreach (var (aliasKey, identities) in groups)
+        {
+            var names   = CharterAliasMap.GetValueOrDefault(aliasKey) ?? identities;
+            var exclude = CharterAliasExclude.GetValueOrDefault(aliasKey, []);
+            foreach (var identity in identities) map.Add(identity, (names, exclude));
+        }
+        return map;
+    }
+
+    /// <summary>
+    ///     精确 Charter 的匹配谓词：输入恰为某身份名（忽略大小写）时按该人全部名义并集（含反向排除）匹配，
+    ///     使真名查询与别名查询结果一致；否则单一 substring（兼容 "サファ太 vs 翠楼屋" 这种合作署名）。
+    /// </summary>
+    public static bool MatchCharter(string signedCharter, string input) =>
+        CharterIdentityMap.TryGetValue(input, out var person)
+            ? MatchCharter(signedCharter, person.Names, person.Exclude)
+            : signedCharter.Contains(input, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>名义组 OR 命中且不落 Exclude。CharterAlias selector 与身份查询共用。</summary>
+    public static bool MatchCharter(string signedCharter, IReadOnlyList<string> names, IReadOnlyList<string> exclude) =>
+        names.Any(n => signedCharter.Contains(n, StringComparison.OrdinalIgnoreCase))
+        && !exclude.Any(x => signedCharter.Contains(x, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     ///     阈值表。第一项是用户输入的字符串（中文别名 + ASCII rank/fc/fs 缩写），第二项是阈值定义。
@@ -702,13 +745,17 @@ public static class PlateData
 
             // 谱师别名作为一等 token，且在 Constant 之前检查：多字别名「华火职人」靠长度压过单字代字「华」，
             // 同长度同位置时（「7.3」vs 定数 7.3）按先检查者胜出 → 别名优先。
-            if (TryFindRightmostCharterAliasInString(workingPart, out var caStart, out var caLen, out var caSel))
+            // 别名/定数 token 嵌在 workingPart 内出现的某个真谱师名/身份名里时（如「隅田川星人 13」
+            // 的「隅田川」）不参与竞争：让等级等 token 先剥，真名整段落到 precise Charter。
+            if (TryFindRightmostCharterAliasInString(workingPart, out var caStart, out var caLen, out var caSel)
+                && !TokenEmbeddedInCharterName(workingPart, caStart, caLen, knownCharters))
             {
                 if (caLen > matchLen || (caLen == matchLen && caStart > matchStart))
                 { matchStart = caStart; matchLen = caLen; matched = caSel; }
             }
 
-            if (TryFindRightmostConstantInString(workingPart, out var cStart, out var cLen, out var cSel))
+            if (TryFindRightmostConstantInString(workingPart, out var cStart, out var cLen, out var cSel)
+                && !TokenEmbeddedInCharterName(workingPart, cStart, cLen, knownCharters))
             {
                 if (cLen > matchLen || (cLen == matchLen && cStart > matchStart))
                 { matchStart = cStart; matchLen = cLen; matched = cSel; }
@@ -923,6 +970,18 @@ public static class PlateData
     }
 
     private static bool IsAsciiLetter(char c) => c is >= 'a' and <= 'z' or >= 'A' and <= 'Z';
+
+    /// <summary>候选 token 区间被 workingPart 内出现的某个更长真谱师名/身份名覆盖时，它是名字的一部分而非 selector。</summary>
+    private static bool TokenEmbeddedInCharterName(
+        string s, int start, int length, IReadOnlyCollection<string> knownCharters)
+    {
+        return knownCharters.Concat(CharterIdentityMap.Keys).Any(name =>
+        {
+            if (name.Length <= length) return false;
+            var i = s.IndexOf(name, Math.Max(0, start + length - name.Length), StringComparison.OrdinalIgnoreCase);
+            return i >= 0 && i <= start;
+        });
+    }
 
     /// <summary>
     ///     精确 charter 匹配：当且仅当 selectorPart 是某个已知 charter 名的 substring 时命中。

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Linq;
@@ -1154,14 +1155,84 @@ public class MaiMaiDxPlateDataTest
         Assert.That(((PlateData.Selector.Charter)q.Selectors.Single()).Name, Is.EqualTo("群青リコリス"));
     }
 
-    [Test]
-    public void CharterAlterEgoMapResolvesShisui()
+    // ──────────────────────────────────────────────────────────────────────
+    // 谱师身份并集（CharterIdentityMap + MatchCharter）：精确输入某身份名时按人级并集匹配，
+    // 使真名查询与别名查询同集。解析层不感知（selector 类型不变）。
+    // ──────────────────────────────────────────────────────────────────────
+
+    // 同一人的不同身份互相带出（含合作署名）；大小写不敏感。
+    [TestCase("The ALiEN",  "隅田川星人",     true)]
+    [TestCase("The ALiEN",  "隅田川華火大会", true)]
+    [TestCase("the alien",  "隅田川星人",     true)]
+    [TestCase("隅田川星人", "The ALiEN",      true)]
+    [TestCase("隅田川星人", "The ALiEN vs. Phoenix", true)]
+    [TestCase("翠楼屋",     "翡翠マナ",       true)]
+    [TestCase("翡翠マナ",   "翠楼屋",         true)]
+    [TestCase("Phoenix",    "小鳥遊さん",     true)]
+    [TestCase("BELiZHEL",   "Luxizhel",       true)]
+    [TestCase("ロシェ＠ペンギン", "ロシェ@ペンギン", true)]           // 全角＠身份（实际署名写法），与半角同人
+    [TestCase("チャン@DP皆伝", "舞舞10年ズ ～ファイナル～", true)]   // 短子串「舞舞10年ズ」覆盖两种合作署名
+    [TestCase("はっぴー",       "舞舞10年ズ ～ファイナル～", true)]
+    // 合作名义不是身份：精确打合作名义仍只查该署名。
+    [TestCase("七味星人",   "隅田川星人",     false)]
+    [TestCase("七味星人",   "超七味星人",     true)]  // substring 命中，非身份并集
+    // 非身份输入退化为单一 substring。
+    [TestCase("Jack",       "Jack & Licorice Gunjyo", true)]
+    [TestCase("Jack",       "隅田川星人",     false)]
+    public void MatchCharterUnifiesIdentitiesOfSamePerson(string input, string signed, bool expected)
     {
-        // 打本名「翠楼屋」时 handler 会并查马甲「翡翠マナ」（匹配层）；解析层仍是普通 Charter。
-        Assert.That(PlateData.CharterAlterEgos("翠楼屋"), Has.Member("翡翠マナ"));
-        Assert.That(PlateData.CharterAlterEgos("Jack"), Is.Empty);
+        Assert.That(PlateData.MatchCharter(signed, input), Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void MatchCharterAppliesExcludeToIdentityQueries()
+    {
+        // 「サファ太 respects for 小鳥遊さん」是 サファ太 的致敬独谱：身份查询（小鳥遊/Phoenix）要剔除，
+        // 但按 サファ太 身份查询要命中。
+        const string respects = "サファ太 respects for 小鳥遊さん";
+        Assert.That(PlateData.MatchCharter(respects, "小鳥遊"),  Is.False);
+        Assert.That(PlateData.MatchCharter(respects, "Phoenix"), Is.False);
+        Assert.That(PlateData.MatchCharter(respects, "サファ太"), Is.True);
+    }
+
+    [Test]
+    public void CharterIdentityMapIsConsistent()
+    {
+        // 每个身份名必须与其名义组相关（身份是某名义的 substring 或反之），防止身份挂错组。
+        foreach (var (identity, (names, _)) in PlateData.CharterIdentityMap)
+        {
+            Assert.That(names.Any(n =>
+                    n.Contains(identity, StringComparison.OrdinalIgnoreCase)
+                    || identity.Contains(n, StringComparison.OrdinalIgnoreCase)),
+                Is.True, $"身份「{identity}」与其名义组无关联");
+        }
+    }
+
+    [Test]
+    public void IdentityQueryKeepsCharterSelectorType()
+    {
+        // 身份并集只在匹配层生效，解析层契约不变：真名输入仍是普通 Charter selector。
         var q = MustParse("翠楼屋将完成表");
         Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+    }
+
+    // 别名/定数 token 嵌在真名里时不参与竞争：与等级组合的真名查询不被切开（否则静默丢同人署名）。
+    [TestCase("隅田川星人14完成表", "隅田川星人")] // 「隅田川星人」内嵌别名 key「隅田川」
+    [TestCase("7.3Hz 14完成表",     "7.3Hz")]     // 「7.3Hz」内嵌别名/定数同形 token「7.3」
+    public void IdentityNameEmbeddingAliasKeySurvivesComboQuery(string raw, string charter)
+    {
+        var q = MustParse(raw);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Charter>().Single().Name, Is.EqualTo(charter));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("14"));
+    }
+
+    [Test]
+    public void AliasComboWithLevelStillParsesAsAlias()
+    {
+        // 别名不嵌在任何真名里时，组合查询照常走别名（回归）。
+        var q = MustParse("川哥14完成表");
+        Assert.That(q.Selectors.OfType<PlateData.Selector.CharterAlias>().Single().Input, Is.EqualTo("川哥"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("14"));
     }
 
     // ---- 游戏内成就姓名框贴图映射 ----

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -1264,20 +1264,13 @@ public partial class MaiMaiDx
             // 复活曲集合（虚拟类别）。
             PlateData.Selector.Revival => PlateData.IsRevivalSong(song.Id),
 
-            // substring 匹配：兼容 "サファ太 vs 翠楼屋" 这种合作谱师名义。
-            // 本名命中后再并查其高难马甲（如打"翠楼屋"也带出"翡翠マナ"）。
             PlateData.Selector.Charter c =>
                 levelIdx < song.Charters.Count
-                && (song.Charters[levelIdx].Contains(c.Name, StringComparison.OrdinalIgnoreCase)
-                    || PlateData.CharterAlterEgos(c.Name).Any(e =>
-                        song.Charters[levelIdx].Contains(e, StringComparison.OrdinalIgnoreCase))),
+                && PlateData.MatchCharter(song.Charters[levelIdx], c.Name),
 
-            // 谱师别名：任一 canonical substring 命中即可（OR），覆盖本名 / 高难马甲 / 合作名义；
-            // 但命中 Exclude 的署名（含 substring 却不属本人）要剔除。
             PlateData.Selector.CharterAlias ca =>
                 levelIdx < song.Charters.Count
-                && ca.Names.Any(n => song.Charters[levelIdx].Contains(n, StringComparison.OrdinalIgnoreCase))
-                && !ca.Exclude.Any(x => song.Charters[levelIdx].Contains(x, StringComparison.OrdinalIgnoreCase)),
+                && PlateData.MatchCharter(song.Charters[levelIdx], ca.Names, ca.Exclude),
 
             // song-level substring 匹配，兼容 "sasakure.UK x DECO*27" 这种合作作曲名义。
             PlateData.Selector.Artist a =>
@@ -1287,7 +1280,7 @@ public partial class MaiMaiDx
             // 谱师 ∪ 作曲家：处理 "rintaro soma" 这种身兼两职的人。
             PlateData.Selector.CharterOrArtist ca =>
                 (levelIdx < song.Charters.Count
-                 && song.Charters[levelIdx].Contains(ca.Name, StringComparison.OrdinalIgnoreCase))
+                 && PlateData.MatchCharter(song.Charters[levelIdx], ca.Name))
                 || (!string.IsNullOrEmpty(song.Info.Artist)
                     && song.Info.Artist.Contains(ca.Name, StringComparison.OrdinalIgnoreCase)),
 


### PR DESCRIPTION
群友实测发现：完成表里「隅田川星人」和「The ALiEN」是同一位谱师，查询结果却不一样——前者 66 张谱、后者只有 3 张，而中文别名「隅田川」能查到完整的 73 张。原因是 #69 的人级并集只做在别名路径上：直接打真名走精确 substring 匹配，唯一的例外是当时为翠楼屋加的马甲并查（翠楼屋→翡翠マナ），没有推广到其他谱师。同类问题波及所有「一人多个可打名义」的谱师（Phoenix/小鳥遊、BELiZHEL/Luxizhel、The Dove/鳩ホルダー 等）。

本 PR 把「同一人怎么打结果都一样」补完整。

## 机制

- 新增谱师身份表：身份名（本名/独立马甲，18 组 50 个，归属全部沿用 #69 里确认过的关系）→ 该谱师全部名义 + 反向排除。精确谱师查询的输入恰为某身份名时按人级并集匹配，与对应中文别名同集；其余输入维持单一 substring 匹配（合作名义如「七味星人」精确打时仍只查该署名）。解析层不感知这张表，selector 类型与既有解析契约不变；原 CharterAlterEgoMap 并入，翠楼屋↔翡翠マナ 现在双向可查。
- 修一个组合查询的既有缺陷：「隅田川星人14完成表」这类输入，别名 token「隅田川」会把名字切开（解析成别名 + 等级 + 残段「星人」），静默少署名。现在别名/定数 token 嵌在某个真名里时不参与解析竞争，让等级等 token 先剥、真名整段走精确匹配。
- 反向排除（「サファ太 respects for 小鳥遊さん」不属小鸟游）此前只作用于别名路径，现在对身份查询同样生效——精确打「小鳥遊」不再误报这张谱。

## 数据修正

- 企鹅组补收全角＠写法「ロシェ＠ペンギン」：该谱师的合作署名实际用全角＠，从游戏/wiki 复制粘贴打出的正是这个形。
- 「舞舞10年ズ（チャンとはっぴー）」改为短子串「舞舞10年ズ」：ジングルベル MASTER 的署名是「舞舞10年ズ ～ファイナル～」，此前 DP皆传/哈皮 都覆盖不到（#69 遗留缺口）。

## 验证

- 全量曲库对照：50 个身份逐一验证「真名查询 = 别名查询」结果集相等；17 个非身份输入（合作名义、部分名、Jack 等）与改动前逐一同集，零回归；身份名与曲师名零碰撞。
- 相关测试套件 258 全绿（新增 22 个用例：身份并集/反向排除/一致性守卫/解析契约不变/组合查询与回归），全解决方案编译零警告。

*本 PR 的代码与文案由 Claude Fable 5 撰写。*