### PR TITLE
feat(maimai): 合并柚子别名库到歌曲别名表

### DIFF
--- a/Marisa.Frontend/public/assets/maimai/aliases.tsv
+++ b/Marisa.Frontend/public/assets/maimai/aliases.tsv
@@ -1,559 +1,559 @@
 	N/A	如月车站	无名	没名字	消除记忆	空格	空白
-"""411Ψ892"""	211985	411892	411Ψ892	985211
-#狂った民族２ PRAVARGYAZOOQA	#疯狂民族2 PRAVARGYAZOOQA
-+♂	加男	嘉然
--OutsideR:RequieM-	外R：安魂曲
-1000年生きてる	千年老妖	活了一千年
-184億回のマルチトニック	184亿回のマルチトニック	184亿次多调
-39みゅーじっく！	39music	39音乐！	大大大大大大傻逼
+"""411Ψ892"""	211985	411892	411Ψ892	985211	411	411👅892	三叉戟
+#狂った民族２ PRAVARGYAZOOQA	#疯狂民族2 PRAVARGYAZOOQA	250绝赞	Progynova	二百五十个绝赞	最炫民族风	最狂民族风	机娘2	汉堡	汉堡包	狂民族	狂民族2	疯狂的民族2	🍔
++♂	加男	嘉然	+男	plus男子	下头男	正男	男的来了
+-OutsideR:RequieM-	外R：安魂曲	outsider	吃拉面	吃泡面	吃面	嗦拉面	妹子嗦面	我和我的泡面	拉面	杯面	泡面	阿梓喵吃面	🍜
+1000年生きてる	千年老妖	活了一千年	1000年生	一千年生	别急24	千年	千年生	壁尻	存活千年	超越光2	超越窗
+184億回のマルチトニック	184亿回のマルチトニック	184亿次多调	184	184亿	184亿回
+39みゅーじっく！	39music	39音乐！	大大大大大大傻逼	39	39歌	39音乐	三玖
 411Ψ892	211985
-7thSense	七拍子	第七感
-8-EM	ATM	八音
-ALiVE	活着
-AMABIE	阿妈别
-AMAZING MIGHTYYYY!!!!	AM	惊人力量!!!!	惊异之力
-ARAIS	ARAI
-ARROW	箭	箭矢
-Abstruse Dilemma	深奥困境
-Acceleration	加速	转圈金曲
-Aegleseeker	光追	追光者
-Aetheric Energy	紫13大地雷
-After Burner	AB	冲破火网
-Agitation！	激动！	激荡
-Ai C	爱C
-Aiolos	A打头的风神	艾俄洛斯	艾欧洛斯
-Alcyone	昴宿六
-Alea jacta est!	孤注一掷	尼哥	白人打架	种植园纠纷	科比肘击詹姆斯	骰子已掷！	黑人击剑	黑人打架
-Alice in 冷凍庫	Alice in 冷冻库
-Alice's Suitcase	爱丽丝的手提箱
-Altale	机器人钓鱼	阿泰尔
-Apollo	阿波罗
-Armageddon	阿妈咯噔
-Arty Party	USAO Party	U趴	纵派	纵连派对	艺术派对
+7thSense	七拍子	第七感	7	7s	7th	7感	七感	旗杆	第七个sensei	阿斯特瑞之死	阿玛希斯特之死
+8-EM	ATM	八音	8em	syk	喰喰	大大大	大柰子	小孩	很酷，不说话	橘优羽	涩图
+ALiVE	活着	余华	嗷呜	活
+AMABIE	阿妈别	abie	啊妈逼	啊麻痹	没妈	阿妈比	阿玛别
+AMAZING MIGHTYYYY!!!!	AM	惊人力量!!!!	惊异之力	不可思议的大概概概概	四个感叹号	恋爱裁判2	恋爱裁判3	惊人强大	惊异全能	！！！！
+ARAIS	ARAI	八幡海铃	海玲	阿瑞斯	阿赖斯	鸟人	鸟加鸟加
+ARROW	箭	箭矢	OW	矢	箭头	🏹
+Abstruse Dilemma	深奥困境	ad	摩耶	鸟屎2
+Acceleration	加速	转圈金曲	acc	五毛	加速器
+Aegleseeker	光追	追光者	rtx	光锥	拉格兰	追光	🧐
+Aetheric Energy	紫13大地雷	ae	❤	亚当重锤	以太能量	应用工程
+After Burner	AB	冲破火网	东京热	后烧	燃尽
+Agitation！	激动！	激荡	agi	gbc	吉他姐2
+Ai C	爱C	aic	挨草	爱丽丝的摇篮	艾草
+Aiolos	A打头的风神	艾俄洛斯	艾欧洛斯	aio	肉包	阿米诺斯
+Alcyone	昴宿六	alc	凯尔希	古希腊掌管反手交互的神
+Alea jacta est!	孤注一掷	尼哥	白人打架	种植园纠纷	科比肘击詹姆斯	骰子已掷！	黑人击剑	黑人打架	2025春晚	aj	aje	avemujica	农具打架	击剑	宝可梦剑盾	打架	木已成舟	求求你们不要再打啦	种植园纷争	骰子已经掷下	骰子已被掷下	魂5	黑人打胶	🗿	🤺
+Alice in 冷凍庫	Alice in 冷冻库	冰箱	冷冻库	冷死爱丽丝	冻死爱丽丝	哦哦哦	爱丽丝	爱丽丝在冰箱
+Alice's Suitcase	爱丽丝的手提箱	as	手提箱	爱丽丝手提箱	🧳
+Altale	机器人钓鱼	阿泰尔	tga年度最佳	你先别急	别急2	削除的电线	天线	开心的小曲儿	机器人	漏电电线	电线
+Apollo	阿波罗	kana	☬	刹那转头	吴奇隆	我去是吴奇隆	独行月球	皇城刹那裙底发光	绝密航天	🍍
+Armageddon	阿妈咯噔	arma	⑥	世界末日	东方树叶	太阳信仰	核弹	灵乌路空	灵知的太阳信仰	阿玛革冬	阿空
+Arty Party	USAO Party	U趴	纵派	纵连派对	艺术派对	ap	arty	artyparty	usao派对	usao银趴	usao音趴	动物园	动物派对	动物银趴	小动物开银趴	小动物淫趴	小动物银啪	小动物银帕	小动物银趴	小动物音趴	我和我的动物朋友们	狐朋狗友	粉兔	银趴	🐻🐱🐰🐶雪豹
 Axeria	ax	阿克塞里亚
-B.B.K.K.B.K.K.	Bass kick	bbkkbkk
-B.M.S.	bms	光吉
-BAD∞END∞NIGHT	BAD END NIGHT	坏结夜
-BANG!	砰！
-BATTLE NO.1	战地一	战斗第一	战第一	打架第一名	第一战	缝合怪
-BETTER CHOICE	更好的选择	更好选择
+B.B.K.K.B.K.K.	Bass kick	bbkkbkk	bbk	bbkk	bk	↑↑↓↓↑↓↓	↑↓	汉堡王
+B.M.S.	bms	光吉	光吉猛修他爹	冰美式	披萨	抱猫神	达美乐披萨
+BAD∞END∞NIGHT	BAD END NIGHT	坏结夜	badendnight	∞	♾️	鬼畜公馆
+BANG!	砰！	bang	棒	邦	钢管
+BATTLE NO.1	战地一	战斗第一	战第一	打架第一名	第一战	缝合怪	14个男人	tanoc	一战	好多人	干架第一名	战地1	战斗爽	战斗，爽！	打架第一	打胶第一名	第一名	聚众斗殴	阿莫阿莫	音游难忘今宵
+BETTER CHOICE	更好的选择	更好选择	烈焰红唇	👄
 BIRTH	出生	初生	畜生	诞生
-BLACK ROSE	黑玫瑰
-BLACK SWAN	黑天鹅
-BLUE ZONE	蓝区	蓝的车	蓝色地带
-BOKUTO	剥裤头	波裤头
+BLACK ROSE	黑玫瑰	迪卢克	黑肉丝
+BLACK SWAN	黑天鹅	周黑鸭	布莱克死亡	甘雨	神乐七奈	路西法	香菇	黑丝袜	黑色丝袜	黑蒜
+BLUE ZONE	蓝区	蓝的车	蓝色地带	极品飞车	蓝得盆	蓝界	蓝的区	蓝的盆	蓝粽	蓝色高级车	蓝车	飞车
+BOKUTO	剥裤头	波裤头	→↓→↓→↓→↓	破裤头
 BOOM! BOOM!! BOOM!!!	砰砰砰	砰！砰！！砰！！！
-BOUNCE & DANCE	弹跳与舞蹈	蹦跳与舞动
-BREAK YOU!!	击碎你！！	破坏你	绝赞你
-BREaK! BREaK! BREaK!	bbb	卧槽全大P	爆爆爆	绝赞绝赞绝赞
-BULK UP (GAME EXCLUSIVE EDIT)	增肌（游戏独占版）
-BaBan!! －甘い罠－	BaBan!! －甜蜜陷阱－	甜蜜的陷阱
-Back 2 Back	b2b	回二回	背靠背
-Backyun! －悪い女－	Backyun! －坏女人－	Backyun! －恶い女－	恶女
+BOUNCE & DANCE	弹跳与舞蹈	蹦跳与舞动	bounce dance	bounce＆dance	又蹦又跳	小星	小白兔	弹力舞	弹舞	弹跳
+BREAK YOU!!	击碎你！！	破坏你	绝赞你	breakyou	炸你	爆你	碎了你	跟你爆了
+BREaK! BREaK! BREaK!	bbb	卧槽全大P	爆爆爆	绝赞绝赞绝赞	3b	break	break!break!break!	kop2	βββ	三个绝赞	三绝赞	不不不	仨绝赞	哔啵拜	哔波掰哔波掰	大b歌	崩三	崩坏3	崩坏三	崩崩崩	爆！	爆！爆！爆！	破坏破坏破坏	绝赞³	绝赞！绝赞！绝赞！	绿绿绿	苹果苹果派	落落落
+BULK UP (GAME EXCLUSIVE EDIT)	增肌（游戏独占版）	bulk	bulk up	bulkup	三千快乐曲
+BaBan!! －甘い罠－	BaBan!! －甜蜜陷阱－	甜蜜的陷阱	baban	八班	甘民	甜蜜陷阱
+Back 2 Back	b2b	回二回	背靠背	2B	b歌	一笔画	回2回	背2背
+Backyun! －悪い女－	Backyun! －坏女人－	Backyun! －恶い女－	恶女	坏女人	妖艳魔女	恶之女	我异域了
 Bad Apple!! Feat.nomico (REDALiCE Remix)	坏苹果remix
-Bad Apple!! feat nomico	坏苹果
-Bad Apple!! feat.nomico (REDALiCE Remix)	坏苹果	坏苹果!! feat.nomico (REDALiCE混音)
-Bad Apple!! feat.nomico (Tetsuya Komuro Remix)	坏苹果 feat.nomico (小室哲哉混音版)	坏苹果!! feat.nomico (小室哲哉混音)
-Bad Apple!! feat.nomico ～五十嵐 撫子 Ver.～	Bad Apple!! feat.nomico ～五十岚 抚子 Ver.～	坏苹果!! feat.nomico ～五十岚抚子版～
-Baddest	哈里路大旋风	日本女子高中生大笑1分钟	最坏
-Bang Babang Bang!!!	太大了我都看晕了	砰巴砰砰！！！	邦邦邦	邦邦邦邦
-Baqeela	巴奇拉
+Bad Apple!! feat nomico	坏苹果	badapple	bdap	good huawei	iphone	好华为	好安卓	烂苹果	黑白苹果	黑苹果
+Bad Apple!! feat.nomico (REDALiCE Remix)	坏苹果	坏苹果!! feat.nomico (REDALiCE混音)	badappleremix	dx坏苹果	坏苹果3	坏苹果remix	小红的烂苹果	烂苹果3	烂苹果remix	红苹果	🍎
+Bad Apple!! feat.nomico (Tetsuya Komuro Remix)	坏苹果 feat.nomico (小室哲哉混音版)	坏苹果!! feat.nomico (小室哲哉混音)	25黑苹果	坏苹果4	黑苹果
+Bad Apple!! feat.nomico ～五十嵐 撫子 Ver.～	Bad Apple!! feat.nomico ～五十岚 抚子 Ver.～	坏苹果!! feat.nomico ～五十岚抚子版～	中二坏苹果	彩绿坏苹果	彩绿烂苹果	彩绿苹果	纵连坏苹果
+Baddest	哈里路大旋风	日本女子高中生大笑1分钟	最坏	16块钱	十六块钱	坏极了	太坏了	樋口枫	樋口枫大旋风
+Bang Babang Bang!!!	太大了我都看晕了	砰巴砰砰！！！	邦邦邦	邦邦邦邦	bbb	bbbb	大奶子	大柰子	大胸	太大了	邦邦
+Baqeela	巴奇拉	巴奎拉
 Barbed Eye	坏眼	狗谷爱
-Beat Of Mind	bom	nmb的mai	心灵节拍
-Beat Opera op.1	甘雨	节拍歌剧 op.1
-Beat of getting entangled	boge	纠缠之拍	纠缠的节拍	胡来的处男	胡辣汤
-Beautiful Future	美丽未来
-Beginning together!	一起开始！	开始同行
-Believe the Rainbow	相信彩虹
-Big Daddy	大爹	大老爹	星野爱高潮
-Black Lair	黑巢
-Black Out	黑出
-Blank Paper (Prod. TEMPLIME)	白纸	空白纸张 (Prod. TEMPLIME)
-Blew Moon	吹月
-Bloody Trail	血痕	血路
-Blows Up Everything	吹爆	炸毁一切	瞎几把吹
-Boys O’Clock	男孩时钟
-Brain Power	O-oooooooooo	脑力
-Brand-new Japanesque	全新和风	全新日本人
-Burn My Soul	燃我灵魂
-Burning Hearts ～炎のANGEL～	BR	燃烧之心 ～火焰天使～	阳炎
+Beat Of Mind	bom	nmb的mai	心灵节拍	买了麦乐鸡	彩虹糖	心跳	打脑阔	红鼻子男
+Beat Opera op.1	甘雨	节拍歌剧 op.1	op	op1	歌剧1	甘雨鬼叫
+Beat of getting entangled	boge	纠缠之拍	纠缠的节拍	胡来的处男	胡辣汤	❓	一坨蓝	别急13
+Beautiful Future	美丽未来	大好前程	无一物啊啊	美味	美好未来	美好的未来	雷炎
+Beginning together!	一起开始！	开始同行	开始一起
+Believe the Rainbow	相信彩虹	btr	别信彩虹	北面	彩虹	彩虹六号	彩虹桥	相信LGBT	辉代主题曲	🌈
+Big Daddy	大爹	大老爹	星野爱高潮	nero	notail	大坝	大爸	大爸爸	大跌	无敌爸爸	星野爱	比格大帝	汤姆猫	阿嘿颜	🤩	🥵
+Black Lair	黑巢	bl	公主斗恶龙
+Black Out	黑出	晕倒	曼巴out	黜
+Blank Paper (Prod. TEMPLIME)	白纸	空白纸张 (Prod. TEMPLIME)	blank paper	空白纸
+Blew Moon	吹月	blew shit	吹月亮	哇哇哇哇哇哇耶耶耶	蓝月亮	🌙
+Bloody Trail	血痕	血路	血迹	贝利亚
+Blows Up Everything	吹爆	炸毁一切	瞎几把吹	6级白谱	bue	吹	吹吹爆	吹爆一切	嘿嘿歌	拆爆	爆
+Boys O’Clock	男孩时钟	tfboys	男同时刻	男同时间	男同时间到	男孩时间
+Brain Power	O-oooooooooo	脑力	bass kick	bp	佐助	圣诞老头	地精老头	观星
+Brand-new Japanesque	全新和风	全新日本人	如龙	如龙0	如龙见参
+Burn My Soul	燃我灵魂	红烧天堂
+Burning Hearts ～炎のANGEL～	BR	燃烧之心 ～火焰天使～	阳炎	炎天使	烧心
 CHAOS	混沌	超市	超死
-CHOCOLATE BOMB!!!!	巧克力炸弹
-CITRUS MONSTER	CM	柑橘怪物	橘子怪兽
-CO5M1C R4ILR0AD	5140	cosmic railroad	宇宙铁道	星穹铁道	银河铁道
-CYBER Sparks	cs	赛博火花	魔光炮	魔理沙爆炸
-CYCLES	循环	轮回	马挖路	马瓦鲁
-Calamity Fortune	cf	卡拉米提佛纯	灾厄命运	穿越火线
-Caliburne ～Story of the Legendary sword～	咖喱棒	圣剑1	圣剑传说	生煎1
-Candy Tall Woman	砍弟搞女人	糖果高个女	糖果高女士	糖高女	高血糖女人
-Catch Me If You Can	抓到我算你赢	来抓我啊
-Catch The Future	抓住未来
-Catch the Wave	赶上潮流
-Caterpillar Song	毛毛虫之歌
-Change Our MIRAI！	com	五对奶子	五对柰子	改变我们的未来！	改变未来
-Chronomia	时律	时间法则
-Churros Parlor	吉事果屋	吉事果店
-Cider P@rty	苹果派对	苹果酒派对
-City Escape: Act1	城市逃亡：第一幕	索1
-Climax	stop in maimai	妖艳魔男	高潮
-Club Ibuki in Break All	伊吹俱乐部全破坏	绝赞俱乐部	西瓜跳舞
+CHOCOLATE BOMB!!!!	巧克力炸弹	cho爆炸	巧克力爆	巧克力蚌埠	答辩2	🍫💣
+CITRUS MONSTER	CM	柑橘怪物	橘子怪兽	柑橙怪兽	柚子怪兽	橘怪	欧润吉	🍊
+CO5M1C R4ILR0AD	5140	cosmic railroad	宇宙铁道	星穹铁道	银河铁道	514	co5	railroad	⭐️奴	五氧化碳	宇宙泥头车	宇宙铁路	崩坏星穹铁道	星奴	星怒铁道	星穹轨道	星铁	水晶火车	火车头	铁路	银河列车	银河铁路	雷切2
+CYBER Sparks	cs	赛博火花	魔光炮	魔理沙爆炸	endtime青春版	反恐精英	小endtime	赛博斯派克	赛博炮	黄色嘉然	🧹
+CYCLES	循环	轮回	马挖路	马瓦鲁	cyc	cycle	吗哇路	挖马路	饼饼快乐曲	马哇路	马洼路	马瓦路	🐎🐸🦌	🐴🐸🦌
+Calamity Fortune	cf	卡拉米提佛纯	灾厄命运	穿越火线	dxcf	leaf教你画星星	sdcf	小鸟游没几几	常发	早苗教你画星星	标cf	标准cf
+Caliburne ～Story of the Legendary sword～	咖喱棒	圣剑1	圣剑传说	生煎1	圣剑	圣剑一	生煎	石中剑	福瑞	福瑞1
+Candy Tall Woman	砍弟搞女人	糖果高个女	糖果高女士	糖高女	高血糖女人	太宗偷女人	狗日的wjr	糖女士	糖果高女人	高血糖
+Catch Me If You Can	抓到我算你赢	来抓我啊	你抓不住我	兔女郎	兔女郎彩华	抓我	抓我如果你可以	早乙女彩华	有种抓住我	来抓我呀	樱岛麻衣	猫鼠游戏	露娜
+Catch The Future	抓住未来	洋葱
+Catch the Wave	赶上潮流	10	ctw	抓波	抓波浪	抓浪	歌姬计划	👆🏻👌🏻
+Caterpillar Song	毛毛虫之歌	别急15	女菩萨念经	室内系武士	昆虫学家法布尔	毛毛虫	肯德基	肯德基老爷爷	臭虫	🐛
+Change Our MIRAI！	com	五对奶子	五对柰子	改变我们的未来！	改变未来	dx五对奶子	不含月铃姐妹	中年男人	五个女人	四大一小	四对奶子	小心彩绿
+Chronomia	时律	时间法则	天文钟
+Churros Parlor	吉事果屋	吉事果店	cp	巴哈姆特	油条客厅	达达利亚
+Cider P@rty	苹果派对	苹果酒派对	cider party	cp	汽水派对
+City Escape: Act1	城市逃亡：第一幕	索1	act1	刺猬头跑酷
+Climax	stop in maimai	妖艳魔男	高潮	squirt	我有很多手指	犀利马克思	犀利麦克斯	阿莱乌斯	魔男	🐍🐳
+Club Ibuki in Break All	伊吹俱乐部全破坏	绝赞俱乐部	西瓜跳舞	ymn	东方年柄年中	小bbb	萃香跳舞
 CocktaiL	鸡尾酒
-Color My World	彩绘世界	彩色我的世界
-Colorfull:Encounter	多彩相遇
-Comet Panto Men!	彗星潘托男！	特大跳舞
-Complex Mind	复杂心境	复杂心智
-Conquista Ciela	征服天空
-Contrapasso -paradiso-	ctps	天堂	天堂齿轮
-Cosmic Magic Shooter	宇宙魔术射手	宇宙魔法射手
-Cosmic Train	宇宙列车
-Counselor	顾问
-Crazy Circle	疯圈	黑喂狗
-Credits	cooperation	信用	制作人员	学分
-Crush On You	COU	coy	创死你	迷恋你
-Cry Cry Cry	哭哭哭
-Cryptarithm	密码算术
-Cthugha	克图格亚	火球
-Cyaegha	完形填空	绿魔王
-DADDY MULK -Groove remix-	爸爸奶	老爹牛奶 -律动混音-
-DANGEROOOOUS JUNGLE	危险丛林
-DETARAME ROCK&ROLL THEORY	detarame	胡扯摇滚理论
-DEVOTION	奉献
-DO RORO DERODERO ON DO RORO	多罗罗	源平2	百鬼大战绘卷	迪罗迪罗
-DRAGONLADY	龙女士
-DROPS feat. Such	坠落 feat. Such	水滴 feat. Such
+Color My World	彩绘世界	彩色我的世界	302	cmw	悲怆	颜色我世界	颜色我的世界
+Colorfull:Encounter	多彩相遇	绿黑姬
+Comet Panto Men!	彗星潘托男！	特大跳舞	cpm	man	men！	卖鱼客	彗星哑剧人	求生之路	特大男人
+Complex Mind	复杂心境	复杂心智	cm	复合思维	复杂思维
+Conquista Ciela	征服天空	cc	光吉猛修	头疼	电脑战机	男人唱歌	脑阔疼
+Contrapasso -paradiso-	ctps	天堂	天堂齿轮	cp	⚙	⚙️	齿轮	齿轮天堂
+Cosmic Magic Shooter	宇宙魔术射手	宇宙魔法射手	cms	感情的摩天楼	摩天轮	魔弹射手	魔术射手	魔法射手
+Cosmic Train	宇宙列车	ct	green主题曲	地铁	小星穹铁道	星穹列车	星穹铁道	星空列车	超代主题曲
+Counselor	顾问	小护士	律师
+Crazy Circle	疯圈	黑喂狗	ddlc	多多理财
+Credits	cooperation	信用	制作人员	学分	corporation	信用卡	信誉	可用点数	安眠曲	提供	点数	王一鑫	🐘
+Crush On You	COU	coy	创死你	迷恋你	ikun	冲你身上	创似拟	厉不厉害你坤哥	小黑子	性感良辛在线热舞	我喜欢你	撞死你	星摆2	暗恋你	木有芭蕾	母牛芭蕾	蔡徐坤	虫儿飞	鸡你太美
+Cry Cry Cry	哭哭哭	ccc	crycrycry	嗷嗷哭	😭😭😭
+Cryptarithm	密码算术	削除鬼叫2	密码学
+Cthugha	克图格亚	火球	南瓜头	古神	大火球	岩浆怪	火神	火神2	炎头	赛图格亚	🎃
+Cyaegha	完形填空	绿魔王	dabcabcaabcadbaa	古神语	咲弥	咲弥削吐司	塞伊格亚	完型填空	花绿青	赛伊格亚	赛洛图亚	赛落图亚
+DADDY MULK -Groove remix-	爸爸奶	老爹牛奶 -律动混音-	大爹奶	大爹马克	忍者战士	爸爸的雷达	爹地奶	爹奶	爹爹奶
+DANGEROOOOUS JUNGLE	危险丛林	dj	危险森林	大腿	超级大腿	阿尔卑斯与危险森林
+DETARAME ROCK&ROLL THEORY	detarame	胡扯摇滚理论	8787	drrt	drt	摇滚理论	星星歌	箱部弹吉他	箱部的摇滚理论	萝莉～萝莉～
+DEVOTION	奉献	挚爱	热爱	献身	虔诚
+DO RORO DERODERO ON DO RORO	多罗罗	源平2	百鬼大战绘卷	迪罗迪罗	dororo	原批大战罕见2	百鬼	百鬼大战罕见
+DRAGONLADY	龙女士	ub	喇叭	尼美舒利	母奶龙	纵连女士	舍得	龙之梦	龙女	龙玉涛
+DROPS feat. Such	坠落 feat. Such	水滴 feat. Such	drops
 DUAL ROZES	双玫瑰
-Danza zandA	小号歌	蛋砸砸蛋
-Death Scythe	死亡镰刀	死镰
+Danza zandA	小号歌	蛋砸砸蛋	danza	万达	砸蛋	蛋砸
+Death Scythe	死亡镰刀	死镰	ds	死镰1
 Define	定义
-Deicide	弑神
-Desperado Waltz	亡命之徒华尔兹	绝望的华尔兹
-Destiny Runner	命运奔跑者
-Destr0yer	d0	destroyer	削除光线
-Dive into The Sky ～initialized～	潜入天空～初始化～	飞入天空 ～初始化～
-Divide et impera!	分而治之	分而治之！
-Doll Judgment	DJ	人偶审判	人形裁判
-Don't Fight The Music	不要打歌	别与音乐为敌	别打歌	别打音乐
-Dragoon	鸭头	龙	龙骑兵	龙骑士
-Dreadnought	手电筒	电棒子
-Dreampainter	sta金曲	梦之画家	梦境绘画者
-Drive Your Fire	开你的火	开火
-D✪N’T  ST✪P  R✪CKIN’	don't stop rocking	dont stop rocking	dsr
+Deicide	弑神	弑神者
+Desperado Waltz	亡命之徒华尔兹	绝望的华尔兹	亡徒华尔兹	华二	华尔兹	噔噔噔	安塞腰鼓	打鼓的小女孩	第三只手
+Destiny Runner	命运奔跑者	dr	命运跑者	蕾米莉亚
+Destr0yer	d0	destroyer	削除光线	----------☀️◻	destr🦌yer	dx削除射线	null	——口	别急10	削除	削除射线	方块头	标d0	标准d0	毁灭方块人	毁灭者	消除男	界限突破	神父	终极闪光	驱逐舰
+Dive into The Sky ～initialized～	潜入天空～初始化～	飞入天空 ～初始化～	dive	潜入天空	风神少女
+Divide et impera!	分而治之	分而治之！	kop决胜bgm	击剑2	打架2	猫娘打架	猫娘打架2	黑人打架2
+Doll Judgment	DJ	人偶审判	人形裁判	人偶	人偶裁判	人形审判	玩偶	玩偶审判
+Don't Fight The Music	不要打歌	别与音乐为敌	别打歌	别打音乐	刹那	刹那立正	宵崎奏	小气走	憋打歌
+Dragoon	鸭头	龙	龙骑兵	龙骑士	多拉贡	奶龙	白龙	绝味鸭头	绝味鸭脖	麻辣兔头	麻辣鸭头	龙先生	🐉	🐲
+Dreadnought	手电筒	电棒子	大喷菇	巧脆卷	无畏号	无畏号战舰	无畏战舰	无畏舰	望远镜	死亡手电筒	🔦
+Dreampainter	sta金曲	梦之画家	梦境绘画者	绘梦者	🎩
+Drive Your Fire	开你的火	开火	大姨父	极地大冲击	红色电音	驾驶你的火
+D✪N’T  ST✪P  R✪CKIN’	don't stop rocking	dont stop rocking	dsr	astrobot	dont stop rockin	q群管家	tga年度最佳	⭐⭐⭐	宇宙机器人	小机器人	年度最佳	年度最佳游戏	摇滚别停	机器人	玩机器	秧bot	🤖
 D✪N’T ST✪P R✪CKIN’	别停摇滚
-ECHO	一口	回声	恶臭
-ENERGY SYNERGY MATRIX	ESM	傻吊猫	沙雕猫	能量协同矩阵
-ENJOY POLIS	享乐都市
-EVERGREEN	一直绿	常绿	常青	青春永驻
-EYE	眼
-Edelweiss	雪绒花
-Elemental Ethnic	元素民族
+ECHO	一口	回声	恶臭	A口	人形师单手鸟	电视头	诶口
+ENERGY SYNERGY MATRIX	ESM	傻吊猫	沙雕猫	能量协同矩阵	dxesm	dxesm跑	esm跑	恶俗猫	标esm	神经猫	跑路猫	邮政	饿死猫
+ENJOY POLIS	享乐都市	enjoypolis
+EVERGREEN	一直绿	常绿	常青	青春永驻	eg	常绿树	永绿	绿一色	绿色圆圈	长春	长荣
+EYE	眼	林狗	眼睛	羊哥	👀
+Edelweiss	雪绒花	前往堵门	熊出没
+Elemental Ethnic	元素民族	机关枪	机枪肌肉男	狗叫机关枪
 Empire of Winter	冬之帝国
-End Time	et	嗯了么	恩德太
-End of Twilight	暮光终结	黄昏终结
-Endless World	ew	无尽世界
-Endless, Sleepless Night	无尽不眠之夜	无尽不眠夜
-Energizing Flame	活力之焰	烈焰
-Estahv	白戒
-Ether Second	以太秒	以太第二
-Ether Strike	es	以太冲击	以太打击
+End Time	et	嗯了么	恩德太	endtime	伊岛	最后的老时	终时	终焉时刻	终章	结束啦
+End of Twilight	暮光终结	黄昏终结	夜之城	摩天楼	暮色	暮色终结	🌃
+Endless World	ew	无尽世界	口红	💄
+Endless, Sleepless Night	无尽不眠之夜	无尽不眠夜	esn	不眠之夜	不眠夜	东方不眠夜	俄罗斯娜娜	博丽灵梦	欧美博丽灵梦	漫漫长眠夜	灵梦1	美国灵梦
+Energizing Flame	活力之焰	烈焰	ef	机娘3	特蕾西娅	瑞文皇帝2	粉红机娘	粉色机娘	能量火	能量火焰	钢铁机娘2
+Estahv	白戒	arcahv精神续作	六戒	真寻	谢丝塔
+Ether Second	以太秒	以太第二	es2	以太二	以太冲击2
+Ether Strike	es	以太冲击	以太打击	my guiding star	乙醚罢工	以太攻击	白内障	白色电音以太大冲击	零光	零光吹喇叭	📢0
 Everybody Say HARDCORE TANO*C	人人喊硬核TANO*C	大家说硬核TANO*C
-Excalibur ～Revived resolution～	ex咖喱棒	圣剑2	生煎2	福瑞2	誓约胜利之剑～复苏的决心～
-FEEL ALIVE	女人赛跑	感受活着	感觉活着
+Excalibur ～Revived resolution～	ex咖喱棒	圣剑2	生煎2	福瑞2	誓约胜利之剑～复苏的决心～	圣剑二	生煎二
+FEEL ALIVE	女人赛跑	感受活着	感觉活着	小蜜蜂	感觉死	感觉活
 FEEL the BEATS	FB	ftb	感受节拍
-FFT	付费通	傅立叶快速变换	埃夫爱妇踢	快速傅里叶变换	狒狒头
-FLOWER	扶老二	花
-FLUFFY FLASH	毛茸茸闪光	软闪
-FREEDOM DiVE (tpz Overcute Remix)	FD	FDFD	自由俯冲 (tpz超可爱混音)	自由落体
-FUJIN Rumble	父进入母b了	父进入母逼	福晋软贝	风神	风神轰鸣
-Falling	坠落
-Falsum Atlantis.	亚特兰蒂斯	虚假亚特兰蒂斯
-Feel My Fire	感受我的火	感受我的火焰
+FFT	付费通	傅立叶快速变换	埃夫爱妇踢	快速傅里叶变换	狒狒头	ttf	傅立叶	傅立叶变换	傅立叶转换	傅里叶	傅里叶变换	发发图	喜报	大灵通	快速傅立叶变换	扶扶她	沙发太撸管	狒狒踢	福费廷	粪粪掏	芳芳痛
+FLOWER	扶老二	花	全機種制霸	扶寿二	花神	🌹
+FLUFFY FLASH	毛茸茸闪光	软闪	ff	ff14	福利闪光	结城莉玖
+FREEDOM DiVE (tpz Overcute Remix)	FD	FDFD	自由俯冲 (tpz超可爱混音)	自由落体	234.56	23456	fdmm	freedom dive	↓	丛雨	发癫	大陆首杀	牢大坠机	科比	自由戴夫	自由潜水
+FUJIN Rumble	父进入母b了	父进入母逼	福晋软贝	风神	风神轰鸣	fujin	gc风神	先天太乙神风诀	大风神	巴巴托斯	温迪
+Falling	坠落	佛泠	跳楼
+Falsum Atlantis.	亚特兰蒂斯	虚假亚特兰蒂斯	fa	亚特兰提斯	刹那	刹那下海	在海下面在海下面	水神8	皇城刹那	艾伦走路人	虚伪的亚特兰蒂斯
+Feel My Fire	感受我的火	感受我的火焰	fmf	感受我的烧	感觉我烧	海绵	爱如火
 Feel The Luv	感受爱
-FestivaLight	milked	节日之光	节日光
-Final Step!	最后一步	最后一步！
-First Dance	一！舞！	第一支舞
-Fist Bump	拳碰	碰拳
+FestivaLight	milked	节日之光	节日光	festival light	三小只	三相之力	日服之光	节日灯	雪代主题曲	魔法灯光夜
+Final Step!	最后一步	最后一步！	final step	fs	天天酷跑	终步
+First Dance	一！舞！	第一支舞	15	1！5！	e舞成名	fd	一曲成名	一舞	一舞成名	井芹仁菜	初舞	第一舞
+Fist Bump	拳碰	碰拳	索尼克力量
 Flashback	闪回
-Flashkick	快闪	闪踢
-Fragrance	大楼	斜塔	芬芳	香水
-Freak Out Hr.	失控时刻
-Future	未来	错位歌
-GEMINI -M-	双子星	戈米尼
-GEOMETRIC DANCE	几何舞步	几何舞蹈
-GET!! 夢&DREAM	GET!! 梦&DREAM	取得梦和梦	学园handsome	得到！！梦与梦想
-GIGANTØMAKHIA	三体	老头环	费大	走路人
-GO BACK 2 YOUR RAVE	g2r	gb2	gb2yr	回到你的锐舞	回去你的2rave	回去你的波
-GOODMEN	好人	好男人	良民
-GRÄNDIR	grandir
-Garakuta Doll Play	GDP	小丑	废品人偶剧	果丹皮	鬼牌
-Garden Of The Dragon	龙之花园	龙花园
-Geranium	天竺葵
-Get Happy	快乐起来	爽了	给爽
-Ghost Dance	幽灵舞	鬼舞
-Glorious Crown	王冠	皇冠	荣耀之冠
-Good Bye, Mr. Jack	再见杰克	再见杰哥
-Good bye, Merry-Go-Round.	旋转木马	旋转杩
+Flashkick	快闪	闪踢	flash	滑铲	闪击	闪电旋风劈	闪电旋风踢	黄色闪光
+Fragrance	大楼	斜塔	芬芳	香水	响水	喷香滴	白楼开花	白香芋	芒果	芳香	香香
+Freak Out Hr.	失控时刻	ksm和ykn	ksm和ykn背靠背	ykn和ksm	东云绘名vs宵崎奏	女同17	性感ksm和ykn	邦多利集结	邦高祖	雄氏老方	黑白双煞
+Future	未来	错位歌	ftr	蓝的人
+GEMINI -M-	双子星	戈米尼	gemini	genshin	googlegemini	双子座
+GEOMETRIC DANCE	几何舞步	几何舞蹈	gd	几何之舞	几何舞	几何跳舞
+GET!! 夢&DREAM	GET!! 梦&DREAM	取得梦和梦	学园handsome	得到！！梦与梦想	getdream	get梦	下巴戳死人学园	梦	火鸡帅哥2	获得梦和梦
+GIGANTØMAKHIA	三体	老头环	费大	走路人	alanwalker	elden ring	faded	gigantomakhia	kop3	刀客塔拿书	博士	博士读书	艾伦沃克	艾伦走路者	艾兰沃克	艾尔登法环	艾鲁迪克	褪色者
+GO BACK 2 YOUR RAVE	g2r	gb2	gb2yr	回到你的锐舞	回去你的2rave	回去你的波	2	业界骚然
+GOODMEN	好人	好男人	良民	好汉歌	良面	良麵	👍	👍🏻
+GRÄNDIR	grandir	gr	德文	瓜点	甘地
+Garakuta Doll Play	GDP	小丑	废品人偶剧	果丹皮	鬼牌	guy	joker	lbw	shq	国内生产总值	小丑牌	性感小丑在线发牌	扑克牌	管理	绿豆	轨道炮	酸奶	金盆	🃏	🤡
+Garden Of The Dragon	龙之花园	龙花园	wonderland	中国龙	喔喔喔	花园龙
+Geranium	天竺葵	贪玩蓝月2
+Get Happy	快乐起来	爽了	给爽	小系统z	得乐	得到开心	水果沙拉	系统g	给他哈皮
+Ghost Dance	幽灵舞	鬼舞	gd	幽灵跳舞	魂5
+Glorious Crown	王冠	皇冠	荣耀之冠	cat^o^	fd2	gc	史莱姆皇帝	团子	番茄炒蛋	荣耀的皇冠	👑
+Good Bye, Mr. Jack	再见杰克	再见杰哥	再见	再见我的杰	杰哥	杰哥不要
+Good bye, Merry-Go-Round.	旋转木马	旋转杩	good bye merry go round	good bye, mother-not-found	good bye, mother-not-found.	good bye, mothre-not-found	goodbye,mother-not-found	再见旋转木马	再见转圈圈	再见，旋转木马	旋转mua	旋转古神	日向千夏	木马	杩	江南style	白人掐腰	阿尼娅	龙图	🎠	🐎	🐴	🔁🌲🐴
 Got more raves？	gmr	还要狂欢吗？	郭沫若
-Grievous Lady	gl	对立拉窗帘	悲痛女士	病女
-Grip & Break down !!	紧握与崩溃!!	紧握与粉碎
-HANIPAGANDA	花牌甘达
-HECATONCHEIR	百臂巨人
-HERA	赫拉	黑拉
-HIMITSUスパーク	秘密火花
-HOT LIMIT	热限	阳性
-HUMANBORG	人类博格
+Grievous Lady	gl	对立拉窗帘	悲痛女士	病女	对立	有病的女士	生病的女人	痛苦的女士	老弱病残女
+Grip & Break down !!	紧握与崩溃!!	紧握与粉碎	gbd	grip	grip &amp; break down !!	东方铁拳乡	红魔馆内战	红魔馆爆炸	说的道理
+HANIPAGANDA	花牌甘达	两排奶龙	埴轮宣扬	奶龙军团	杖刀偶磨弓	汉尼拔	😯
+HECATONCHEIR	百臂巨人	heca	MysteryPrism	捅椅子	摆臂巨人	百手巨人	百足巨人
+HERA	赫拉	黑拉	一号键质检员	七匹狼	狐狸	狐狸模拟器	纵连	纵连高手	芝士雪豹	超级大串	🦊
+HIMITSUスパーク	秘密火花	秘密
+HOT LIMIT	热限	阳性	光吉熊	太烧辣	捆绑滴蜡熊	火辣限制	热限制	红熊	裸足	🥵
+HUMANBORG	人类博格	baddest2	人类伯格	人类堡	赛博人
 HYP3RTRIBE	超速部落
 Hainuwele	huawei	华为
-Halcyon	翡翠鸡
-Halfway(>∀<)	半途(>∀<)
-Hand in Hand	手牵手
-Heart Beats	心跳
+Halcyon	翡翠鸡	dx翡翠鸡	sd🐔	标准翡翠鸡	标翡翠鸡	浅鸽处刑曲	翡翠鸟	翡鸡杯	脆皮鸡	静谧之鸟	🐔
+Halfway(>∀<)	半途(>∀<)	(>∀<)	halfway	半路	爆能器	行百里者半九十	（>▽<）
+Hand in Hand	手牵手	hih	手在手里面	手拉手	握握手	诺基亚	难忘今宵
+Heart Beats	心跳	喝茶	幸福的兔子	铅笔画
 Heartbeats	小红金曲	心跳
-Heavenly Blast	天爆	皇冠2	😆
-Hello, Hologram	你好，全息	你好，全息图
-Help me, ERINNNNNN!!	erin	救救我，ERINNNNNN!!	永琳
-Help me, あーりん！	erin！erin！	救救我，亚铃！	教我，永琳！
-Her Dream Is To Be A Fantastic Sorceress	她的梦想是成为一名了不起的女巫	她的梦想是成为幻想魔女
-Horoscope Express	星座快车
-How To Make 音ゲ～曲！	如何制作音游曲！
-Hurtling Boys	疾驰少年
-Hyper Active	小黄车	泥头车	超活跃	黄卡车
-I ♥	我爱
-IMAWANOKIWA	今际之终	今际之边
-INFINITE WORLD	无限世界	英菲尼迪
-INFiNiTE ENERZY -Overdoze-	无限能量 -过量-	无限能量-过量
-INTERNET OVERDOSE	妍酱	网络过量
-INTERNET YAMERO	网络别这样	网络病娇
+Heavenly Blast	天爆	皇冠2	😆	fd3	hb	天堡	天暴	爆	球球	皇冠二	蜜雪冰城	跟你爆了	雪王	ｏ(≧∇≦)ｏ
+Hello, Hologram	你好，全息	你好，全息图	hello hologram	hello,hologram	hello，hologram	hh	hologram	你好holo	你好全息像	你好全息图像	全息图像	全息影像	管人跳舞2
+Help me, ERINNNNNN!!	erin	救救我，ERINNNNNN!!	永琳	帮帮我永琳姐	帮我	救我	救救我
+Help me, あーりん！	erin！erin！	救救我，亚铃！	教我，永琳！	帮帮我	帮我	帮我阿李安	彩绿永琳	救我	月铃姐妹
+Her Dream Is To Be A Fantastic Sorceress	她的梦想是成为一名了不起的女巫	她的梦想是成为幻想魔女	她的梦想是成为一名出色的女巫
+Horoscope Express	星座快车	he	horoscope	像素三小只	星座快讯	星际特快	观星列车
+How To Make 音ゲ～曲！	如何制作音游曲！	怎么做音游曲	音游曲	预制菜
+Hurtling Boys	疾驰少年	hb	大手	猛冲男孩	神之右手
+Hyper Active	小黄车	泥头车	超活跃	黄卡车	卡车	我们仨	撞大运	擎天柱
+I ♥	我爱	ilove
+IMAWANOKIWA	今际之终	今际之边	ima	imawa	临终	临终之际	弥留之际
+INFINITE WORLD	无限世界	英菲尼迪	天狗拍照	恶心丸	📷
+INFiNiTE ENERZY -Overdoze-	无限能量 -过量-	无限能量-过量	am2	ieo	坟前	坟前自拍	坟头拍照	坟头自拍	无限力量依赖	无限能量	🧺子
+INTERNET OVERDOSE	妍酱	网络过量	74块钱	daisuke	io	kotoko	overdose	主播女孩	主播女孩重度依赖	升天	土豆地雷	地雷女	小天使请安	我有抑郁症	我有玉玉症	玉玉症	管人	超天酱
+INTERNET YAMERO	网络别这样	网络病娇	†升天†	互联网太棒了	卷纸maimai	地雷女2	快远离互联网	超天酱2	躁郁症	马赛克2
 Idoratrize World	偶像化世界
 Ievan Polkka	甩葱歌
-Ignis Danse	火之舞	火神
-Ignite Infinity	点燃无限	燃尽无限
-Imitation:Loud Lounge	假面	呀哈哈	土著	奇面族	模仿：喧闹休息室
-Imperishable Night 2006 (2016 Refine)	2006	不朽之夜2006（2016精炼版）
-In Chaos	在超市	混沌之中	阴超市
-In my world (Prod. KOTONOHOUSE)	在我的世界 (Prod. KOTONOHOUSE)
-Infantoon Fantasy	if	婴儿幻想	婴童幻想
-Invitation	邀请
-Irresistible	不可抗拒
-I’m Here (feat. Merry Kirk-Holmes)	我在这里	我在这里 (feat. Merry Kirk-Holmes)
-JACKY [Remix]	JACKY [混音]	JACKY [混音版]
-JUMPIN' JUMPIN'	SH金曲	姜萍	跳跳
-Jack-the-Ripper◆	开膛手杰克	开膛手杰克◆
-Jimang Shot	急忙射
-Jouez Avec Moi?	与我共舞
-Jumble Rumble	DJ鼠	几把乱报	几把乱爆	混乱隆隆
-Jump!! Jump!! Jump!!	三蹦子	跳!!跳!!跳!!	跳跳跳
-Justified	森林冰火人	正义	正当化
-Jörqer	jorqer	乔尔格
-KILLER B	傻逼	杀B	杀手b	杀手乙
-KING	无名指扣牙
-KING is BACK!!	kib	王者归来	王者归来！！
-KISS CANDY FLAVOR	亲亲砍弟佐料	吻糖果味	小红帽
-KONNANじゃないっ！	才不是困难呢！	柯南
-Kairos	关键时机	凯洛斯
-Kattobi KEIKYU Rider	丁丁电车	京急	京急电车	列车	卡透批来打	叮叮电车	叮叮车
-Kinda Way	KW	有点路
-Kiss Me Kiss	吻我吻
-Knight Rider	霹雳游侠	骑士骑手
-Komplexe	像神一样啊
-L'épilogue	法文歌	终章
+Ignis Danse	火之舞	火神	一个妮子	一起去吃烤肉吧	卫宫士郎	史尔特尔	火影忍者	红孩儿	跳高
+Ignite Infinity	点燃无限	燃尽无限	psp2
+Imitation:Loud Lounge	假面	呀哈哈	土著	奇面族	模仿：喧闹休息室	丘丘人	面具	面具娃娃
+Imperishable Night 2006 (2016 Refine)	2006	不朽之夜2006（2016精炼版）	2016	永夜抄2006	灵梦玩火
+In Chaos	在超市	混沌之中	阴超市	inchaos	🐴	🐴！
+In my world (Prod. KOTONOHOUSE)	在我的世界 (Prod. KOTONOHOUSE)	imw	in my world	在我的世界
+Infantoon Fantasy	if	婴儿幻想	婴童幻想	两茄子	中指	中指机器人	竖中指	竖中指机器人	🖕	🖕🏻
+Invitation	邀请	！？
+Irresistible	不可抗拒	不可阻挡	可莉	魔卡少女樱
+I’m Here (feat. Merry Kirk-Holmes)	我在这里	我在这里 (feat. Merry Kirk-Holmes)	im here	imhere	我在这	索尼克未知边境
+JACKY [Remix]	JACKY [混音]	JACKY [混音版]	jacky	vr战士	舞萌往事
+JUMPIN' JUMPIN'	SH金曲	姜萍	跳跳	jj
+Jack-the-Ripper◆	开膛手杰克	开膛手杰克◆	jack the ripper	jtr	ripper	开膛手	杰克开膛手	杰哥	杰哥雷普
+Jimang Shot	急忙射	2015	囧仙	大叔唱歌	报纸歌
+Jouez Avec Moi?	与我共舞	jam	moi	和我玩	来一起玩	来玩	法文歌2	跟我玩	问号	陪我玩
+Jumble Rumble	DJ鼠	几把乱报	几把乱爆	混乱隆隆	dj猫	jr	午夜dj	小豆泽心羽	打碟猫	早苗叠	猫打碟	猫猫打碟	貌似困	魔法猫咪
+Jump!! Jump!! Jump!!	三蹦子	跳!!跳!!跳!!	跳跳跳	jump	元气少女蹦蹦蹦	芳文跳	跳三下
+Justified	森林冰火人	正义	正当化	哪吒大战敖丙	梅西大战科比	牌佬打架	红蓝对决
+Jörqer	jorqer	乔尔格	joker	j歌	pvq	qer	别急1.5	周可儿	小金熊	猫头鹰
+KILLER B	傻逼	杀B	杀手b	杀手乙	杀人蜂	果然敌人	王女
+KING	无名指扣牙	burger king	剔牙	姐就是女王	小夫	无名指抠牙	汉堡王	浮游生物	王	霸者	👑
+KING is BACK!!	kib	王者归来	王者归来！！	king is back	kobe is back	kobe is back!!	你回来了	王回家	王回来了	王归	王是后背	王是背	王负剑
+KISS CANDY FLAVOR	亲亲砍弟佐料	吻糖果味	小红帽	kcf	亲甜滴	亲糖口味	小女孩福瑞	糖的味道	糖糖
+KONNANじゃないっ！	才不是困难呢！	柯南	konnan	不该是这样	如龙5	才不是这样！	泽村遥	美腿
+Kairos	关键时机	凯洛斯	开罗	开罗斯	开肉丝	时间之神
+Kattobi KEIKYU Rider	丁丁电车	京急	京急电车	列车	卡透批来打	叮叮电车	叮叮车	丁丁车	五块钱	京急线	叮叮叮	叮叮叮叮叮	呦西哟西	收到	松江有轨	爱上火车	电车	电车妹	电车娘	电车骑士
+Kinda Way	KW	有点路	健达路	迷你世界
+Kiss Me Kiss	吻我吻	kiss	kissmeass	qwq	亲我亲
+Knight Rider	霹雳游侠	骑士骑手	kr	骑乘	骑士骑士	骑士骑骑士	骑骑	骑骑士士
+Komplexe	像神一样啊	complex	kom	大黑姬	雄氏老方	黑姬	黑姬唱歌
+L'épilogue	法文歌	终章	后记
 L4TS:2018 (feat. あひる & KTA	伊蕾娜	银发女孩
-L4TS:2018 (feat. あひる & KTA)	L4TS:2018 (feat. 鸭子 & KTA)
+L4TS:2018 (feat. あひる & KTA)	L4TS:2018 (feat. 鸭子 & KTA)	2018	knd	l4ts	伊蕾娜	宵崎奏	小七走	小奈子伊蕾娜	小奶子伊蕾娜	小气走	白毛萝莉	绫地宁宁	银发女孩
 L9	绿9	轴交互
-LAMIA	拉米亚
-LANCE	兰斯	男厕	蓝枪
-LOSE CONTROL	失控
+LAMIA	拉米亚	刹那	刹那拉面	战斗服宵崎奏	拉弥亚
+LANCE	兰斯	男厕	蓝枪	兰瑟	开元	懒死	枪	烂死	缆车	蓝瑟
+LOSE CONTROL	失控	塔露拉	失去控制	饕餮尤魔
 LOSER	卢瑟	我	输了
-LOSTPHANTASIA	失乐园幻想	失幻境
-LOVE EAST	爱东	爱东方	转转
-LUCIA	露西亚
-Last Brave ～ Go to zero	变成0	最后的勇气波浪线变成零	走向0
-Last Kingdom	最后王国
-Last Samurai	最后的武士
-Latent Kingdom	潜在王国	潜隐王国
-Let you DIVE!	纵身一跃	让你潜入！
-Let's Go Away	恶臭赛车	让我们离开
-Lia=Fail	圣剑3
-Life Feels Good	好日子	感觉很好	生活感觉好	生活感觉良好
-LiftOff	升空
-Lights of Muse	喵斯之光	缪斯之光
-Like the Wind [Reborn]	一块钱	如风 [重生]
-Limit Break	LB	极限突破	限制绝赞
-Limits	极限
-Link	林克
-Link(CoF)	链接
-Lionheart	狮心
-"Little ""Sister"" Bitch"	婊子	小婊妹	小婊子	碧池
-Live & Learn	SA2	活着与学习	生与学
-Lividi	李伟迪	李维迪
-Living Universe	活宇宙
-Lost Desire	失落的欲望	迷失的欲望
-Love Kills U	爱杀你
-Love You	爱你
-Love or Lies	爱或谎言
-Love's Theme of BADASS ～バッド・アス 愛のテーマ～	Love's Theme of BADASS ～バッド・アス 爱のテーマ～	拔大蒜	硬汉之爱主题曲
-Luminaria	光之颂
+LOSTPHANTASIA	失乐园幻想	失幻境	严肃灵梦	灵梦戴眼镜	电眼逼人
+LOVE EAST	爱东	爱东方	转转	爱吃
+LUCIA	露西亚	卢锡安	圣枪游侠	露西娅
+Last Brave ～ Go to zero	变成0	最后的勇气波浪线变成零	走向0	bt	勇敢变成0	去做0	去找0	我们去做0	最后勇敢变成0	机甲
+Last Kingdom	最后王国	lk	luke	小lk	最后的王国	终末帝
+Last Samurai	最后的武士	11月的雨	dx四月雨	lastsamurai	last炫	六月的雨	六月的食	六月雨	别急5	十一月的雨	唯我武士	年末的雨	拆弹	拉斯特萨姆热爱	拼好饭	星星武士	最后武士	武士	绝地武士	黄金船
+Latent Kingdom	潜在王国	潜隐王国	lk	三十块	三十块钱	俩曲师打架	大lk	曲师打架	潜伏王国	老二vs大国奏音	老二大战大国奏音
+Let you DIVE!	纵身一跃	让你潜入！	let you dive	lyd	wacca	伊丽莎白	让你潜	让你潜水	让你落
+Let's Go Away	恶臭赛车	让我们离开	梦游美国	芜湖	赛车
+Lia=Fail	圣剑3	l=f	liafail	剑3	命运之石	圣剑三	生煎3	生煎三	福瑞3
+Life Feels Good	好日子	感觉很好	生活感觉好	生活感觉良好	lfg	倍儿爽	生活好	生活真美好	真快活
+LiftOff	升空	dx四月雨	东云纺	关电梯	刑具	发射	妙脆角	抬棺	火箭	电梯下降	赫拉0.5	起飞	长角女孩
+Lights of Muse	喵斯之光	缪斯之光	lom	卡姿兰大眼睛	喵斯光	布若	暮色的光
+Like the Wind [Reborn]	一块钱	如风 [重生]	三潭印月	像风一样	像风一样复兴的	像风一样自由	动力甩尾	十段之壁	如风	莱克.德.万帝	蓝的盆	野兽先辈
+Limit Break	LB	极限突破	限制绝赞	三角初华	三角洲	三角洲行动	三角符文	界限打击	限界突破	黄金大三角
+Limits	极限	限制
+Link	林克	cof	朋友圈	链接
+Link(CoF)	链接	cof	link	朋友圈
+Lionheart	狮心	狮子心	莱因哈特
+"Little ""Sister"" Bitch"	婊子	小婊妹	小婊子	碧池	bitch	lsb	小sb	小妹妹臭婊子
+Live & Learn	SA2	活着与学习	生与学	开心超人	活和学	索尼克大冒险2
+Lividi	李伟迪	李维迪	执念	李云迪
+Living Universe	活宇宙	psp2	活在宇宙
+Lost Desire	失落的欲望	迷失的欲望	ld	失去感觉了	失去欲望了	失感	失欲
+Love Kills U	爱杀你	lku	爱情害你	爱杀了你	爱杀人	爱死你了	爱音吃西瓜
+Love You	爱你	我喜欢你
+Love or Lies	爱或谎言	lol	爱或谎
+Love's Theme of BADASS ～バッド・アス 愛のテーマ～	Love's Theme of BADASS ～バッド・アス 爱のテーマ～	拔大蒜	硬汉之爱主题曲	badass	僵尸骑摩托	哥布林骑摩托	扒大蒜	拔大葱	猫抓板	绿巨人骑摩托车
+Luminaria	光之颂	水神6	流明	海晶灯	露米娅	鹿米
 Lunar Mare	月马
-Lunatic Vibes	狂乱节拍	疯狂氛围
-Löschen	删除	消除
-M.S.S.Planet	M.S.S.行星	mss	妈杀杀星球
-MAGENTA POTION	品红药水	洋红药水
-MAGNETAR GIRL	磁星女孩	磁星少女
-MAKE IT FUNKY NOW	三明治	放克起来
-MAXRAGE	极怒	满怒	红温	绝赞交互	良怒2
-MEGATON BLAST	百万吨冲击	百万吨爆破
-MEGATON KICK	百万吨踢击
-METATRON	梅塔特隆	钟楼
+Lunatic Vibes	狂乱节拍	疯狂氛围	bo2	breakover2	lv	月狂氛围	疯狂震动	黑楼哉辉
+Löschen	删除	消除	loschen	螺丝陈
+M.S.S.Planet	M.S.S.行星	mss	妈杀杀星球	dxmss	我是地球
+MAGENTA POTION	品红药水	洋红药水	pmt决胜曲	假酒害人	品红色药水	指甲油	洋红色药水	粉红指甲油	粉香水	红药水	药水	魔法药水
+MAGNETAR GIRL	磁星女孩	磁星少女	mg	柚子	磁铁女孩
+MAKE IT FUNKY NOW	三明治	放克起来	funky	makeitfuckynow	mifn	milf	sandwich	两面包夹培根	两面包夹芝士	🥪
+MAXRAGE	极怒	满怒	红温	绝赞交互	良怒2	好生气	小七	巨他妈生气	很生气	急怒	暴怒	极限红温	核按钮	樱雨	气炸	气炸了	狂怒	红按钮	红色重启	续标识	超级生气	超雄	迪卢克	迪卢克按地雷	迪卢克按按钮	迪卢克按炸弹	😡
+MEGATON BLAST	百万吨冲击	百万吨爆破	mb	mfy	优香	体操服优香	华尔兹2	威震天爆炸	早濑优香	核爆	百万吨爆	百万吨爆炸	高濑梨绪
+MEGATON KICK	百万吨踢击	kick	mk	兆吨	大白腿	大飞脚	拉普兰德	李宁踹开线	百万吨级踢腿	百万吨踢	百万吨飞踢	踢腿	钢踢
+METATRON	梅塔特隆	钟楼	tat	五边形	元创	死镰2	死镰二	绝灭天使	马塔龙
 METEOR	流星
-MIRROR of MAGIC	MoM	镜魔	魔镜
-MOBILYS	灯球
+MIRROR of MAGIC	MoM	镜魔	魔镜	橙代主题曲	镜子魔法	魔法镜子
+MOBILYS	灯球	光球	困锁的灯	摸比利	橘子怪兽二	灯泡	灯灯灯灯	灯笼	电灯泡	💡
 MORNINGLOOM	晨光织机
-MUSIC PЯAYER	音乐玩家
-MYTHOS	小提琴	神话
+MUSIC PЯAYER	音乐玩家	musicprayer	幻想回廊	音祷
+MYTHOS	小提琴	神话	233	卖淫团伙原神	卖银团伙原神	卖骚死	🎻
 Maboroshi	幻影
-Magical Flavor	MF	milk+op	魔法味道	魔法风味
+Magical Flavor	MF	milk+op	魔法味道	魔法风味	galgame	别急27	白代主题曲
 Make Up Your World feat. キョンシーのCiちゃん & らっぷびと	创造你的世界 feat. 僵尸Ci酱 & 说唱人	妆点你的世界
-MarbleBlue.	大理石蓝
-Mare Maris	大帆船	小破船	开船	海之梦	海盗船	船医	船歌
-Maxi	马克西	马戏	马西
-Melody！	旋律	旋律！
-Metamorphosism	变态主义	消除鬼叫
-MilK	牛奶
-Mjölnir	钢琴冒烟	雷神之锤
-Money Money	紫苑镇	钱钱	骂你骂你
-Monochrome Rainbow	单色彩虹	黑白彩虹
-Moon of Noon	午月	尊尼获加	月儿子
+MarbleBlue.	大理石蓝	妈宝蓝
+Mare Maris	大帆船	小破船	开船	海之梦	海盗船	船医	船歌	stasis	⛵	大航海	小白船	帆船	明日方舟	海面谭	白船来航	船	贼船	郑和下西洋	鸭屁股	🚤
+Maxi	马克西	马戏	马西	dxmaxi	dx马戏	max!	嘻嘻马	标maxi	标准maxi	🐴😁
+Melody！	旋律	旋律！	melody	东方绚彩歌	美乐蒂	马老弟
+Metamorphosism	变态主义	消除鬼叫	meta	削除鬼叫	变形	变态	变质	哇袄	硅胶	质变
+MilK	牛奶	奶	白色液体	😋
+Mjölnir	钢琴冒烟	雷神之锤	mjo	mjolnir	mjr	冒烟钢琴	喵喵槌	喵喵锤	打火机	炸琴	砸钢琴	管子冒烟	管子海	脆脆薯条	钢琴	钢琴抽大烟	钢琴抽烟	麻将	🎹💨
+Money Money	紫苑镇	钱钱	骂你骂你	moneymoney	来财	钱钱钱钱钱	马内马内	💰
+Monochrome Rainbow	单色彩虹	黑白彩虹	dx单色彩虹	dx黑白彩虹	黑白格	😎
+Moon of Noon	午月	尊尼获加	月儿子	hop	一块钱3	五块钱	你过关	农具做瑜伽	印度人2	四块钱	堇神啊	星星入门	月吗	月孙子	牢大	牢大打坐	牢大硅胶	牢大鬼叫	科比跳舞	科比鬼叫
 Mr. Wonderland	梦幻岛	王大狼	王大郎
-Mutation	木糖醇
-My Dearest Song	大提琴	我最亲爱的歌	我爱歌	生日歌
-My First Phone	小灵通	我的第一部手机	电话
-My My My	mymymy	我我我	我的我的我的
-Mysterious Destiny	神秘命运	贝姐
-Mystic Parade	神秘游行
-N3V3R G3T OV3R	3333	ngo	永不结束
-NAGAREBOSHI☆ROCKET	流星火箭
-NIGHT OF FIRE	夜火	逮虾户
-NOIZY BOUNCE	嘈杂弹跳	噪动弹跳
-NULCTRL	空键
+Mutation	木糖醇	mocation	仁王	变化	变异	变种	木他神	木忒行	突变
+My Dearest Song	大提琴	我最亲爱的歌	我爱歌	生日歌	teravolt	女人拉提琴	我最亲爱的乐曲	母人拉大提琴	白奈
+My First Phone	小灵通	我的第一部手机	电话	☎️	中二的雨	别急20	别急3	座机	手机	爷の手机	👴的第一部手机
+My My My	mymymy	我我我	我的我的我的	mai mai mai	买买买	麦麦麦
+Mysterious Destiny	神秘命运	贝姐	md	猎天使魔女
+Mystic Parade	神秘游行	男同5
+N3V3R G3T OV3R	3333	ngo	永不结束	3炸	n3	never get over	别急18	别急19	双枪老太婆	四个三	永远不过
+NAGAREBOSHI☆ROCKET	流星火箭	像素猫猫	小羊	梅干茶渍	火箭	火箭猫	火箭猫猫	火箭福瑞	福瑞火箭	那旮热博士	飞天兽太
+NIGHT OF FIRE	夜火	逮虾户	niko	nof	世终舞厅	头文字d	奶头发炎	开幕大火	目害
+NOIZY BOUNCE	嘈杂弹跳	噪动弹跳	bud主题曲	双代主题曲	女同16
+NULCTRL	空键	cxk	nc	ntr	nul	wota艺	一根星星	唱跳rap篮球	无控	无控制	牛ctrl	牛唱跳rap	牛唱跳rap篮球	牛啃臭	牛啃草	红蓝	🐮🌿
 Natural Flow	自然流	自然流动
-Neon Kingdom	霓虹王国
-Nerverakes	两块钱	地球仪
-Never Give Up!	永不放弃	永不放弃！
-New York Back Raise	纽约后仰	纽约后抬
-Night Fly	发热金曲	夜飞
-NightTheater	夜之剧场	夜剧场
-Nitrous Fury	氮化福瑞
-No Limit RED Force	无极限红力	无限红力
-No Routine	无常规
-Now or Never	non	机不可失	现在或从不
-Nyan Cat EX	彩虹猫
-OMAKENO Stroke	大魔神击
-OTOGEMA	电棍
-Oath Act	誓约行动
-On your mark (104期 Ver.)	各就各位（104期 Ver.）
-One Step Ahead	领先一步
-Oshama Scramble!	Oshama混战！	哦杀妈	牛奶	牛奶猫
-Our Wrenally	OW	守望先锋	高数	魔法夏祭	魔法阿嬷
+Neon Kingdom	霓虹王国	nk	霓虹	霓虹国度	霓虹城
+Nerverakes	两块钱	地球仪	二块钱	神经痛
+Never Give Up!	永不放弃	永不放弃！	nevergiveup	nevergonnagiveyouup	ngu	rickroll	不给上	从不给上	你被骗了	永不言弃	永远不给上	绝不认输
+New York Back Raise	纽约后仰	纽约后抬	nybr	纽约赌场	赌场
+Night Fly	发热金曲	夜飞	晚上苍蝇	晚上飞	蓝鲸	🐳
+NightTheater	夜之剧场	夜剧场	night theater	nt	夜剧院
+Nitrous Fury	氮化福瑞	furry	nf	十段之壁	架子鼓	氮气狂怒	氮气福瑞	蓝色福瑞
+No Limit RED Force	无极限红力	无限红力	无尽的赤红之力	无限红	红色电音极地大冲击
+No Routine	无常规	三梦奇缘	东方龙	杨墓	没有日常	没门	画苍浅学姐	绿色女人	龙女
+Now or Never	non	机不可失	现在或从不	时不我待	机不可失时不再来
+Nyan Cat EX	彩虹猫	nya	哈基米	湖南省歌	🌈🐱
+OMAKENO Stroke	大魔神击	omakeno	os	呐喊	小齿轮	😱
+OTOGEMA	电棍	10周年	otto	ottogame	ottogema	otto干嘛	十周年	狗打碟	音游人	音游玩家
+Oath Act	誓约行动	ocean cat	宣誓行为	涩涩青蛙子	诹访子
+On your mark (104期 Ver.)	各就各位（104期 Ver.）	莲之空
+One Step Ahead	领先一步	一步个头	一步向前	向前一步
+Oshama Scramble!	Oshama混战！	哦杀妈	牛奶	牛奶猫	dx奶	dx奶猫	dx牛奶	dx黑白哈基米	os!	两只猫和谐共处	丰胸奶	凯尔希嵯峨贴贴	凯尔希打嵯峨	喝奶	女同15	奶猫	巧克力与香子兰	标奶	标牛奶	每日一瓶奶，强健音游人	牛乳	牛奶猫dx	牛奶猫标准	猫娘贴贴	黑白哈基米	😄😄	😸😸	🥛
+Our Wrenally	OW	守望先锋	高数	魔法夏祭	魔法阿嬷	ena	临兵斗者皆阵列在前	别急9	别急加强版	夏祭	夏祭2	夏祭re:master	火女孩	白夏祭	里夏祭	高等数学	魔法阿妈	魔法阿嫲
 Ourania	乌拉尼亚
-Outlaw's Lullaby	OL	如龙1	如龙2	法外之徒的摇篮曲
-P-qoq	拉面火箭	灯射来红
-PANDORA PARADOXXX	PP	儿歌	潘多拉	白潘
-PERSONA feat. PANXI	人格 feat. PANXI	女神异闻录 feat. PANXI
-POP STAR	流行巨星	流行明星
-POWER OF UNITY	团结之力
-PUPA	蛹
-Panopticon	中央美术学院	全景监狱
-Paradisoda	天堂苏打
-Paranoia	偏执狂
-Party 4U ”holy nite mix”	Party 4U “圣夜混音”	p4u	为你而聚 圣夜混音版
-Party☆People☆Princess	派对☆人们☆公主	派对☆人民☆公主
-Phantasm Brigade	幻影旅团	幻灵旅团
-Pixel Voyage	像素航行	小飞机
-Play merrily NEO	欢乐游玩NEO	欢快演奏NEO
+Outlaw's Lullaby	OL	如龙1	如龙2	法外之徒的摇篮曲	ehk	公奶龙	史蒂夫抽烈焰棒	史蒂夫抽烟	如龙
+P-qoq	拉面火箭	灯射来红	oppo	qoq	星际拉面快递	激光火箭
+PANDORA PARADOXXX	PP	儿歌	潘多拉	白潘	100日元	kop5决赛二号曲	kop5官方严选	xxx	今日舞萌	原神	噔噔	天苍苍野茫茫	天苍苍野茫茫风吹草低见牛羊	天苍苍，野茫茫，风吹草低见牛羊	很急	推荐乐曲排行榜	新手教程	最水15	水15	潘	潘多拉悖论	特朗普和黄仁勋拼机	舞状元	随个15
+PERSONA feat. PANXI	人格 feat. PANXI	女神异闻录 feat. PANXI	p5	persona	偏铝酸钠	女神异闻录	女神异闻录5
+POP STAR	流行巨星	流行明星	popstar	匡威	流行星
+POWER OF UNITY	团结之力	pou	团结就是力量	我们联合	联合力量
+PUPA	蛹	东方树叶茉莉花茶	噗啪	噗趴	大蓝闪蝶	扑爬	拉瓦2	蓝的蝶	蝶魔王	🦋
+Panopticon	中央美术学院	全景监狱	mai当牢	ncc	例大祭	保全派驻	别急12	圆形监狱	坐牢	大牢	来坐大牢	正弘	海底谭promax	潮汐监狱	牢	监狱	铁窗泪	高中	黑海底谭
+Paradisoda	天堂苏打	soda	sp+主题曲	splash+主题曲	splashplus主题曲	侧漏	天堂汽水	快乐水	泳装乙姬	苏打	苏打天堂
+Paranoia	偏执狂	妄想症	金色灵梦	镶金灵梦
+Party 4U ”holy nite mix”	Party 4U “圣夜混音”	p4u	为你而聚 圣夜混音版	4u	派对4你
+Party☆People☆Princess	派对☆人们☆公主	派对☆人民☆公主	3p	party people princess	ppp	女同20	派对人们公主	破琵琶
+Phantasm Brigade	幻影旅团	幻灵旅团	pb	灵梦
+Pixel Voyage	像素航行	小飞机	像素旅行	飞机
+Play merrily NEO	欢乐游玩NEO	欢快演奏NEO	neo	pmn	玩的开心neo	耳机
 Pretender	伪装者
-Princess♂	木桶饭	王子殿下♂	蜘蛛精
-Prismatic	棱镜
-Prophesy One	p1	预言一
-QUATTUORUX	四重奏
-QUEEN	女王
-QZKago Requiem	QZKago安魂曲	嵯峨大战凯尔希	巧克力大战香子兰	毒牛奶	猫中毒	茄子卡狗	黑猫打白猫
-Quartet Theme [Reborn]	四重奏主题 [重生]	四重奏主题·重生
-R'N'R Monsta	摇滚怪兽
-RAD DOGS	狂犬	疯狗
-RE:INCARNATED DRAGNER	转生龙	重生龙骑
-REAL VOICE	真实之声
-REVIVER オルタンシア・サーガ -蒼の騎士団- オリジナルVer.	REVIVER オルタンシア・サーガ -苍の骑士团- オリジナルVer.	复苏 奥尔坦西亚传奇 -苍之骑士团- 原版
-RIDGE RACER STEPS -GMT remix-	山脊赛车步调 -GMT混音-	我创死你
-RIFFRAIN	激流雨林
-Radiance	光辉
-Ragnarok	诸神黄昏
-Rainbow Rush Story	彩虹冲刺物语	彩虹冲故事
-Random	随机
-Raven Emperor	锐雯皇帝	鸦皇
-Re:Unknown X	Re:未知X	再：未知X
-Reach For The Stars	摘星	索3	追星
-Reach For The Stars (Re-Colors)	摘星	摘星（重彩版）
-Redemption	救赎
-Regulus	热咕噜
-Restricted Access	限制访问	限制进入
-Revive The Rave	rtr	复兴锐舞	重燃狂欢
-Re：End of a Dream	Re：梦之终结	终梦
-Riders Of The Light	光之骑士
+Princess♂	木桶饭	王子殿下♂	蜘蛛精	princess	公主	公猪	别急16	古明地恋	男公主	男娘2	立本rap	👸	😋
+Prismatic	棱镜	🤗
+Prophesy One	p1	预言一	小路	芋圆	预言1	预言第一名
+QUATTUORUX	四重奏	300绝赞	300颗够吗	aaa绝赞批发	lk2	三百绝赞	夸戳	夸脱	绝赞300
+QUEEN	女王	女皇	浮游生物
+QZKago Requiem	QZKago安魂曲	嵯峨大战凯尔希	巧克力大战香子兰	毒牛奶	猫中毒	茄子卡狗	黑猫打白猫	两只猫打架	哪吒大战敖丙	茄	茄子	🍆
+Quartet Theme [Reborn]	四重奏主题 [重生]	四重奏主题·重生	quartet	十面埋伏	四重奏	手枪人	手枪小人	生死四人组
+R'N'R Monsta	摇滚怪兽	rnr
+RAD DOGS	狂犬	疯狗	红狗
+RE:INCARNATED DRAGNER	转生龙	重生龙骑	rid	化身龙骑	小火龙	龙骑	龙骑士
+REAL VOICE	真实之声	realvoice	本音	真唱	真声音	真音
+REVIVER オルタンシア・サーガ -蒼の騎士団- オリジナルVer.	REVIVER オルタンシア・サーガ -苍の骑士团- オリジナルVer.	复苏 奥尔坦西亚传奇 -苍之骑士团- 原版	reviver	伝説のオルタンシアの蒼の騎士団！	歌名很长的那首	苍之骑士团	苍骑	骑士团
+RIDGE RACER STEPS -GMT remix-	山脊赛车步调 -GMT混音-	我创死你	山脊赛车	汽车总动员	赛车
+RIFFRAIN	激流雨林	达令达令
+Radiance	光辉	江江比耶2
+Ragnarok	诸神黄昏	黄昏
+Rainbow Rush Story	彩虹冲刺物语	彩虹冲故事	rrs	冲向彩虹	彩框冲刺故事	彩虹冲刺故事	终点2	雨后小故事
+Random	随机	燃冬	阮冬木
+Raven Emperor	锐雯皇帝	鸦皇	raven	大奶子眼镜妹	渡鸦皇帝	瑞文皇帝	瑞文米条	秦皇岛	羽毛笔皇帝
+Re:Unknown X	Re:未知X	再：未知X	endtime2	et2	rex	rux	东方ed	东方et	未知x	油库里
+Reach For The Stars	摘星	索3	追星	一拳超人	立直为了星	索尼克缤纷色彩	追星1
+Reach For The Stars (Re-Colors)	摘星	摘星（重彩版）	dx追星	彩追星	新追星	索5	追星2	追星remix
+Redemption	救赎	特大2	狂犬病	西十字星	黑十字	黑十字星	黑南十字
+Regulus	热咕噜	八云蓝	大奈子罗兰	大奶子	大扎修女	大欧派姐姐	大萝莉	天界大奶	女萝莉	奶子很大	如龙4	狮子座α	白法院	白法院鬼叫	真空旗袍	雷古勒斯
+Restricted Access	限制访问	限制进入	ra
+Revive The Rave	rtr	复兴锐舞	重燃狂欢	乳头人	润体乳	硫酸盐
+Re：End of a Dream	Re：梦之终结	终梦	re	re:end of dream	reend	俩女人	女同4	完梦	幻梦	梦的终点	梦终	梦结束	百合	美女背靠背
+Riders Of The Light	光之骑士	光骑	坂本
 Ring	戒指	环
-Rising on the horizon	在地平线升起
-Rodeo Machine	广播	牛仔机器	绿手	绿皮星星歌	马
-RondeauX of RagnaroQ	诸神黄昏回旋曲
-Rooftop Run: Act1	屋顶奔跑：第一幕	索2	逃离屋顶
-Round Round Spinning Around	跑跑卡丁车	转啊转不停
-Rush-Hour	高峰时刻
-Rush-More	冲刺更多	冲更多	多冲
+Rising on the horizon	在地平线升起	horizon	kop4th预选曲	roth	地平线	玛丽萨默斯
+Rodeo Machine	广播	牛仔机器	绿手	绿皮星星歌	马	欧内的手	碳酸的大手	社交的手腕	绿手手	绿手指	蠢鹿	见手青
+RondeauX of RagnaroQ	诸神黄昏回旋曲	ror	rxrq	灵珠大战魔丸	灵珠魔丸	诸神黄昏的回旋曲
+Rooftop Run: Act1	屋顶奔跑：第一幕	索2	逃离屋顶	rooftop run	屋顶跑	屋顶跑步	屋顶跑路：动作1	索尼克2
+Round Round Spinning Around	跑跑卡丁车	转啊转不停	rrsa	大鸟转转转	滨州转转转	绕着旋转	转圈圈	转转	转转转转	魔爪吊带袜美少女
+Rush-Hour	高峰时刻	冲一个小时	冲一小时
+Rush-More	冲刺更多	冲更多	多冲	rush	rush more	rushmore	交友不慎	冲多	冲多了	冲多点	冲很多	削除冲多了	多冲点
 SHINY DAYS	摇曳露营	虾泥爹
-SHOW TIME	表演时间
-SILENT BLUE	SB	四块钱	寂静之蓝	静蓝
-SPICY SWINGY STYLE	SSS	辣味摇摆风	辣摇摆风
-SPILL OVER COLORS	小画家	小脸妹	溢色
-SQUAD-Phvntom-	小队-幻影-
-STAIRWAY TO GENERATION	阶梯
+SHOW TIME	表演时间	修胎么	怪盗基德	马可波罗
+SILENT BLUE	SB	四块钱	寂静之蓝	静蓝	↓↑	乙醇姬	水晶迪克	水神9	色篮	蓝绿	静谧的蓝	默蓝
+SPICY SWINGY STYLE	SSS	辣味摇摆风	辣摇摆风	大奶子	好大	巨乳	果皇壮如牛	高坂穗乃果
+SPILL OVER COLORS	小画家	小脸妹	溢色	soc	sunnyduck	东云绘名	格蕾修	水手服小女孩画画	画板	缠流子	调色板	🎨
+SQUAD-Phvntom-	小队-幻影-	quaso	sp	squad	丝瓜	幻影小队	幽灵小队	战术小队
+STAIRWAY TO GENERATION	阶梯	stairway	一片绿	八块钱
 STARRED HEART	星心	星标之心
-STARTLINER	启明星
-STEEL TRANSONIC	钢铁超音速
-STEREOSCAPE	立体风景
-SUPER AMBULANCE	超级救护车
-Sage	贤者
+STARTLINER	启明星	wifi满格	きみと	キミト	内鬼	君と	音击
+STEEL TRANSONIC	钢铁超音速	st	刚铁鸡娘	机娘	机甲娘	粉毛机娘	粉毛机甲	粉红机娘	红色有角三倍速	超音速钢	超音钢	钢跨音速	钢铁回音	钢铁机姬	钢铁机娘	钢铁音速	钢铁鸡娘	铁音速	🐔
+STEREOSCAPE	立体风景	天体观测	玩手机	立体镜
+SUPER AMBULANCE	超级救护车	120	俺不能死	千夏开大	千夏肚脐眼	救护车	日向千夏	超级小千夏	🚑
+Sage	贤者	sabe	sega	世嘉	圣人	撒歌	撒给	萨格
 Saika	彩华
-Sakura Fubuki	樱吹屎	樱吹雪	樱花吹雪
-Save This World νMIX	拯救世界	拯救世界 νMIX
-Scarlet Lance	狗含剑	猩红长枪	红枪
-Scarlet Wings	REDALiCE	小星星2	猩红之翼	红烧鸡翅	红翅膀子	绯红之翼
-Scars of FAUNA	动物之痕	土神
-Schwarzschild	史瓦西	四川火娃	四川火娃弱智齿轮队	四川白娃
-Scream out! -maimai SONIC WASHER Edit-	美国紫妈	赞不绝口
-Secret Sleuth	ss	兔爷快乐歌	秘密侦探
-See The Light	见光
-Selector	选择器
-Session High⤴	Session High	↗️	⤴️	⬆️	高潮合奏
-Seyana. ～何でも言うことを聞いてくれるアカネチャン～	Seyana. ～什么都听你的茜酱～	Seyana. ～何でも言うことを闻いてくれるアカネチャン～	说的事呢
-Shining Ray ～僕らの絆～	Shining Ray ～仆らの绊～	闪耀之光 ～我们的羁绊～	闪耀之光～我们的羁绊～
-Shooting Shower～DANCE TIME(シンディ)～	disc up	射击雨～舞动时光	流星雨～舞时(辛迪)～
+Sakura Fubuki	樱吹屎	樱吹雪	樱花吹雪	fbk	sakura	吹雪	白上吹雪	神里绫华	🌸💨❄️
+Save This World νMIX	拯救世界	拯救世界 νMIX	psp	救世	救世啊	梦幻之星携带版
+Scarlet Lance	狗含剑	猩红长枪	红枪	叉子	斯卡雷特开元	斯卡雷特开源	朗基努斯之枪	朗基努斯枪	火枪	狗罕见	红叉	红温叉子	红烧狮子头	红色紧身裤	苍响	麒麟X夜刀
+Scarlet Wings	REDALiCE	小星星2	猩红之翼	红烧鸡翅	红翅膀子	绯红之翼	小黑姬	红翼	红鸡翅	鸡翅膀	鸭翅	黑姬	黑姬拔刀
+Scars of FAUNA	动物之痕	土神	钟离
+Schwarzschild	史瓦西	四川火娃	四川火娃弱智齿轮队	四川白娃	schw	s属性爆发	四川香水	暗黑之盾	水神10	漆黑之盾	火娃	烓	长香水	黑斜塔	黑盾	黑臭火	黑色小孩	黑香水	🔥🐸
+Scream out! -maimai SONIC WASHER Edit-	美国紫妈	赞不绝口	dx赞不绝口	dx青蛙子	哈基咩	哦哦，哦哦哦	喊出来	嬉皮笑脸	微笑女人	诹访子	谷爱凌	青蛙子
+Secret Sleuth	ss	兔爷快乐歌	秘密侦探	咪咪蒸蛋	言叶2
+See The Light	见光	stl	喜之郎	喜德来	屎都濑	看光	看见光	金坷垃
+Selector	选择器	dxselector	dx绿女人	dx选择器	specter	エロ世界	我和你的工口异世界	标准绿女人	标选择器	绿女人	绿妹	绿色女人	选择者	马哇路加强版	马挖路plus	🧚♂️
+Session High⤴	Session High	↗️	⤴️	⬆️	高潮合奏	↑
+Seyana. ～何でも言うことを聞いてくれるアカネチャン～	Seyana. ～什么都听你的茜酱～	Seyana. ～何でも言うことを闻いてくれるアカネチャン～	说的事呢	akane	seyana	sodayo	不管说什么都在听着的琴叶茜酱	小茜	琴叶茜
+Shining Ray ～僕らの絆～	Shining Ray ～仆らの绊～	闪耀之光 ～我们的羁绊～	闪耀之光～我们的羁绊～	shining ray
+Shooting Shower～DANCE TIME(シンディ)～	disc up	射击雨～舞动时光	流星雨～舞时(辛迪)～	好闻	爆炸头
 Shooting Stars	流星
-Signature	签名卡
-Sky High [Reborn]	天空高	天空高 [重生]
-Snow Colored Score	雪色乐谱
-Sound Chimera	声音奇美拉	音之嵌合体
-Southern Cross	南十字星	屏幕上有蟑螂
-Space Harrier Main Theme [Reborn]	太空哈利	太空哈利主题 [重生]
-Spin me harder	电蝴蝶	蓝蝴蝶	转得更快
-Splash Dance!!	泼水舞	飞溅之舞！！
-Spring of Dreams	春之梦	梦之春
-Sprintrances	冰山
-"Sqlupp (Camellia's ""Sqleipd*Hiytex"" Remix)"	"Sqlupp (Camellia的""Sqleipd*Hiytex""混音)"	失去了屁屁	色情撸屁屁
-Stardust Memories	星尘回忆
-StargazeR	观星者
-Starlight Dance Floor	发热错位金曲	星光舞厅	星光舞池
-Starlight Disco	星光迪斯科
-Starlight Vision	星光幻视	星光视觉
-Starry Colors	星彩	繁星色彩
-Still	仍然	依然
-Straight into the lights	直入光芒	直入灯光
-Strange Bar	奇异酒吧	怪奇酒吧
-Streak	拆房子	米奇妙妙屋	绿庙
-Strive against fate	逆天改命
-Strobe♡Girl	闪光♡女孩	闪灯♡女孩
-Sun Dance	太阳舞	日舞	日跳舞
-Sunday Night feat Kanata.N	周日夜晚 feat Kanata.N
+Signature	签名卡	签名
+Sky High [Reborn]	天空高	天空高 [重生]	天高
+Snow Colored Score	雪色乐谱	scs	雪色分	雪色记录	雪颜色分数
+Sound Chimera	声音奇美拉	音之嵌合体	himera	天使马杀鸡	奇美拉	奇美拉之声	小奇美拉	灵梦撒币plus	音奇美拉
+Southern Cross	南十字星	屏幕上有蟑螂	1+1	403	♂十字	一加一	全是交互	南十字	南十字深深封印	南方十字	噩梦之城	守护南十字星	打交神曲	特大	舞萌特大	麦当劳1+1	🌟
+Space Harrier Main Theme [Reborn]	太空哈利	太空哈利主题 [重生]	太空	太空哈姆	太空蛤蜊
+Spin me harder	电蝴蝶	蓝蝴蝶	转得更快	更努力转我	更大力转我	更难的旋转	用力转我	蝴蝶	转我更猛些	🦋
+Splash Dance!!	泼水舞	飞溅之舞！！	splash dance	五个音击小女孩	水花之舞	泳装2	爽舞
+Spring of Dreams	春之梦	梦之春	娜兹玲	小老鼠	春之港湾	春梦	莉莉白
+Sprintrances	冰山	一块五	戈仑冰人
+"Sqlupp (Camellia's ""Sqleipd*Hiytex"" Remix)"	"Sqlupp (Camellia的""Sqleipd*Hiytex""混音)"	失去了屁屁	色情撸屁屁	sqlupp	孽蜥	帅气露屁屁	手速疯批	涩情撸屁屁	色情撸pp	色情露屁屁	酥妻露屁屁
+Stardust Memories	星尘回忆	sm	星尘记忆	🌍	🌏
+StargazeR	观星者	大荒囚天指	摘星人	空条承太郎	虎哥
+Starlight Dance Floor	发热错位金曲	星光舞厅	星光舞池	sdf	夜店魔理沙	大姐姐魔理沙	星光大道
+Starlight Disco	星光迪斯科	dx星光	starlightdisco	星光	标星光	绿色圆圈
+Starlight Vision	星光幻视	星光视觉	星光视界	樱花灵梦	灵梦樱	🌸
+Starry Colors	星彩	繁星色彩	斯大林格勒	星之彩	星色	魔爪
+Still	仍然	依然	七对奈子
+Straight into the lights	直入光芒	直入灯光	acid	ow2	中出光	小东雪莲	直入光	长驱直入光
+Strange Bar	奇异酒吧	怪奇酒吧	sb	sb2	别急11	奇怪的条	奇怪的胸罩	奇怪的酒吧	奇怪罩杯	奇怪酒吧	奇艺酒吧	小金熊	怪吧	怪酒吧	死神之棒	酒吧	酒老二	陌生酒吧
+Streak	拆房子	米奇妙妙屋	绿庙	牛排	绿房	裸奔	青楼
+Strive against fate	逆天改命	fate	saf	反抗命运	对抗命运	对抗尸体	抗争命运	抗命	电风扇	红剑
+Strobe♡Girl	闪光♡女孩	闪灯♡女孩	strobegirl	闪烁少女
+Sun Dance	太阳舞	日舞	日跳舞	sd	孙舞	将军舞	金正恩跳舞	阳舞	🌞💃
+Sunday Night feat Kanata.N	周日夜晚 feat Kanata.N	像素儿子	周日夜	周日夜晚	带孩子	星期日夜晚
 Supersonic Generation	超音速世代
-Sweet Requiem	甜蜜安魂曲
-Sweetiex2	甜心x2
-Sweets Time	甜点时光	甜蜜时光
-Sweets×Sweets	甜蜜×甜蜜
-Swift Swing	海澜之家
-Synthesis.	合成。
-System “Z”	系统z	系统“Z”	蔬菜沙拉
-TEmPTaTiON	他不太深	小萝莉	小萝莉的诱惑
-TRUST	信任	小仏凪色图	玉足	足控
-Technicians High	科技高	高科技
+Sweet Requiem	甜蜜安魂曲	redandblue	sr	塞钱	灵梦转圈	灵梦镇魂曲	甜蜜镇魂曲	红蓝灵梦	镇魂曲
+Sweetiex2	甜心x2	教室
+Sweets Time	甜点时光	甜蜜时光	小幸隐	强强虫	甜时间	芙兰数星星	迪士尼乐园
+Sweets×Sweets	甜蜜×甜蜜	甜²	甜甜	甜蜜蜜	阳光彩虹小白马
+Swift Swing	海澜之家	ss2	五熊扛鼎	他们是经理	滴蜡熊热舞	滴蜡熊爱跳舞	白铜寺拉小提琴	荡秋千	迪拉熊热舞	迪拉熊跳舞
+Synthesis.	合成。	合成	合成天下	合成法	生椰拿铁
+System “Z”	系统z	系统“Z”	蔬菜沙拉	z	zyf	小系	沙拉	系统贼	麦乐鸡	🥗
+TEmPTaTiON	他不太深	小萝莉	小萝莉的诱惑	dy	mika	塔铺忒深	小天使	引诱	百合咲	百合咲mika	百合咲低语	肯德基六翅桶	诱惑	轻语
+TRUST	信任	小仏凪色图	玉足	足控	yokidou	大脚丫子	小仏凪吃雪糕	湿身少女翘脚吃冰糕	狱卒	玉足冰棍	糯香柠檬茶	老冰棍	脚歌	🦶
+Technicians High	科技高	高科技	dx科技高	标准科技高	科技	科技很高	蓝的盆
 Tell Your World	TYW	传达你的世界	告诉你的世界
-Terminal Storm	终末风暴
-The 90's Decision	90年代决定	90年代的决定
-The Cursed Doll	诅咒人偶	诅咒玩偶
-The Great Banquet	盛宴
-The Great Journey	伟大旅程
-The wheel to the right	三块钱	印度人	右转之轮	电锯
-TiamaT:F minor	m T:F	剃阿妈头发	提亚马特	音响龙	🦍🦍
-Tic Tac DREAMIN’	⏰	大雷	滴答做梦
-Titania	体坛	江江比耶	泰坦尼亚	缇坦妮娅	踢他娘	阿迪快乐歌
-Transcend Lights	超越之光	超越光芒
-Trick tear	诡泪	诡计之泪
-Tricolor⁂circuS	三个出生	三色⁂马戏团	三色马戏团
-Trrricksters!!	恶作剧者！！	诡计多端！！
-True Love Song	真爱之歌	真爱歌
+Terminal Storm	终末风暴	终端风暴	麻花
+The 90's Decision	90年代决定	90年代的决定	90s	90秒
+The Cursed Doll	诅咒人偶	诅咒玩偶	诅咒娃娃
+The Great Banquet	盛宴	tgb	伟大的宴窝	盛大宴会
+The Great Journey	伟大旅程	大冒险	好旅行	黄金矿工
+The wheel to the right	三块钱	印度人	右转之轮	电锯	dj-mega	一块钱2	你右边有人	光头强	右轮	国服刀妹	底力	欢乐喜锯人	电锯人	电锯惊魂	老婆	车轮右拐	轮子右拧
+TiamaT:F minor	m T:F	剃阿妈头发	提亚马特	音响龙	🦍🦍	tf	tfboys	tiama t:fboys	ttf	健身教练	大猩猩	手感提	提	提一提	提亚玛特	提提，提提提	提提，提提提！	泡泡玛特	猩手教程	猩猩歌	猩猩比	白豆	绝赞交互	黑神话	黑神话悟空	🦍	🦍🦍,🦍🦍🦍
+Tic Tac DREAMIN’	⏰	大雷	滴答做梦	emu	千早爱音	睡衣	粉毛睡衣
+Titania	体坛	江江比耶	泰坦尼亚	缇坦妮娅	踢他娘	阿迪快乐歌	qqn比耶	tinan	☁🐼✌	✌	✌️	✌🏻	二氧化钛	双色球	天卫三	江江	江江比✌️	蓝毛小萝莉	蓝毛萝莉	踢他奶	踢她娘
+Transcend Lights	超越之光	超越光芒	114514	bright主题曲	tl	九月的雨	别急19	小女孩们的茶话会	美瞳广告	萝莉的雨	超超光光	超越光	音击妹妹	音击的武士	音击的雨
+Trick tear	诡泪	诡计之泪	tt	次元裂缝	欺诈泪	欺骗泪	被骗哭了	诈泪	诡泣
+Tricolor⁂circuS	三个出生	三色⁂马戏团	三色马戏团	tricolor circus	三只福瑞过节	福瑞三小只	福瑞过节	龙晖胞
+Trrricksters!!	恶作剧者！！	诡计多端！！	tricksters	trrr	黄泉盟主
+True Love Song	真爱之歌	真爱歌	会员制餐厅	小管弦乐	真情歌	真爱	真的爱情歌	糖糖
 Trust	信任
-Turn around	转弯	转身
-TwisteD! XD	xd	扭曲XD	扭曲！XD
-U&iVERSE -銀河鸞翔-	U&iVERSE -银河鸾翔-	金牛奶	银河翱翔
+Turn around	转弯	转身	ta	中国好声音	橘之夏	转向	量子采音
+TwisteD! XD	xd	扭曲XD	扭曲！XD	td	twisted	TwisteD！XD	退订
+U&iVERSE -銀河鸞翔-	U&iVERSE -银河鸾翔-	金牛奶	银河翱翔	3d白猫	kop3rd预选曲	u&amp;iverse -銀河鸞翔-	universe	金典有机奶	银河	银河乱翔	银河卵翔	银河护卫队	银河拉翔	银河飞翔	银河鸞翔	银河鸾翔	鸾翔	😫
 U.S.A.	usa
-ULTRA B+K	access to the light	bk2	超B+K
-ULTRA POWER	终极力量	超力
-ULTRA SYNERGY MATRIX	超协同矩阵
-UTAKATA	浮世
+ULTRA B+K	access to the light	bk2	超B+K	b+k	ubk	河天	超级bk	超级汉堡王
+ULTRA POWER	终极力量	超力	超强力量	超强能量	超能力	额外能量
+ULTRA SYNERGY MATRIX	超协同矩阵	esm2	usm	手撕猫娘
+UTAKATA	浮世	亚索	拔刀	泡沫	维吉尔
 Ultimate taste	终极品味
-Ultranova	A4纸	摩托车	超新星
-Upshift	升档
-Urban Crusher [Remix]	城市粉碎机 [混音]	都市粉碎机 混音版
-Ututu	ubuntu	乌图图	乌班图
-VANTABLACK RAVER	电乙姬	黑乙姬
-VERTeX	水神	顶点
-VERTeX (rintaro soma deconstructed remix)	VERTeX (rintaro soma 解构混音)	水神 1.5	水神1.5
-VIIIbit Explorer	8bit浏览器
+Ultranova	A4纸	摩托车	超新星	🏍️
+Upshift	升档	chapter 2	upshit	上蹲	在屎上	大写锁定
+Urban Crusher [Remix]	城市粉碎机 [混音]	都市粉碎机 混音版	uc	urbancrusher	城市毁灭者	汽车人	波尔布特	泰坦陨落	高达
+Ututu	ubuntu	乌图图	乌班图	胡图图
+VANTABLACK RAVER	电乙姬	黑乙姬	⚡乙姬⚡	上单乙姬	乙姬丰胸	乙姬红温	伞墨	吴乙凡	哈吉马利诺雷	完美挑战曲乙姬	放电乙姬	狂暴乙姬	电音乙姬	电鳗乙姬	红眼乙姬	黑化乙姬	黑己姬	黑神话：乙姬
+VERTeX	水神	顶点	水神1	水神一	羽落心弦	芙卡洛斯	芙宁娜	🌊
+VERTeX (rintaro soma deconstructed remix)	VERTeX (rintaro soma 解构混音)	水神 1.5	水神1.5	摩羯	本草纲目1.5	水神9	水神remix
+VIIIbit Explorer	8bit浏览器	5*8-30/2+3bit	8bit	8比特	8比特浏览器	dx8bit	dx八比特	八位探索者	八比特	八比特浏览器	八比特管理器	大手子	巴比特	标8bit	标准8bit	标准八比特	标准浏览器	标巴比特	浏览器	海葵姐
 VOLT	伏特
-VSpook!	V惊悚！	万圣惊魂
-Vallista	瓦莉斯塔
-Valsqotch	金熊	黄金滴蜡熊
-ViRTUS	水神2	水神二	辣妹子辣
-Virtual to LIVE	vtl	彩虹社	皮套人之歌	虚拟到现实	雨刮器
-WARNING×WARNING×WARNING	星条旗	条纹过膝袜	注意注意注意	警告×警告×警告
-WE'RE BACK!!	我们回来了	我们回来了！！
-WORLD'S END UMBRELLA	世末伞
-We Are Us	我们即我们	我们是我们
-We Gonna Journey	wgj	我们将启程	我们要旅行
-We Gonna Party	wgp	咱想开派对	我们要派对
-White Traveling Girl	白旅女	白色旅人	白色旅行少女
-WiPE OUT MEMORIES	抹除记忆
-Windy Hill -Zone 1	索4	风之丘 -区域1
-Witches night	古明地三鲜	古明地恋	女巫之夜
-World Vanquisher	Mother Vanquisher	WV	世征	世界征服者	威猛先生
-World's end loneliness	世终孤独
-Xenovcipher	泽拉斯
-Xevel	x	黑白双gay
-Y.Y.Y.計画!!!!	Y.Y.Y.计划!!!!	Y.Y.Y.计划！！！！	Y.Y.Y.计画!!!!	yyy
-YATTA!	太好了！	好耶！
-YA･DA･YO [Reborn]	YADAYO	亚达哟	呀·哒·哟 [重生]
-YU-MU	榆木脑袋
-YURUSHITE	五河琴里	原谅我	狗屎	玉如屎	王妃
-Yakumo >>JOINT STRUGGLE (2019 Update)	yakumo	八云 >>联合斗争 (2019更新)	八云紫
-Yet Another ”drizzly rain”	Yet Another “drizzly rain”	帕秋莉
-Yorugao	夜颜
-You Mean the World to Me	你是我的一切
-Zitronectar	柠檬花蜜
+VSpook!	V惊悚！	万圣惊魂	debi	vspook	vspork	vs猪肉	大战猪肉	对决猪肉	对战熟猪排	对战猪肉	打扑克	猪	猪肉	脸书	花火	黑姬3	🐖	🐷
+Vallista	瓦莉斯塔	瓦里斯塔
+Valsqotch	金熊	黄金滴蜡熊	do_while	kop1	世界华尔兹	别急7	大金熊	征服	熊大	熊熊	迪拜熊	金夏阳	金库玛	金色奶龙	金色滴蜡熊	银币	黄金熊
+ViRTUS	水神2	水神二	辣妹子辣	2024春晚	kop4	op	一半敖丙一半哪吒	台风	噔噔噔噔噔噔	本草纲目	芙宁娜
+Virtual to LIVE	vtl	彩虹社	皮套人之歌	虚拟到现实	雨刮器	上下反怒锤	彩虹社歌	管人歌	管人痴	虚拟生活	雨刷器
+WARNING×WARNING×WARNING	星条旗	条纹过膝袜	注意注意注意	警告×警告×警告	warning	www	万宁星星	克劳恩皮丝	小丑	警告警告警告
+WE'RE BACK!!	我们回来了	我们回来了！！	weareback	我们是背
+WORLD'S END UMBRELLA	世末伞	☔	世末雨伞	世界终末雨伞	世界结束雨伞	世终伞	世终雨伞
+We Are Us	我们即我们	我们是我们	wau	我们是美国
+We Gonna Journey	wgj	我们将启程	我们要旅行	我们去旅行	王国军	红色长角
+We Gonna Party	wgp	咱想开派对	我们要派对	埃菲尔铁塔	埃菲尔铁塔圣诞树	埃菲尔铁塔着火	我们即将排队	我们去派对	我们去银趴	铁塔	铅神	银趴
+White Traveling Girl	白旅女	白色旅人	白色旅行少女	wtg	白色旅行女孩	萃香	西瓜fumo
+WiPE OUT MEMORIES	抹除记忆	10周年	fade out memories	maimai机台	wet out trousers	wipe	wipeout	wom	串烧	十周年	抹去记忆	洗衣机	消失的记忆	消逝的回忆	缝合怪	走马灯	超级缝合怪
+Windy Hill -Zone 1	索4	风之丘 -区域1	小追星	索尼克失落的世界	追星上位
+Witches night	古明地三鲜	古明地恋	女巫之夜	东方紫发女	恋恋	魔女之夜	魔女的夜
+World Vanquisher	Mother Vanquisher	WV	世征	世界征服者	威猛先生	2025春晚	☝️	三点饮茶	中二谭	中二送披萨	噔噔噔噔噔	奶龙征服者	手感噔噔	春晚2	春晚机器人	春晚机器人舞	林楠	秧歌bot	金手指	😎👆	🤓☝	🤓☝️	🤓☝🏻	🤓👆
+World's end loneliness	世终孤独	wel	世孤	世末孤独	世終孤独	世终	世翠孤独	奥尔菲斯	孤独终老	寡	寡王	林尼
+Xenovcipher	泽拉斯	冰火人	异种密码	星召起飞	棺材板	离神	终极猎手	远古巫灵
+Xevel	x	黑白双gay	健身房	叉evel	女人唱歌男人死	女鬼小气走	宵崎奏	希尔薇	希沃	累死人不偿命	苦命鸳鸯	邪恶vel
+Y.Y.Y.計画!!!!	Y.Y.Y.计划!!!!	Y.Y.Y.计划！！！！	Y.Y.Y.计画!!!!	yyy	yyy计划	yyy计画	计画
+YATTA!	太好了！	好耶！	yatta	好耶	胡萝卜	🥕
+YA･DA･YO [Reborn]	YADAYO	亚达哟	呀·哒·哟 [重生]	ydy	不要嘛	中专说唱	六个喇叭	幻想地带
+YU-MU	榆木脑袋	yumu	文早苗	榆木
+YURUSHITE	五河琴里	原谅我	狗屎	玉如屎	王妃	yuru****e	二郎腿	匹诺康尼	回娄底	娄底人	摇晃的红酒杯	杰斯顿	火神青春版	灼眼的夏娜	犹如史	犹如屎	红酒	红酒杯	萝莉喝酒	萨塔妮亚	萨塔妮娅	逢坂茜	黄鱼	🍷
+Yakumo >>JOINT STRUGGLE (2019 Update)	yakumo	八云 >>联合斗争 (2019更新)	八云紫	2019	八云	八云一家	压裤摸
+Yet Another ”drizzly rain”	Yet Another “drizzly rain”	帕秋莉	姆q
+Yorugao	夜颜	月光花	有乳膏	有如皋	油乳膏	牙膏	牛肉干	犹如高	紫黑
+You Mean the World to Me	你是我的一切	ymtwtm	你是我的世界	你是我的全世界	凯尔希2	我的世界
+Zitronectar	柠檬花蜜	柠檬	柠檬蜜
 [J]Garakuta Doll Play	Garakuta Doll Play	人形玩偶
-[X]	x	推特
+[X]	x	推特	13.7	twitter	∞	叉	无穷大	无限	艾克斯	高斯函数
 [X]人マニア	人狂热
 [r]Garakuta Doll Play	Garakuta Doll Play	玩偶戏
-[は]Garakuta Doll Play	Garakuta Doll Play	玩偶屋
+[は]Garakuta Doll Play	Garakuta Doll Play	玩偶屋	[宴]garakuta doll play	哈皮gdp
 [両]はんぶんこ	[两]はんぶんこ	一人一半	两半分
-[光]BREaK! BREaK! BREaK!	BREaK! BREaK! BREaK!
+[光]BREaK! BREaK! BREaK!	BREaK! BREaK! BREaK!	光bbb	宴bbb
 [助]メズマライザー	催眠者
 [匿]匿名M	匿名M
-[協]Hand in Hand	[协]Hand in Hand
-[協]Love You	[协]Love You
-[協]ぽっぴっぽー	[协]ぽっぴっぽー	蔬菜汁
+[協]Hand in Hand	[协]Hand in Hand	协hand in hand	协hih	多人运动	宴hih
+[協]Love You	[协]Love You	协love you	协loveyou	协爱你	宴love you	宴loveyou	宴爱你	爱你	现充
+[協]ぽっぴっぽー	[协]ぽっぴっぽー	蔬菜汁	协popipo	协蔬菜歌	宴popipo	宴蔬菜歌
 [協]アカツキアライヴァル	[协]アカツキアライヴァル
 [協]エイリアンエイリアン	[协]エイリアンエイリアン	外星人外星人
-[協]ポップミュージックは僕のもの	[协]ポップミュージックは仆のもの	流行音乐属于我	流行音乐是我的
-[協]ラグトレイン	Lag Train	[协]ラグトレイン	协奏列车
+[協]ポップミュージックは僕のもの	[协]ポップミュージックは仆のもの	流行音乐属于我	流行音乐是我的	男同打男同
+[協]ラグトレイン	Lag Train	[协]ラグトレイン	协奏列车	协延误列车	协延迟列车	宴延误列车
 [協]三妖精SAY YA!!!	[协]三妖精SAY YA!!!
 [協]太陽系デスコ	[协]太阳系デスコ	太阳系迪斯科
-[協]恋愛裁判	[协]恋爱裁判
-[協]疾走あんさんぶる	[协]疾走あんさんぶる	疾走合奏
+[協]恋愛裁判	[协]恋爱裁判	协恋爱裁判	宴恋爱裁判
+[協]疾走あんさんぶる	[协]疾走あんさんぶる	疾走合奏	协寄走	宴疾走
 [即]チューリングの跡	[即]チューリングの迹	图灵之迹
 [右]The wheel to the right	向右的轮子
 [嘘]ライアーダンサー	嘘谎舞者	说谎者舞者
@@ -561,763 +561,788 @@ Zitronectar	柠檬花蜜
 [回]ハム太郎とっとこうた	哈姆太郎快快歌
 [回]回る空うさぎ	回旋空兔	旋转的空中兔
 [奏]さくゆいたいそう	咲唯体操	奏樱体操
-[奏]アカツキアライヴァル	晓之劲敌	晓之竞争者
+[奏]アカツキアライヴァル	晓之劲敌	晓之竞争者	[協]アカツキアライヴァル	协拂晓抵达	宴拂晓	宴拂晓抵达
 [奏]アンビバレンス	矛盾	矛盾心理
 [奏]チュルリラ・チュルリラ・ダッダッダ！	丘哩啦·丘哩啦·哒哒哒！	奏 啾哩啦·啾哩啦·哒哒哒
 [奏]テレキャスタービーボーイ	Telecaster B-Boy
 [奏]ヒトガタ	奏·人形
 [奏]洗脳	[奏]洗脑
-[宴]CYCLES	CYCLES
-[宴]Oshama Scramble!	Oshama Scramble!
+[宴]CYCLES	CYCLES	宴cycles	宴挖马路	耐cycles
+[宴]Oshama Scramble!	Oshama Scramble!	宴牛奶
 [宴]Oshama Scramble! (Cranky Remix)	Oshama Scramble! (Cranky Remix)
-[宴]セガサターン起動音[H.][Remix]	[宴]セガサターン起动音[H.][Remix]	世嘉土星启动音[H.][Remix]	世嘉土星启动音混音
+[宴]セガサターン起動音[H.][Remix]	[宴]セガサターン起动音[H.][Remix]	世嘉土星启动音[H.][Remix]	世嘉土星启动音混音	宴启动音
 [息]ノンブレス・オブリージュ	息之无息义务	无呼吸义务
-[星]しゅわスパ大作戦☆	[星]しゅわスパ大作战☆	气泡苏打大作战☆	泡泡大作战
+[星]しゅわスパ大作戦☆	[星]しゅわスパ大作战☆	气泡苏打大作战☆	泡泡大作战	宴大作战	星大作战
 [星]ほしぞらスペクタクル	[星]星空奇观
 [某]Garakuta Doll Play	废品人偶游戏
 [爆]Love's Theme of BADASS ～バッド・アス 愛のテーマ～	[爆]Love's Theme of BADASS ～バッド・アス 爱のテーマ～	坏蛋爱之主题曲	爆裂坏蛋爱之主题
 [片]神々が恋した幻想郷	[片]众神眷恋的幻想乡	[片]神々が恋した幻想乡
-[狂]タカハせ！名人マン	狂高桥！名人侠	高桥名人！
+[狂]タカハせ！名人マン	狂高桥！名人侠	高桥名人！	宴高桥名人	手汗快乐歌	狂高桥	狂高桥名人
 [玉]Garakuta Doll Play	Garakuta Doll Play
 [甘]スイートマジック	甜蜜魔法
-[疑]DETARAME ROCK&ROLL THEORY	胡扯摇滚理论
+[疑]DETARAME ROCK&ROLL THEORY	胡扯摇滚理论	[宴]detarame rock&roll theory	别急25	宴摇滚理论	宴箱部
 [疑]ロキ	ロキ	洛基
 [習]ウミユリ海底譚	[习]ウミユリ海底谭	海百合海底谭
 [耐]Space Harrier Main Theme [Reborn]	太空哈利主题曲 [重生]
-[蔵]Aegleseeker	[藏]Aegleseeker
-[蔵]Glorious Crown	[藏]Glorious Crown
-[蔵]In Chaos	[藏]In Chaos
-[蛸]チルノのパーフェクトさんすう教室	琪露诺的完美算数教室	琪露诺的完美算术教室
+[蔵]Aegleseeker	[藏]Aegleseeker	宴光追	藏光追
+[蔵]Glorious Crown	[藏]Glorious Crown	宴皇冠	藏皇冠
+[蔵]In Chaos	[藏]In Chaos	宴超市	藏超市
+[蛸]チルノのパーフェクトさんすう教室	琪露诺的完美算数教室	琪露诺的完美算术教室	宴算数教室
 [蛸]不機嫌なスリーカード	[蛸]不机嫌なスリーカード	不悦的三张牌
 [覚]スカーレット警察のゲットーパトロール24時	[觉]スカーレット警察のゲットーパトロール24时	深红警察的贫民区巡逻24时	猩红警察贫民区24小时巡逻
-[覚]東京リアルワールド	[觉]东京リアルワールド	东京现实世界
+[覚]東京リアルワールド	[觉]东京リアルワールド	东京现实世界	好记星	宴东京	觉东京
 [逆]KING is BACK!!	王者归来！！
-air's gravity	空气重力
+air's gravity	空气重力	空气炸锅
 awake	觉醒	起了	醒了
-brilliant better	璀璨更好
-c.s.q.n.	csqn	厕所青年	吃屎去捏	吃屎青年
-come again	再来一遍
-conflict	bus	公交车	冲突
-connecting with you	pink挑战
-emomomo	emo莫莫	😅	🤔
-enchanted love	el	迷情之恋	迷情之爱
-enchanted wanderer	迷途旅人
-energy trixxx	能量三角
-fake!fake!	假假	假！假！
-felys -final remix-	felys -最终混音-
-folern	乐山大佛盖小被	佛冷
+brilliant better	璀璨更好	bb	更精彩	金毛弹吉他	黄色吉他
+c.s.q.n.	csqn	厕所青年	吃屎去捏	吃屎青年	csdn	nahc2o4	草酸氢纳	草酸氢钠	😐	😑
+come again	再来一遍	cum again	再冲一次	再来	舞立方踩在脚下
+conflict	bus	公交车	冲突	dx公交车	宫村	对立	标公交车	标准公交车	🚌
+connecting with you	pink挑战	与你连接	和你连接	樱代主题曲	连接你
+emomomo	emo莫莫	😅	🤔	e3mo	emo	一般工作师匠	恶魔摸摸	网易云	🤔️
+enchanted love	el	迷情之恋	迷情之爱	15+	八月的雨	别急17	四月的夜明	小青蛙	小骊龙	蛙泳	迷人的爱	迷惑爱	醉心之爱	附魔爱	附魔的爱	青蛙	青蛙王子	🐸
+enchanted wanderer	迷途旅人	ew	别急21	维什戴尔	醉心求知者	附魔喵	附魔旅行者	附魔流浪者	附魔爱2	青蛙2	青蛙王子2	黑猫	🐸2
+energy trixxx	能量三角	xxx	美友姬	美有姬	能量xx	能量xxx	能量三角形	能量叉	能量叉叉	马娘
+fake!fake!	假假	假！假！	fake	fakefake	万物皆虚	假的假的	弹簧	彩虹圈	骗子
+felys -final remix-	felys -最终混音-	fely	felys	凤梨酥	开花歌	菲利斯	菲莉丝	非礼死	风流原神	风流韵事	飞叶子	飞雷神
+folern	乐山大佛盖小被	佛冷	北冰洋	水陈	给我玩中二节奏	迪希雅
 jelly	果冻
-keep hopping	kamome sano	继续跳跃	蹦跳不停
-larva	幼虫	拉瓦	腊八
-magician's operation	魔术师的操作	魔术手	魔法师手术
-maimaiちゃんのテーマ	maimai酱	maimai酱的主题
-maiム・maiム feat.週刊少年マガジン	maiム・maiム feat.周刊少年マガジン	舞舞 feat.周刊少年Magazine	麦姆·麦姆 feat.周刊少年Magazine
-my flow	我的流动
-mystique as iris	如鸢尾花般神秘	神秘如鸢尾花	鸢尾之谜
+keep hopping	kamome sano	继续跳跃	蹦跳不停	kh	一直跳	一起摇摆	保持火拼
+larva	幼虫	拉瓦	腊八	pupa2	冰	区	岩浆	拉完	源石虫	神之震惊	萨菲	蓝色尖锐湿疣	虫	蛆	辣蛙	雪降雨	青泥石	龟头结冰	＝⚡️★
+magician's operation	魔术师的操作	魔术手	魔法师手术	那刻夏	魔法手指	黑屏	黑手
+maimaiちゃんのテーマ	maimai酱	maimai酱的主题	真代主题曲	舞萌酱
+maiム・maiム feat.週刊少年マガジン	maiム・maiム feat.周刊少年マガジン	舞舞 feat.周刊少年Magazine	麦姆·麦姆 feat.周刊少年Magazine	两男一女	功夫	周刊少年	啦啦啦啦啦
+my flow	我的流动	bolobinelebowigi	我流	我的流
+mystique as iris	如鸢尾花般神秘	神秘如鸢尾花	鸢尾之谜	iris	mai	siri	像鸢尾花一样神秘	出云子	坐椅子	如密鸢尾花	如虹膜般神秘	虹膜	鸢尾花
 needLe	针
-oboro	小火球	小火苗	胧
-on the rocks	加冰
+oboro	小火球	小火苗	胧	dx小火球	dx火球	哦菠萝	小火焰	我的吉吉在燃烧	标准火球	火球	超新星燃烧	🌠
+on the rocks	加冰	otr	冰酒	在石头上
 only my railgun	炮姐	超炮
-otorii INNOVATED -[i]3-	创新鸟居-[i]3-	大鸟居	电前列腺	电所有人前列腺	雷熊
-ouroboros -twin stroke of the end-	衔尾蛇 -终末双击-	衔尾蛇 -终焉的双重冲击-
-ozma	奥兹玛
-planet dancer	星球舞者	爸爸拉粑粑	行星舞者
-popcorn	爆米花
-quiet room	qr	安静的房间	静屋
-raputa	拉普塔
-shake it!	摇它	摇起来！	爷爷爷爷
+otorii INNOVATED -[i]3-	创新鸟居-[i]3-	大鸟居	电前列腺	电所有人前列腺	雷熊	i3	⚡🐻	囚徒	熊二	电你前列腺	电击前列腺	电刑	电熊	紫色滴蜡熊	闪电熊	雷电法王
+ouroboros -twin stroke of the end-	衔尾蛇 -终末双击-	衔尾蛇 -终焉的双重冲击-	我们的菠萝	衔尾蛇
+ozma	奥兹玛	哦在吗
+planet dancer	星球舞者	爸爸拉粑粑	行星舞者	pd	残月跳舞	男人坐椅子	蹲马桶
+popcorn	爆米花	企鹅物流	企鹅警长	出警	帝企哥	高松灯
+quiet room	qr	安静的房间	静屋	silentroom	男同2
+raputa	拉普塔	rpt	中国结	拉普大	热葡萄	西直门桥	𐎼𐎠𐎱𐎹𐎢𐎫𐎠	🍇	🐥🐥🐥	🥵🍇
+shake it!	摇它	摇起来！	爷爷爷爷	shake it	自行车	骑自行车的男人	骑车
 snooze	小憩	小睡
-sweet little sister	甜二妹	甜小姐姐	甜美小妹妹
-sølips	100块钱	solips	一百元	一百块钱	嗦	👦🏻
-taboo tears you up	三倍icecream	淘宝撕碎你	禁忌之泪撕裂你
-tape/stop/night	强虫	磁带/停止/夜晚
-the EmpErroR	电磁脉冲错误	皇帝
-tiny tales continue	小小故事续	小故事继续
-true my heart -Lovable mix-	女人打电话	真心 -可爱混音-	真我心
-welcome to maimai!! with マイマイマー	欢迎来到maimai!! 与舞舞玛	欢迎来到maimai！！与麦麦玛
-wheel	车轮	轮子
-with U	与你同行
-Λzure Vixen	蔚蓝狐
-ℝ∈Χ LUNATiCA	雷克斯月狂
-Åntinomiε	反律	二律背反	Antinomie
-"≠彡""/了→"	删了	太空熊	彡了
-♡マイマイマイラブ♡	my my my love	sega游戏宇宙一	♡我的我的我的爱♡	又人又人
-『んっあっあっ。』	『嗯啊哈。』	嗯啊啊啊。
-『ウソテイ』 ～一回戦せりなvsしろなvsなずな～	《谎言亭》～第一战芹奈vs白奈vs菜奈～	『ウソテイ』 ～一回战せりなvsしろなvsなずな～	谎言对决 ～第一战 芹奈vs白奈vs菜奈～
-【東方ニコカラ】秘神マターラ feat.魂音泉【IOSYS】	【东方nico卡拉】秘神摩多罗 feat.魂音泉【IOSYS】	【东方ニコカラ】秘神マターラ feat.魂音泉【IOSYS】	见前
-あつすぎの歌	太热之歌	太热的歌
-あなたは世界の終わりにずんだを食べるのだ	あなたは世界の终わりにずんだを食べるのだ	世界尽头吃枝豆	你在世界尽头吃豆子
-あねぺったん	只含月铃姐妹	姐姐啪嗒
+sweet little sister	甜二妹	甜小姐姐	甜美小妹妹	sls	小甜妹
+sølips	100块钱	solips	一百元	一百块钱	嗦	👦🏻	100元	100块	solidworks	s∅lips	一百块	唯我论	索	🔒
+taboo tears you up	三倍icecream	淘宝撕碎你	禁忌之泪撕裂你	dxtaboo	dx淘宝	dx禁忌将你撕裂	淘宝	滔搏	禁忌将你撕裂	竹竹的板子
+tape/stop/night	强虫	磁带/停止/夜晚	tape stop night	tsn	中国弱虫	中国强虫	中国强🐛	中国虫	中文歌	国产弱虫	带停夜	弱虫2	暮色电台	磁带暂停夜晚	磁带机	磁带机黑胶	胶停夜
+the EmpErroR	电磁脉冲错误	皇帝	emperror	nenene	siesta	vinta	↗️↘️↗️	东海帝皇	两小儿跳棋	俩跳棋	农夫山泉	怡宝和农夫山泉	爱神	电子脉冲错误	西瓜皮	跳一跳	跳棋	钢琴冒烟的艺术家	锅盖头跳棋	👫
+tiny tales continue	小小故事续	小故事继续	ttc	小传说继续	小故事
+true my heart -Lovable mix-	女人打电话	真心 -可爱混音-	真我心	打电话
+welcome to maimai!! with マイマイマー	欢迎来到maimai!! 与舞舞玛	欢迎来到maimai！！与麦麦玛	go! go! 575	maimai	欢迎来到舞萌的世界
+wheel	车轮	轮子	悠哇悠哇	猫车	轮	马挖路2
+with U	与你同行	withu	和你	莉莉
+Λzure Vixen	蔚蓝狐	av	凯南	我独自升级	猩红凝视	维导
+ℝ∈Χ LUNATiCA	雷克斯月狂	lunatica	rex	r属于x	黑天鹅2
+Åntinomiε	反律	二律背反	Antinomie	太空熊2	太空熊二
+"≠彡""/了→"	删了	太空熊	彡了	kimitour	→	≠	キミツア	キミツアー	三了	不等于三引号斜杠了左箭头	宇宙迪拉熊	心肺功能检查	星际传奇	机密a	火箭熊	熊二	秘密计划A	立了	绝赞天堂	绝赞熊
+♡マイマイマイラブ♡	my my my love	sega游戏宇宙一	♡我的我的我的爱♡	又人又人	maimai love	maimailove	maimaimailove	出mai我的爱	爱情买卖	章鱼歌	舞萌痴
+『んっあっあっ。』	『嗯啊哈。』	嗯啊啊啊。	「んっあっあっ。」	举手	初音鬼叫	嗯啊啊	烟嗓	顶级烟嗓
+『ウソテイ』 ～一回戦せりなvsしろなvsなずな～	《谎言亭》～第一战芹奈vs白奈vs菜奈～	『ウソテイ』 ～一回战せりなvsしろなvsなずな～	谎言对决 ～第一战 芹奈vs白奈vs菜奈～	一回战	中二兔子跑	兔子跑2	彩绿兔子跑	防空警报
+【東方ニコカラ】秘神マターラ feat.魂音泉【IOSYS】	【东方nico卡拉】秘神摩多罗 feat.魂音泉【IOSYS】	【东方ニコカラ】秘神マターラ feat.魂音泉【IOSYS】	见前	东方〇起	东方勃起	秘神	秘神摩多罗
+あつすぎの歌	太热之歌	太热的歌	hero死了	半夏	夏热之歌	夏热歌	太热了	好热	好热歌	最热之歌	热死了	热死了之歌	阿紫一
+あなたは世界の終わりにずんだを食べるのだ	あなたは世界の终わりにずんだを食べるのだ	世界尽头吃枝豆	你在世界尽头吃豆子	世界终食	世终俊达	你在这世界的终焉，吃下了俊达	俊达萌发电报	俊达萌打电报	俊达萌被吃	在世界末日吃掉了俊达	摩斯密码	摩斯电码	海鲜味毛豆	食终孤独
+あねぺったん	只含月铃姐妹	姐姐啪嗒	便当	假酒	姐姐好平	月铃姐妹	醋溜便当
 あの世行きのバスに乗ってさらば。	あの世行きのバスに乘ってさらば。
-ありふれたせかいせいふく	司空见惯的世界征服	平凡世界征服
-いちげき！のテーマ	一击！主题曲
-いっしそう電☆舞舞神拳！	114514	いっしそう电☆舞舞神拳！	一唱双电☆舞舞神拳！	一射电舞神拳
+ありふれたせかいせいふく	司空见惯的世界征服	平凡世界征服	世界征服	初音围巾	司空见惯	围巾初音白背景	红围巾
+いちげき！のテーマ	一击！主题曲	一击	吃我一击吧	音击愚人节
+いっしそう電☆舞舞神拳！	114514	いっしそう电☆舞舞神拳！	一唱双电☆舞舞神拳！	一射电舞神拳	maimai神拳	一子相传	呜呜神拳	武萌神拳	紫代主题曲	舞舞神拳
 いっぱい食べる君が好きだよ	喜欢大吃的你
-いーあるふぁんくらぶ	12fan	伊阿鲁芬俱乐部	王力宏
+いーあるふぁんくらぶ	12fan	伊阿鲁芬俱乐部	王力宏	12	12fanclub	dx王力宏	fanclub	一二俱乐部	一二粉丝俱乐部	中日友好歌	周杰伦	烟雾列车	熊猫头
 うっせぇわ	吵死了
 うまるん体操	小埋体操
-おくすり飲んで寝よう	おくすり饮んで寝よう	吃药睡觉	吃药睡觉吧
-おこちゃま戦争	おこちゃま战争	孩子们的战争	孩子气战争	孩子气的战争	小孩子战争
-おちゃめ機能	おちゃめ机能	五月病	天真烂漫机能	调皮功能
-おても☆Yan	山歌	阿铁摸呀	阿铁摸鸭	陕北民歌
-おとせサンダー	落下雷霆	落雷
-おねがいダーリン	拜托了darling	拜托了亲爱的
-おジャ魔女カーニバル!!	光吉猛修发癫	光吉猛修跳舞	奥哈女巫嘉年华	小魔女	小魔女嘉年华！！
-お嫁にしなさいっ！	嫁给我吧！
+おくすり飲んで寝よう	おくすり饮んで寝よう	吃药睡觉	吃药睡觉吧	吃完药就睡觉	吃完药就睡觉吧	吃完药睡觉	吃药
+おこちゃま戦争	おこちゃま战争	孩子们的战争	孩子气战争	孩子气的战争	小孩子战争	孩子气	战争
+おちゃめ機能	おちゃめ机能	五月病	天真烂漫机能	调皮功能	天真浪漫机能	机能
+おても☆Yan	山歌	阿铁摸呀	阿铁摸鸭	陕北民歌	yan	おても	刀锋女王	双押跳拍	日本民歌	烟	😃	😃👍
+おとせサンダー	落下雷霆	落雷	otosethunder	司空震	雷落
+おねがいダーリン	拜托了darling	拜托了亲爱的	one	拜托了原神	拜托了，亲爱的
+おジャ魔女カーニバル!!	光吉猛修发癫	光吉猛修跳舞	奥哈女巫嘉年华	小魔女	小魔女嘉年华！！	光吉猛修	光吉猛修小魔女	小魔女嘉年华	魔女
+お嫁にしなさいっ！	嫁给我吧！	东方花嫁	东方萃翠酒醉	女同7	婚礼	婚礼进行曲	结婚
 お気に召すまま	お气に召すまま	气召	皆大欢喜
-お願い！コンコンお稲荷さま	お愿い！コンコンお稻荷さま	拜托！狐仙大人
-かせげ！ジャリンコヒーロー	赚大钱！小丑英雄	赚钱！叮当英雄
-からくりピエロ	机关小丑	活动小丑	🤡
-きたさいたま2000	kita	全网最帅五兄弟	北埼玉2000	塞他妈	过北脱新
-きみのためなら死ねる	为了你而死	为你而死
-きゅうくらりん	九克拉林	心跳不止
-きゅびずむ	Qubism
-きゅびびびびずむ	Qubibibibism
-きらっせ☆ウッド村ファーム	妖精村	闪耀吧木村农场
+お願い！コンコンお稲荷さま	お愿い！コンコンお稻荷さま	拜托！狐仙大人	拜托了狐仙大人	拜托了！狐仙大人	拜托啦！狐仙大人
+かせげ！ジャリンコヒーロー	赚大钱！小丑英雄	赚钱！叮当英雄	¥	哈姆	哈姆？	英雄银行
+からくりピエロ	机关小丑	活动小丑	🤡	小丑	活动沙口
+きたさいたま2000	kita	全网最帅五兄弟	北埼玉2000	塞他妈	过北脱新	2000	下北泽2000	五兄弟	光污染小人	北埼玉	北琦玉	北琦玉2000	埼玉2000	太鼓2000	琦玉2000	😁😁😁😁😁
+きみのためなら死ねる	为了你而死	为你而死	失败的man	死
+きゅうくらりん	九克拉林	心跳不止	ddlc	可不抱头	心动不已	心跳不动	心跳不已	晴天娃娃	纱世里	绿衣女人摸脸蛋
+きゅびずむ	Qubism	地雷女自孽	立体主义
+きゅびびびびずむ	Qubibibibism	立体体体体主义
+きらっせ☆ウッド村ファーム	妖精村	闪耀吧木村农场	はっぴー酱下乡扶贫	木村农场	銚子县	😆😆
 くらべられっ子	被比较的孩子
-ぐるぐるWASH！コインランドリー・ディスコ	suomi	洗衣房	转转洗！投币洗衣迪斯科
-げきオコスティックファイナリアリティぷんぷんマスタースパーク	激怒声学最终现实噗噗大师火花	激怒声学最终现实怒放大师火花
-ここからはじまるプロローグ。	从这里开始的序章
-ここからはじまるプロローグ。 (Kanon Remix)	从这里开始的序曲 (Kanon Remix)	从这里开始的序章
-このピアノでお前を8759632145回ぶん殴る	1145141919810	用这架钢琴揍你8759632145次
-さくゆいたいそう	樱唯体操	樱结体操
-さよならヒストリー	再见历史
+ぐるぐるWASH！コインランドリー・ディスコ	suomi	洗衣房	转转洗！投币洗衣迪斯科	咕噜咕噜	咕噜咕噜wash	屏幕清洁工	檄代主题曲	洗衣机	滚筒洗衣机
+げきオコスティックファイナリアリティぷんぷんマスタースパーク	激怒声学最终现实噗噗大师火花	激怒声学最终现实怒放大师火花	东方名字很长	东方曲名过长
+ここからはじまるプロローグ。	从这里开始的序章	prologue	prologue starting	从此开始的序章	从现在开始的序曲	像素圣剑	像素福瑞	兽太	口口一夕	圣剑0	小圣剑	小狐狸	小生煎	小福瑞	序章	序言	松鼠	狐狸剑	猫圣剑	由此开始的序章	电子福瑞	福瑞举剑	福瑞勇者	福瑞小英雄	福瑞控	福瑞救老婆
+ここからはじまるプロローグ。 (Kanon Remix)	从这里开始的序曲 (Kanon Remix)	从这里开始的序章	kanon remix	从现在开始的序曲	像素福瑞2	像素福瑞remix	圣剑0.5	福瑞控2	福瑞控remix	福瑞的135秒
+このピアノでお前を8759632145回ぶん殴る	1145141919810	用这架钢琴揍你8759632145次	1919810	8759632145	一串数字	一堆数字	我会用这架钢琴殴打你8759632145次	用钢琴揍你8759632145回	踢钢琴	钢琴	钢琴打人	钢琴殴打	钢琴砸人
+さくゆいたいそう	樱唯体操	樱结体操	sakuyui exercise	sakuyui taisou	咲唯体操	女同17	我等心友
+さよならヒストリー	再见历史	慧音热舞
 さよならプリンセス	再见公主
-しねばいいのに	死了一了百了	死了就好
-しゅわスパ大作戦☆	しゅわスパ大作战☆	修哇	修哇大作战	气泡大作战☆	温泉大作战
-すーぱーぬこになりたい	nuko	变超猫	想变成超级猫
-すーぱーぬこになれんかった	我无法成为超级努子	没能成为超级猫	魔法美发滚
+しねばいいのに	死了一了百了	死了就好	不如死了算了	剁椒鱼头	去死死算了	明明死了就好了	死了算了	红鲤鱼与绿鲤鱼	西内	西内吧一诺尼	要是死了就好了	鲤鱼王
+しゅわスパ大作戦☆	しゅわスパ大作战☆	修哇	修哇大作战	气泡大作战☆	温泉大作战	ymn	下药歌	大作战	炎拳
+すーぱーぬこになりたい	nuko	变超猫	想变成超级猫	变成猫	变猫	开水壶成精	想变成猫	想变猫	想要变成超级猫	想要成为super nuko	想要成为超级猫猫	我想变成猫咪	猫猫	粉猫	超猫	超级猫猫
+すーぱーぬこになれんかった	我无法成为超级努子	没能成为超级猫	魔法美发滚	变不成猫	投降猫	无法成为超级猫猫	没变成猫猫	没能成为超级猫猫	猫咪	蓝蓝路	超猫2	超级猫	超级猫咪	超级猫猫
 ずんだもんの朝食 〜目覚ましずんラップ〜	ずんだもんの朝食 〜目觉ましずんラップ〜	豆丁的早餐～唤醒豆说唱～	豆泥的早餐 〜闹钟豆泥说唱〜
-ずんだもんの朝食　〜目覚ましずんラップ〜	ずんだもんの朝食 〜目觉ましずんラップ〜
-ずんだパーリナイ	ずんだ派对夜	毛豆派对夜
-その群青が愛しかったようだった	その群青が爱しかったようだった	群青爱	那片群青曾如此可爱
-ただ選択があった	ただ选择があった	唯有选择
-だからパンを焼いたんだ	だからパンを烧いたんだ	所以我烤了面包	烧面包
-だから僕は音楽を辞めた	だから仆は音乐を辞めた	不要停下来啊	我放弃了音乐	所以我放弃了音乐	所以我放弃音乐了
-だれかの心臓になれたなら	だれかの心脏になれたなら	如果能成为谁的心脏的话	若能成为某人的心脏
-だんだん早くなる	渐渐加速	渐渐变快	蛋蛋变快	越来越快	逐渐加快
-ってゐ！ ～えいえんてゐVer～	是！～永远亭Ver～	永恒亭Ver
-つるぺったん	光溜溜	鹤平摊
-てらてら	亮晶晶	闪闪发光
-でらっくmaimai♪てんてこまい!	滴蜡熊	超棒maimai♪手忙脚乱!
-とびだせ！TO THE COSMIC!!	去宇宙	飞向宇宙！！
-とりあえずアナタがいなくなるまえに	总之在你消失之前	总是在你消逝之前
-どぅーまいべすと！	do my best	domybest	努力做到最好！	尽我所能！
-どうしてこうなった	为什么会这样	怎么会变成这样	怎会如此	跳舞狗
-ないせんのうた	内线之歌	再见IM外星人	好他妈烦	这个地球是一秒都待不下去了
-なるとなぎのパーフェクトロックンロール教室	⑨	成和凪的完美摇滚教室	琪露诺的完美算数教室
-にじよめちゃん体操第一億	1e8	にじよめちゃん体操第一亿	体操一亿	虹梦酱体操第一亿
-にっこり^^調査隊のテーマ	にっこり^^调查队のテーマ	微笑^^调查队主题	微笑调查队主题曲
-にゃーにゃー冒険譚	にゃーにゃー冒险谭	喵喵冒险谭
-ねぇ、壊れタ人形ハ何処へ棄テらレるノ？	ねぇ、坏れタ人形ハ何处へ弃テらレるノ？	坏人偶	坏人偶何处弃	坏人形	破碎人偶何处弃
-のじゃロリック	萝莉腔调
-のだ	野田
-はいよろこんで	好的，乐意效劳
+ずんだもんの朝食　〜目覚ましずんラップ〜	ずんだもんの朝食 〜目觉ましずんラップ〜	俊达萌	俊达萌叫床	俊达萌叫起床	俊达萌的早餐	俊达萌起床	朝食目觉	毛豆	毛豆叫床	毛豆喊起床	毛豆精	起きて	起床	起床了	起床战争	起床歌	起来啦	📢	📣	😆
+ずんだパーリナイ	ずんだ派对夜	毛豆派对夜	俊达派对之夜	俊达萌派对
+その群青が愛しかったようだった	その群青が爱しかったようだった	群青爱	那片群青曾如此可爱	群青	那份群青仿佛是很可爱的样子	那片群青好像很可爱
+ただ選択があった	ただ选择があった	唯有选择	jubeat	仅仅做出选择而已	只是在不断选择	打地鼠	答题卡	选择
+だからパンを焼いたんだ	だからパンを烧いたんだ	所以我烤了面包	烧面包	初音烤面包	烤面包	烧	白葱烤面包	铜锣烧	面包	🍞
+だから僕は音楽を辞めた	だから仆は音乐を辞めた	不要停下来啊	我放弃了音乐	所以我放弃了音乐	所以我放弃音乐了	エイミー	于是我放弃了音乐	仆音乐辞	团长	奥尔加	放弃音乐	音乐辞	音辞
+だれかの心臓になれたなら	だれかの心脏になれたなら	如果能成为谁的心脏的话	若能成为某人的心脏	如果能成为谁的心脏	心脏
+だんだん早くなる	渐渐加速	渐渐变快	蛋蛋变快	越来越快	逐渐加快	专注轻机枪	别急8	动力小子	哈压库	当当哈呀库那路	慢慢变快	末白	渐变快	渐渐加快	渐渐变急	秃老头	蛋蛋	蛋蛋加速	蛋蛋歌	走路人	走路歌	越战越勇	跑男	逐渐加速	逐渐变快	闲鱼客服
+ってゐ！ ～えいえんてゐVer～	是！～永远亭Ver～	永恒亭Ver	因幡帝	屁股	帝帝	永远亭	翘屁股	翘臀
+つるぺったん	光溜溜	鹤平摊	伊吹萃香	萃香	西瓜	醋溜便当	醋溜便当2
+てらてら	亮晶晶	闪闪发光	忒啦忒啦
+でらっくmaimai♪てんてこまい!	滴蜡熊	超棒maimai♪手忙脚乱!	dx主题曲	三森铃子	天手古舞	舞萌主题曲	迪拉熊
+とびだせ！TO THE COSMIC!!	去宇宙	飞向宇宙！！	uni	universe主题曲	uni主题曲	とびだせ	とびだぜ	压缩tpz	太空牛奶猫	女同13	宇宙牛奶	新牛奶	牛奶2	牛奶3	缝合怪	舞萌2023主题曲	起飞	飞向宇宙
+とりあえずアナタがいなくなるまえに	总之在你消失之前	总是在你消逝之前	小电视	总之在你消逝之前	电视	电视头	电视机	📺
+どぅーまいべすと！	do my best	domybest	努力做到最好！	尽我所能！	do mai best	独立宣言	音街宣言
+どうしてこうなった	为什么会这样	怎么会变成这样	怎会如此	跳舞狗	为什么会变成这样	为什么会变成这样呢	为什么会这样呢	怎么回事呢	怎么这样	白板	跳舞洗狗
+ないせんのうた	内线之歌	再见IM外星人	好他妈烦	这个地球是一秒都待不下去了	内线	内线云1	打电话	没歌
+なるとなぎのパーフェクトロックンロール教室	⑨	成和凪的完美摇滚教室	琪露诺的完美算数教室	中二教室	冒牌⑨	摇滚教室	数学教室	箱部鸣与小佛凪的完美摇滚教室
+にじよめちゃん体操第一億	1e8	にじよめちゃん体操第一亿	体操一亿	虹梦酱体操第一亿	体操	体操第一亿	体操第一億	牵线木偶	🤤
+にっこり^^調査隊のテーマ	にっこり^^调查队のテーマ	微笑^^调查队主题	微笑调查队主题曲	微笑调查队	调查队
+にゃーにゃー冒険譚	にゃーにゃー冒险谭	喵喵冒险谭	nyanya冒险谭	冒险谭	哈基米大冒险	妖精冒险谭
+ねぇ、壊れタ人形ハ何処へ棄テらレるノ？	ねぇ、坏れタ人形ハ何处へ弃テらレるノ？	坏人偶	坏人偶何处弃	坏人形	破碎人偶何处弃	人形	坏人	扔垃圾桶
+のじゃロリック	萝莉腔调	bud+两小只	コンコン結婚コン	你好结婚	女同18	婚婚结婚婚	结婚	结婚婚
+のだ	野田	noda
+はいよろこんで	好的，乐意效劳	乐意效劳	滋嘣
 はげしこの夜 -Psylent Crazy Night-	激烈之夜 -Psylent Crazy Night-	狂乱之夜
-はちみつアドベンチャー	蜂蜜冒险	蜜蜂冒险
-はやくそれになりたい！	好想快点变成那样	好想快点变成那样！	我想快点成为它！	搞快点
-はんぶんこ	一半一半	分一半
-ばかみたい【Taxi Driver Edition】	damedane	像个傻瓜【出租车司机版】	像傻瓜一样【出租车司机版】
-ぱくぱく☆がーる	大口女孩	江江报菜名	肚子饿了	蔡明
-ひれ伏せ愚民どもっ！	伏愚民	跪下吧愚民们！
-ぴぴぱぷぅ！	噼噼啪噗！	比巴卜
-ふらふらふら、	摇摇晃晃	摇摇晃晃、
-へべれけジャンキー	烂醉如泥	烂醉如泥的瘾君子
-ほしぞらスペクタクル	星空奇观	水母	水母姐
+はちみつアドベンチャー	蜂蜜冒险	蜜蜂冒险	はちみ	哈基米	大小福瑞	小孩坐大车	小孩开大车	熊妈妈	蓝色侏儒小熊	蜂蜜adventure
+はやくそれになりたい！	好想快点变成那样	好想快点变成那样！	我想快点成为它！	搞快点	i wanna be it	想快点变成那个样子	想快点成为那个样子	蓝瓶尖叫	音街	音街鳗	😫
+はんぶんこ	一半一半	分一半	三枝明那	半分子	另一半
+ばかみたい【Taxi Driver Edition】	damedane	像个傻瓜【出租车司机版】	像傻瓜一样【出租车司机版】	bakamitai	oceancat	像个傻瓜	像笨蛋一样	八嘎	八嘎米袋	别急20	哭包羽染	如龙5	如龙的雨	打咩打捏	海猫	海猫络合物	玛恩纳	笨蛋	羽染	铃木太一	🐶	🥃
+ぱくぱく☆がーる	大口女孩	江江报菜名	肚子饿了	蔡明	pac pac girl	大胃袋江子	报菜名	江江	江江下锅	江江今天吃什么	江江炫饭
+ひれ伏せ愚民どもっ！	伏愚民	跪下吧愚民们！	佩恩	愚民	辉夜
+ぴぴぱぷぅ！	噼噼啪噗！	比巴卜	噼噼啪噗
+ふらふらふら、	摇摇晃晃	摇摇晃晃、	fulafula	摇晃不清
+へべれけジャンキー	烂醉如泥	烂醉如泥的瘾君子	daisuke	喝醉的五条悟	酩酊大醉的瘾君子
+ほしぞらスペクタクル	星空奇观	水母	水母姐	奏音	巫贼	星球妹	星际奇观	水母妹	水母娘	珊瑚宫心海
 ぼくたちいつでも しゅわっしゅわ！	我们总是活力满满！	我们永远活力四射
-ぼくたちいつでも　しゅわっしゅわ！	修哇	咻哇咻哇	我们总是洗牌！
-ぽっぴっぽー	波比波	蔬菜歌	蔬菜汁
-ぽわわん劇場	ぽわわん剧场	软绵绵剧场
-まっすぐ→→→ストリーム！	直冲→→→激流！	直直直冲！
-まにまに	随波逐流
-みくみくにしてあげる♪【してやんよ】	把你mikumiku掉	把你给MIKUMIKU掉♪【给你】
-みなえをチェック！	检查尾巴！	检查皆江！
-みんなの	兽道	大家的
-みんなのマイマイマー	大家的maimai吗	大家的マイマイマー
+ぼくたちいつでも　しゅわっしゅわ！	修哇	咻哇咻哇	我们总是洗牌！	happyhappy	splash主题曲	丸山彩	休哇休哇	修哇修哇	修车	咻哇	彩黑	柠檬熊	阿驿	雨刮器2
+ぽっぴっぽー	波比波	蔬菜歌	蔬菜汁	advent	popipo	哈基米	波比波比	菜蔬汁
+ぽわわん劇場	ぽわわん剧场	软绵绵剧场	powawan theater	剧场	泡泡剧场	波弯弯剧场
+まっすぐ→→→ストリーム！	直冲→→→激流！	直直直冲！	右右右
+まにまに	随波逐流	manimani	女人射箭	射箭	随之任之	马尼马尼	🏹
+みくみくにしてあげる♪【してやんよ】	把你mikumiku掉	把你给MIKUMIKU掉♪【给你】	狗·眼·①·瞎	飞龙	📉
+みなえをチェック！	检查尾巴！	检查皆江！	口水歌	指挥棒	注目	美苗
+みんなの	兽道	大家的	獸道
+みんなのマイマイマー	大家的maimai吗	大家的マイマイマー	maimai	大家的maimai	大家的maimai人	大家的妈妈	🍥
 もういいよ	够了
-もうみんなしねばいいのに	大家死了好	大家都死了就好	骂脏话
-もぺもぺ	mopemope	毛八毛八
+もうみんなしねばいいのに	大家死了好	大家都死了就好	骂脏话	全寄	全灭	去死吧	团灭	大家一起死	大家去死	大家都去死	大家都死了	如果大家都似了就好了	如果大家都似掉就好了	如果大家都死了就好了	如果大家都趋势了就好了	帕露西	水桥帕露西	趋势
+もぺもぺ	mopemope	毛八毛八	mope	もペもペ	儿歌	儿童金曲	儿童鞋垫	四川变脸	好船	宝宝金曲	小白船	小花	小花花	小蓝花	恐怖小花	恶心	早八早八	毛八	毛坯毛坯	毛胚毛胚	烟火大会	电棍电棍	草	蓝花	闪光弹	鞋垫
 ももいろの鍵	ももいろの键	桃色之钥
-やめろ！聴くな！	やめろ！听くな！	住手！别听！
-ゆけむり魂温泉 II	汤烟魂温泉 II
+やめろ！聴くな！	やめろ！听くな！	住手！别听！	やめろ	不要听	停下！不要听！	别听	听
+ゆけむり魂温泉 II	汤烟魂温泉 II	魂温泉
 ゆりかご	摇篮
-りばーぶ	reverb	重生
-れっつ！みらくる☆はーどこあっ！	laur老婆	来吧！奇迹☆硬核！	老二老婆	雌小鬼
-アイディスマイル	爱迪微笑
-アイドル	偶像
+りばーぶ	reverb	重生	两个人喝茶	混响
+れっつ！みらくる☆はーどこあっ！	laur老婆	来吧！奇迹☆硬核！	老二老婆	雌小鬼	hardcore2	laur撒狗粮	let's miracle☆hardcore	miracle hardcore	wifecore	浮冰	老二和他的老婆
+アイディスマイル	爱迪微笑	ids	idsmile
+アイドル	偶像	idol	爱豆
 アイドル新鋭隊	アイドル新锐队	偶像新锐队
-アイム・マイヒーロー	我是我的英雄
-アウターサイエンス	外层科学	界外科学
+アイム・マイヒーロー	我是我的英雄	i am my hero	我是自己的英雄	英雄	马云
+アウターサイエンス	外层科学	界外科学	outer science	次の
 アウトサイダー	outsider
-アカツキアライヴァル	拂晓抵达	晓之对手
-アカリがやってきたぞっ	灯里来了哦	赤里来了	阿卡丽
-アスノヨゾラ哨戒班	哨戒班	明夜天空哨戒班
-アスヘノBRAVE	勇往直前	向明天的勇气
-アディショナルメモリー	附加记忆	额外记忆
-アトロポスと最果の探究者	最果探究者	阿特洛波斯与终极探索者	阿特罗波斯和终极探索者
-アニマル	动物
-アポカリプスに反逆の焔を焚べろ	アポカリプスに反逆の焰を焚べろ	反逆焰	末世燃起叛逆之火
-アマツキツネ	天狐
-アマノジャクリバース feat. ｙｔｒ	ytr	天邪鬼反转	天邪鬼反转 feat. ytr	灵梦过马路
-アルカリレットウセイ	碱性劣等生	莉莉卡
-アルカンシエル	彩虹	阿尔坎西耶尔
-アルティメットセンパイ	究极先辈	终极前辈
-アンクローズ・ヒューマン	unclose human	未封闭的人类
-アンドロイドガール	Android Girl	安卓女孩	机器人女孩	机器女孩
-アンノウン・マザーグース	妈妈鹅	未知鹅妈妈
-アンハッピーリフレイン	unhappy refrain	不快乐的副歌	不高兴的副歌
+アカツキアライヴァル	拂晓抵达	晓之对手	初音未来和波奇	女同8	拂晓	拂晓已至	鱼葱
+アカリがやってきたぞっ	灯里来了哦	赤里来了	阿卡丽	akari	akari来了哦	来了	来了哟	来了哦	绁星灯	阿卡莉
+アスノヨゾラ哨戒班	哨戒班	明夜天空哨戒班	dx哨戒班	dx烧鸡班	哨戒班2	明日的夜空哨戒班	烧鸡班
+アスヘノBRAVE	勇往直前	向明天的勇气	brave
+アディショナルメモリー	附加记忆	额外记忆	回忆追加
+アトロポスと最果の探究者	最果探究者	阿特洛波斯与终极探索者	阿特罗波斯和终极探索者	大奈子伊蕾娜	大奶伊蕾娜	大奶子伊蕾娜	大奶子依蕾娜	大柰子伊蕾娜	大柰柰伊蕾娜	大雷伊蕾娜	探究者	最果	翠果	阿特洛波斯与尽头的探究者
+アニマル	动物	animal	deco喵喵叫	猫抓板	猫猫初音	猫葱
+アポカリプスに反逆の焔を焚べろ	アポカリプスに反逆の焰を焚べろ	反逆焰	末世燃起叛逆之火	apocalypse rebellious	于启示录上燃烧的叛逆火焰	反逆	在启示录上点燃叛逆的火焰
+アマツキツネ	天狐	兰立忠	刻俄柏	天狗	👍😁👍
+アマノジャクリバース feat. ｙｔｒ	ytr	天邪鬼反转	天邪鬼反转 feat. ytr	灵梦过马路	0梦过马路	天邪鬼	灵梦过街	过马路	🚸
+アルカリレットウセイ	碱性劣等生	莉莉卡	露露卡莉莉卡噜啦哩啦噜啦啦	魔法少女	魔法少女举大棒
+アルカンシエル	彩虹	阿尔坎西耶尔	yamajet	小女孩骑单车	自行车	赤月代	骑自行车	🚴
+アルティメットセンパイ	究极先辈	终极前辈	先辈	小黄毛	究极前辈
+アンクローズ・ヒューマン	unclose human	未封闭的人类	unclosed human	unclosehuman	敬爱	玻璃心	里表情人2
+アンドロイドガール	Android Girl	安卓女孩	机器人女孩	机器女孩	仿生少女	安卓女	安卓少女	琪亚娜
+アンノウン・マザーグース	妈妈鹅	未知鹅妈妈	unknown mother goose	不为人知的鹅妈妈童谣	仁王盾	大鹅妈妈	未知的母鹅	鹅妈妈	鹅妈妈童谣
+アンハッピーリフレイン	unhappy refrain	不快乐的副歌	不高兴的副歌	unhappy	ur	副歌	💗
 アンバークロニクル	琥珀编年史
-アンビバレンス	矛盾心理
-アージェントシンメトリー	argent symmetry	pink op	sta	白银对称性	科目二	银色对称
-イアイア★ナイトオブデザイア	七对奶子	伊艾亚★欲望之夜
-イカサマライフゲイム	作弊生存游戏	欺诈人生游戏
+アンビバレンス	矛盾心理	ambivalence	二律背反	我喜欢阿瓦鲁	穿心	言叶5
+アージェントシンメトリー	argent symmetry	pink op	sta	白银对称性	科目二	银色对称	pink主题曲	方向盘	桃代主题曲	白银	白银对称	草莓章鱼	银对称	银对称性	银色对称性
+イアイア★ナイトオブデザイア	七对奶子	伊艾亚★欲望之夜	iaia	yiayia
+イカサマライフゲイム	作弊生存游戏	欺诈人生游戏	lifegame	人生游戏	虚伪人生游戏	预言小丑	骗人的lifegame	骗人的人生游戏
 イガク	医学
-イノコリ先生	先生	留堂老师
-イロトリドリのメロディ	五彩缤纷的旋律	彩绿之歌
-インターネットサバイバー	internet survivor	网络幸存者	网际生存者
-インドア系ならトラックメイカー	宅系制作人	室内系
-インパアフェクシオン・ホワイトガアル	不完美·白女孩	不完美白女孩
-インビジブル	Invisible	透明人间	隐形
-ウサテイ	兔亭	兔子快跑	帝帝跑跑跑
+イノコリ先生	先生	留堂老师	男同	男同互瞪	男同老师
+イロトリドリのメロディ	五彩缤纷的旋律	彩绿之歌	多彩旋律	小仏凪	端茶
+インターネットサバイバー	internet survivor	网络幸存者	网际生存者	东方互联网	东方女孩重度依赖	东方超天酱	互联网幸存者	互联网生存者	兰	生存者	网瘾二小姐	芙兰朵露	芙兰朵露重度依赖
+インドア系ならトラックメイカー	宅系制作人	室内系	indoor系	nichan	一笔画	内向都是作曲家	室内系的track maker	室内系的trackmaker	室内轨道制造商	小姐姐
+インパアフェクシオン・ホワイトガアル	不完美·白女孩	不完美白女孩	不完美少女	不完美白色女孩	不完美的白之少女	不完美的白色女孩	不完美的白色少女	冴川芽依	文学少女	月乃	白女	霸道总裁爱上我
+インビジブル	Invisible	透明人间	隐形	建筑工地	透明人
+ウサテイ	兔亭	兔子快跑	帝帝跑跑跑	乌撒	兔子	兔子跑	因幡帝	小老帝	石门快乐歌	🐇
 ウタヒメナイトストーム	歌姬夜风暴
-ウッーウッーウマウマ(ﾟ∀ﾟ)	呜—呜—马马(ﾟ∀ﾟ)	扭腰歌
+ウッーウッーウマウマ(ﾟ∀ﾟ)	呜—呜—马马(ﾟ∀ﾟ)	扭腰歌	(ﾟ∀ﾟ)	呜哇呜哇	扭秧歌	扭腰	扭腰舞	焦糖舞	跳的很骚	跳舞歌
 ウマイネームイズうまみちゃん	Umai 的名字是 Umami-chan	哆啦A梦
-ウミユリ海底譚	ウミユリ海底谭	海底捞	海百合海底谭	海脑瘫
-ウルトラトレーラー	超拖车	超长拖车
-エイプリルスター	四月之星
-エイリアンエイリアン	alien	外星人	外星人外星人
-エゴロック	ego rock	自我摇滚
-エスオーエス	SOS	求救信号
-エテルニタス・ルドロジー	东方鼓动	永恒游戏学	～AETERNITAS LUDOLOGY～
-エナドリおいしいソング	能量饮料	能量饮料好喝之歌	能量饮料好喝歌
-エピクロスの虹はもう見えない	エピクロスの虹はもう见えない	再也看不见伊壁鸠鲁的彩虹	圣母	虹见
-エンジェル ドリーム	天使之梦
-エンドマークに希望と涙を添えて	エンドマークに希望と泪を添えて	在终止符处添上希望与眼泪	希望泪	希望累	终点标记添希望与泪
-エンヴィーベイビー	envy babe	envy baby	嫉妒宝贝
-エータ・ベータ・イータ	hera2	伊塔·贝塔·伊塔	工一夕	纵连2	蓝原椿	赫拉2	赫拉二
+ウミユリ海底譚	ウミユリ海底谭	海底捞	海百合海底谭	海脑瘫	初音未来跳海	初音跳海	在海下面	水神3	海底潭	海底谭	海百合	海魔王	谭
+ウルトラトレーラー	超拖车	超长拖车	ultra trailer	超予告编	超预告片	超预告篇
+エイプリルスター	四月之星	april star
+エイリアンエイリアン	alien	外星人	外星人外星人	alien alien	✋🏻😐✋🏻	奥利奥利安	奥利安奥利安	常陆茉子	河南人	阿里安	👽
+エゴロック	ego rock	自我摇滚	egorock	煎饼	煎饼歌	自由摇滚
+エスオーエス	SOS	求救信号	女同19	拉兹乙姬二打一	街机和音游
+エテルニタス・ルドロジー	东方鼓动	永恒游戏学	～AETERNITAS LUDOLOGY～	aeternitas ludology	八云紫
+エナドリおいしいソング	能量饮料	能量饮料好喝之歌	能量饮料好喝歌	drink with me	东鹏特饮	和亲	斐济杯	易拉罐	红牛	能量饮料歌	能量饮料真好喝
+エピクロスの虹はもう見えない	エピクロスの虹はもう见えない	再也看不见伊壁鸠鲁的彩虹	圣母	虹见	上海红茶馆	再见不到伊壁鸠鲁的彩虹
+エンジェル ドリーム	天使之梦	angel dream
+エンドマークに希望と涙を添えて	エンドマークに希望と泪を添えて	在终止符处添上希望与眼泪	希望泪	希望累	终点标记添希望与泪	为结局添上希望与泪水	梦之泪伤	梦泪	筋肉女神	🙂
+エンヴィーベイビー	envy babe	envy baby	嫉妒宝贝	envy	envybaby	剔牙	打牌	拼多多	林尼	雀魂
+エータ・ベータ・イータ	hera2	伊塔·贝塔·伊塔	工一夕	纵连2	蓝原椿	赫拉2	赫拉二	eta beta ita	工一夕八一夕人一夕
 オシオキGIMMICK!!	惩罚把戏	惩罚诡计!!
 オトヒメモリー☆ウタゲーション	乙姫	乙姬	乙姬记忆☆歌宴
-オパ! オパ! RACER -GMT mashup-	OPA! OPA! 赛车手 -GMT串烧-
+オパ! オパ! RACER -GMT mashup-	OPA! OPA! 赛车手 -GMT串烧-	坟头对撞	太东mashup	幻想空间×山脊赛车	才八	才八才八	扫键电车	赛车
 オモイヨシノ	思吉野	恋咏樱
-オリフィス	Orifice	孔口	孔洞
-オレンジの夏	橙夏	橙色的夏天
+オリフィス	Orifice	孔口	孔洞	流孔	流量计	画家	美术生	黄毛美术生
+オレンジの夏	橙夏	橙色的夏天	夏	女人骑自行车	橘之夏	橙之夏	橙色夏天	洋车的	砂狼白子	自行车	菊次郎的夏天	🎞️
 オーケー？ オーライ！	OK？ 好了！	好吧？好了！
-オーケー？　オーライ！	Okay? All right!
-オーディエンスを沸かす程度の能力 feat.タイツォン	东方月灯笼	沸腾程度	让观众沸腾的能力 feat.泰宗
-オーバーライド	超驰
-カゲロウデイズ	车祸曲	车祸歌	阳炎days	阳炎眩乱
-カラッポ・ノンフィクション	Carappo Nonfiction	空洞的非虚构	空洞非虚构
-ガラテアの螺旋	伽拉忒亚的螺旋
-ガランド	Airhead	garando	空洞	花环
-キズナの物語	キズナの物语	羁绊物语	锁链战记
-キミノヨゾラ哨戒班	你的夜空哨戒班	烧鸡班
-キャットラビング	爱猫	猫之爱
-キャプテン・ムラサのケツアンカー	紫船长之臀锚
-キュートなカノジョ	可爱女友	可爱的女友
-キラメキ居残り大戦争	キラメキ居残り大战争	闪烁留级大战争	闪耀留校大战争
-キリキリ舞Mine	girigiri舞	旋舞矿
-キレキャリオン	carry on	切吧 Carry On	切裂尸	双挽乃保
-クレイジークレイジーダンサーズ	ccd	crazy crazy dance	crazycrazydance	疯狂疯狂舞者	疯狂疯狂跳舞
-クレイジー・ビート	Crazy beat	疯狂节拍
-グッバイ宣言	MEGATON KICK	再见宣言	告别宣言
-グラーヴェ	坟	沉重
-グリーンライツ・セレナーデ	绿光小夜曲	绿灯小夜曲
-ケロ⑨destiny	9	⑨	⑨的宿命	青蛙⑨命运
-ココロスキャンのうた	心灵扫描之歌	心灵扫描歌	捂裆男
-コスモポップファンクラブ	宇宙星空俱乐部	宇宙流行乐粉丝俱乐部
-コトバ・カラフル	kotoba colorful	女同3	言语·多彩
+オーケー？　オーライ！	Okay? All right!	3q	ok	ok all right	？！
+オーディエンスを沸かす程度の能力 feat.タイツォン	东方月灯笼	沸腾程度	让观众沸腾的能力 feat.泰宗	沸	沸程度	沸程度能力	沸能力	沸腾
+オーバーライド	超驰	override	覆写
+カゲロウデイズ	车祸曲	车祸歌	阳炎days	阳炎眩乱	车祸	阳炎
+カラッポ・ノンフィクション	Carappo Nonfiction	空洞的非虚构	空洞非虚构	创世纪	彩色纪实文学
+ガラテアの螺旋	伽拉忒亚的螺旋	galatiaの螺旋	ガラテアのにゃんこ	伽拉	伽拉泰亚的螺旋	白洛轩	螺旋	🌀
+ガランド	Airhead	garando	空洞	花环	别急3.5	噬菌体	易拉罐	空气头	罐头章鱼	触手	黑色树枝
+キズナの物語	キズナの物语	羁绊物语	锁链战记	刀剑神域	物语	羁绊的故事	羁绊的物语
+キミノヨゾラ哨戒班	你的夜空哨戒班	烧鸡班	哨戒班	标准哨戒班	橙哨戒班
+キャットラビング	爱猫	猫之爱	cat loving	爱猫tv	白毛红瞳猫娘	香椎
+キャプテン・ムラサのケツアンカー	紫船长之臀锚	村纱水蜜	船长
+キュートなカノジョ	可爱女友	可爱的女友	可爱的女朋友	女朋友	米塔
+キラメキ居残り大戦争	キラメキ居残り大战争	闪烁留级大战争	闪耀留校大战争	大战争	女同2	女同大战争	女同歌	居残	居残大战争
+キリキリ舞Mine	girigiri舞	旋舞矿	kirikiri	キリキリ	舞mine
+キレキャリオン	carry on	切吧 Carry On	切裂尸	双挽乃保	kire carry on	乃保	切下	切下吧carryon	奶包	小电锯	电锯	电锯2	电锯人	电锯女	电锯娘	继续切
+クレイジークレイジーダンサーズ	ccd	crazy crazy dance	crazycrazydance	疯狂疯狂舞者	疯狂疯狂跳舞	185	crazy crazy dancers	crazycrazydancers	二人危险炸弹	女同6	小kib	尬舞姐妹2	疯狂舞者	魔理沙帕秋莉贴贴
+クレイジー・ビート	Crazy beat	疯狂节拍	crazybeat	crazybeats	双人蹦迪	狂乱节拍	狂热节拍	致命节奏
+グッバイ宣言	MEGATON KICK	再见宣言	告别宣言	886宣言	one,two	✌️👌	卡手宣言	扭手宣言
+グラーヴェ	坟	沉重	grave	hello	嘟嘟嘟
+グリーンライツ・セレナーデ	绿光小夜曲	绿灯小夜曲	墨芷	绿光	魔法未来2018
+ケロ⑨destiny	9	⑨	⑨的宿命	青蛙⑨命运	acc	kero
+ココロスキャンのうた	心灵扫描之歌	心灵扫描歌	捂裆男	migo	三千	少林捂裆功	捂裆歌	捂裆派	武当派	白色小人	长梦不醒	音声感情测定器	飞行家
+コスモポップファンクラブ	宇宙星空俱乐部	宇宙流行乐粉丝俱乐部	cosmo pop funclub	cpfc	吧啦吧吧吧	宇宙流行乐俱乐部	小魔仙	巴啦啦	巴啦啦小魔仙	芭芭拉拉粑粑
+コトバ・カラフル	kotoba colorful	女同3	言语·多彩	575	双押妹	双押姐妹花	多彩言语	女同	女同歌	女同贴贴	歌组575
 コネクト	connect	小圆op	联系
-コンティニュー！ feat. 藍月なくる	continue	コンティニュー！ feat. 蓝月なくる	继续！ feat. 蓝月奈苦留	继续！feat. 蓝月なくる
-ゴーゴー幽霊船	Go Go幽灵船	ゴーゴー幽灵船
-ゴーストルール	Ghost rule	幽灵法则	狗斯特露露
-サイバーサンダーサイダー	赛博雷击汽水	赛博雷霆汽水
-サドマミホリック	sb	灵梦撒币	虐麻迷狂
-サヨナラチェーンソー	再见电锯
-サヨナラフリーウェイ	sayonara freeway	再见高速公路
-サンバディ！	桑巴舞者！	桑巴迪！
-サンバランド	桑巴	桑巴乐园
-ザムザ	扎姆扎	赞歌
-シアトリカル・ケース	theatrical case	戏剧性事件	戏剧性案件	戏剧性案例	黑玫瑰3
+コンティニュー！ feat. 藍月なくる	continue	コンティニュー！ feat. 蓝月なくる	继续！ feat. 蓝月奈苦留	继续！feat. 蓝月なくる	禁漫娘	继续	继续！	蓝月	贪玩蓝月	阿诺内
+ゴーゴー幽霊船	Go Go幽灵船	ゴーゴー幽灵船	dx幽灵船	gogo幽灵船	幽灵船	憋憋憋
+ゴーストルール	Ghost rule	幽灵法则	狗斯特露露	dx幽灵法则	口一又卜儿一儿	小吹爆	幽灵	标准幽灵法则	法则	露露	露露小姐	👻
+サイバーサンダーサイダー	赛博雷击汽水	赛博雷霆汽水	ctc	小人打拳	火柴人
+サドマミホリック	sb	灵梦撒币	虐麻迷狂	撒币	撒币的灵梦	灵梦撒钱
+サヨナラチェーンソー	再见电锯	电锯	电锯人	电锯缘兔
+サヨナラフリーウェイ	sayonara freeway	再见高速公路	再见	我有抑郁症	抑郁症
+サンバディ！	桑巴舞者！	桑巴迪！	somebody	光吉猛修开跑车	光吉猛修开车	日本壮熊	本命盘	桑巴迪
+サンバランド	桑巴	桑巴乐园	仰卧起坐	佐藤	标准仰卧起坐	标准桑巴	面具男
+ザムザ	扎姆扎	赞歌	萨姆沙	阿萨姆
+シアトリカル・ケース	theatrical case	戏剧性事件	戏剧性案件	戏剧性案例	黑玫瑰3	case	tc	theatrical・case	侦探跳火车	砂金	言叶3
 シアワセうさぎ	幸福兔	幸福兔子
-シエルブルーマルシェ	Ciel Bleu Marche	天蓝市场	蓝色市场
-シカ色デイズ	鹿色时光
-シスターシスター	姐妹姐妹
-シックスプラン	六计划
-シャルル	charles	三力儿儿	夏尔	夏露露
+シエルブルーマルシェ	Ciel Bleu Marche	天蓝市场	蓝色市场	ciel bleu marché	dx白绯色	做饭	小厨娘	星星歌	眼镜妹	蓝天市场	青空市场	魔法食谱
+シカ色デイズ	鹿色时光	鹿乃子
+シスターシスター	姐妹姐妹	sister sister
+シックスプラン	六计划	6p	6plan	sixplan	第六计划	跳楼2
+シャルル	charles	三力儿儿	夏尔	夏露露	查尔斯	汁儿儿
 シュガーソングとビターステップ	糖歌	糖车
-シュガーホリック	糖瘾
-シリウスの輝きのように	シリウスの辉きのように	如天狼星般闪耀
-ジェヘナ	吉赫纳	杰赫纳
+シュガーホリック	糖瘾	sugarholic	周防	周防パトラ	重度甜食控
+シリウスの輝きのように	シリウスの辉きのように	如天狼星般闪耀	天狼星
+ジェヘナ	吉赫纳	杰赫纳	gehenna	地狱
 ジャガーノート	juggernaut
-ジャンキーナイトタウンオーケストラ	玛奇玛	瘾君子夜城乐团	瘾者之城
-ジレンマ	困境
-ジンギスカン	成吉思汗
-ジングルベル	jingle bell	圣诞歌	圣诞节	铃儿响叮当
-スイートマジック	sweet magic	甜甜魔法	甜蜜魔法
-スカーレット警察のゲットーパトロール24時	スカーレット警察のゲットーパトロール24时	猩红警察贫民区24小时巡逻	猩红警察贫民窟巡逻24小时
-スターリースカイ☆パレード	Starry Sky☆Parade	星光游行	星空☆游行
-スティールユー	偷走你
-ステップアンドライム	step and lime	步与韵	步调与韵律
-ストリーミングハート	流心
-スピカの天秤	希望泪2	角宿一的天平
-スリップフリップ	slipflip	大脸妹	滑翻	短发妹
-スロウダウナー	Slow downer	慢下来的人	慢速者
-スローアライズ	slow arise	slow rise	慢起
-スーパーシンメトリー	超对称性
+ジャンキーナイトタウンオーケストラ	玛奇玛	瘾君子夜城乐团	瘾者之城	junky night town orchestra	瘾者之夜	瘾者之夜城镇乐队	🤫
+ジレンマ	困境	dilemma	两难问题	异瞳	异色瞳	白葱	赤瞳	进退两难	邦邦邦
+ジンギスカン	成吉思汗	watame	wtm	角卷绵芽	金金金金金
+ジングルベル	jingle bell	圣诞歌	圣诞节	铃儿响叮当	dx圣诞	dx圣诞歌	dx鸡公煲	别急15	圣诞	圣诞树	标准圣诞	标圣诞	鸡公煲	🎄
+スイートマジック	sweet magic	甜甜魔法	甜蜜魔法	sm	sweetmagic	swmg	羽泽鸫
+スカーレット警察のゲットーパトロール24時	スカーレット警察のゲットーパトロール24时	猩红警察贫民区24小时巡逻	猩红警察贫民窟巡逻24小时	24时	24时警察	funky	东方警察	东方警察24时	斯卡蕾特	斯卡蕾特警察	斯卡雷特	斯卡雷特警察	琪露诺跳舞	蕾米出警	蟑螂跳舞	警察	警察24时	警察出警24小时	👮
+スターリースカイ☆パレード	Starry Sky☆Parade	星光游行	星空☆游行	starry sky parade	starryskyparade	女同5	星空游行	镜音音街
+スティールユー	偷走你	steelyou	钢铁般的你
+ステップアンドライム	step and lime	步与韵	步调与韵律	stepandlime	男同3	间谍过家家
+ストリーミングハート	流心	嘉然	嘉然比心
+スピカの天秤	希望泪2	角宿一的天平	交流电电棍	天平	天秤	心灵终结	绝望泪	这个需要你自己衡量	黑化希望泪
+スリップフリップ	slipflip	大脸妹	滑翻	短发妹	010	slip flip	不二家	大头妹	耳机女	耳机娘
+スロウダウナー	Slow downer	慢下来的人	慢速者	slowdowner	up down	↑↓	上下	慢下来
+スローアライズ	slow arise	slow rise	慢起	slowarise	慢排列	男同牵手	鲸鱼	鲸鱼情侣
+スーパーシンメトリー	超对称性	supersymmetry	对称性	超对称
 セイクリッド ルイン	圣域废墟	神圣废墟
 セイクリッド　ルイン	圣墟	圣灭	太鼓达人	肾虚
-セカイ	世界
+セカイ	世界	sekai
 セカイはまだ始まってすらいない	世界甚至尚未开始	世界甚至还未开始
-セガサターン起動音[H.][Remix]	セガサターン起动音[H.][Remix]	世嘉土星启动音	世嘉土星启动音[H.][混音]
-セツナトリップ	刹那之旅	刹那旅程	刹那旅行
-セハガガガンバッちゃう！！	世哈哈加油！！	世嘉硬件女孩
-ソリッド	坚实	大贫民
-ソーラン☆節	ソーラン☆节	索兰☆节	索兰节
-タカハせ！名人マン	光头16连	高桥名人	高桥吧！名人侠
-タケモトピアノCMソング	竹本钢琴CM歌	竹本钢琴广告歌
-タテマエと本心の大乱闘	タテマエと本心の大乱斗	表面与真心的大乱斗	面子与真心大乱斗
-ダブルラリアット	双重回旋	双重套索
-ダンシング☆サムライ	茄子先生	跳舞☆武士	跳舞武士
-ダンスロボットダンス	Dance Robot Dance	drd	舞动机器人之舞	跳舞机器人	跳舞机器人跳舞
-ダーリンダンス	达令舞
-チエルカ／エソテリカ	千工儿力	四个日本字杠五个日本字	奇尔卡/秘仪	宫下游
-チュルリラ・チュルリラ・ダッダッダ！	哒哒哒	啾哩啦·啾哩啦·哒哒哒！	啾噜哩啦	啾噜哩啦·啾噜哩啦·哒哒哒！
-チューリングの跡	チューリングの迹	图灵	图灵之迹	萨克斯
-チルノのパーフェクトさんすう教室	⑨	琪露诺的完美算数教室
+セガサターン起動音[H.][Remix]	セガサターン起动音[H.][Remix]	世嘉土星启动音	世嘉土星启动音[H.][混音]	mon3tr	sbga	ss	世嘉土星	启动音	土星	大b圈	夸脱	起动音	转圈接四押
+セツナトリップ	刹那之旅	刹那旅程	刹那旅行	dx刹那	dx刹那旅程	dx刹那旅行	刹那	标准刹那旅程	标刹那旅途
+セハガガガンバッちゃう！！	世哈哈加油！！	世嘉硬件女孩	SBGA	sega hard girls	世嘉硬件娘	好几个娘们
+ソリッド	坚实	大贫民	solid	大穷比	大穷逼	大穷鬼
+ソーラン☆節	ソーラン☆节	索兰☆节	索兰节	嗦拉面	拉面
+タカハせ！名人マン	光头16连	高桥名人	高桥吧！名人侠	たかはし	光头	名人	高桥	😉
+タケモトピアノCMソング	竹本钢琴CM歌	竹本钢琴广告歌	0120370009	cm	卖钢琴	原谅你了小鬼	原谅你了，小鬼！	广告	广告歌	机厅老板快乐歌	猫和老鼠开头	电话号码	竹本钢琴	超级变变变	钢琴广告
+タテマエと本心の大乱闘	タテマエと本心の大乱斗	表面与真心的大乱斗	面子与真心大乱斗	场面话与真心的大乱斗	大乱斗	本心	本心大乱斗
+ダブルラリアット	双重回旋	双重套索	转圈歌
+ダンシング☆サムライ	茄子先生	跳舞☆武士	跳舞武士	dancing samurai	富士山茄子	茄子哥	茄子山	茄子武士	辣椒	🍆🗻
+ダンスロボットダンス	Dance Robot Dance	drd	舞动机器人之舞	跳舞机器人	跳舞机器人跳舞	dancerobotdance	voidoll	↑↓	☝😑👇	小v	机器人舞	机器人跳舞	舞蹈机器人舞蹈	👆🏻😑👇🏻	👆👇
+ダーリンダンス	达令舞	darling dance
+チエルカ／エソテリカ	千工儿力	四个日本字杠五个日本字	奇尔卡/秘仪	宫下游	4/5	cerca/esoterica	チエルカ	企鹅卢卡	倒挂白毛	倒挂金钩	倒立消防员	呐	呐呐呐	呐呐呐呐	小绿人	工力工力	捏	探寻/秘密	探寻秘密	摔倒	擦玻璃	条形码	消防员	渊下宫	若叶睦	铅汞	黄鼠狼
+チュルリラ・チュルリラ・ダッダッダ！	哒哒哒	啾哩啦·啾哩啦·哒哒哒！	啾噜哩啦	啾噜哩啦·啾噜哩啦·哒哒哒！	ddd	jk结月缘	ダッダッダ	告密教室	告密老师	告状	告老师	啾噜哩啦·啾噜哩啦·哒哒哒	啾噜哩啦啾噜哩啦哒哒哒	打小报告	撒撒米糕大	暗杀教室	秋露里拉	结月缘杀人
+チューリングの跡	チューリングの迹	图灵	图灵之迹	萨克斯	credits2	dx信用	jazz for your soul	信用2	图灵之寄	图灵之跡	图灵轨迹	屠龙之技	灭火器	白法院吹萨克斯	螺号	迹	🎷	🎷🥚
+チルノのパーフェクトさんすう教室	⑨	琪露诺的完美算数教室	baka	⑨章算数	数学课堂	琪露诺	琪露诺的完美算术教室	算数教室	算术教室
 チルノのパーフェクトさんすう教室 ⑨周年バージョン	琪露诺完美算术教室⑨周年	琪露诺的完美算术教室⑨周年版
-チルノのパーフェクトさんすう教室　⑨周年バージョン	9周年教室	baka	⑨	九周年	笨蛋教室	算术教室
-ツギハギスタッカート	拼凑断奏
-ツクヨミステップ	月读	月读步	月读舞步
-ツムギボシ	纺星
-テオ	手绪
+チルノのパーフェクトさんすう教室　⑨周年バージョン	9周年教室	baka	⑨	九周年	笨蛋教室	算术教室	9	99	9周年	9周年算数教室	dxbaka	dx琪露诺	机厅几卡	琪露诺	算数教室
+ツギハギスタッカート	拼凑断奏	拼凑的断音	断音
+ツクヨミステップ	月读	月读步	月读舞步	嗒嗒啦嗒啦嗒嗒	女人拿水枪	戴帽女人滋水枪	斯普拉遁	水枪	水枪姐
+ツムギボシ	纺星	fes+主题曲	祝代主题曲
+テオ	手绪	teo	天才	将手	提欧
 テリトリーバトル	territory battle	小男娘	领土战争	领地战争
-テレキャスタービーボーイ	tbb	telecaster b-boy
-ディカディズム	decadism	年代主义	迪卡迪主义
-デコボコ体操第二	体操第二	凹凸体操第二
-デスパレイト	desperate	绝望
-デッドマンズバラッド	僵尸娘	死人之谣
-デッドレッドガールズ	dead red girls	死红女	死红少女
-デビル☆アイドル	恶魔☆偶像	恶魔偶像
+テレキャスタービーボーイ	tbb	telecaster b-boy	bboy	pop子	telecaster b boy	♡	合体	我爱你	比心	电吉他b男	电吉他说唱男孩	电视广播员蜜蜂男孩
+ディカディズム	decadism	年代主义	迪卡迪主义	皇帝小兵	皇帝排队
+デコボコ体操第二	体操第二	凹凸体操第二	体操	凹凸
+デスパレイト	desperate	绝望	666
+デッドマンズバラッド	僵尸娘	死人之谣	bpm300	deadman's ballad	亡者情歌	僵尸	僵尸初音	僵尸妹	呜哇呜哇	恋尸癖	散华礼弥	死人的叙事诗	死人的歌谣
+デッドレッドガールズ	dead red girls	死红女	死红少女	荒野大镖妹
+デビル☆アイドル	恶魔☆偶像	恶魔偶像	devil	devil idol	飞天小女警
 デビルじゃないもん	不是恶魔啦	才不是恶魔呢
-デリヘル呼んだら君が来た	叫了上门服务结果你来了	呼君来
-デンパラダイム	电波	电磁范式
-デーモンベット	恶魔赌注
-トノサマビーム	殿样光束	领主光束
-トラフィック・ジャム	traffic jam	交通堵塞	交通阻塞
-トランスダンスアナーキー	电舞无政府	迷幻舞动无政府
-トリアージ	triage	分诊	检伤分类
-トリドリ⇒モリモリ！Lovely fruits☆	鸟飞林跃！可爱水果☆	鸟鸣⇒茂盛！可爱水果☆
-トルコ行進曲 - オワタ＼(^o^)／	トルコ行进曲 - オワタ＼(^o^)／	土耳其进行曲	土耳其进行曲 - 完蛋＼(^o^)／
-トンデモワンダーズ	怪奇大冒险	离谱奇迹
-ドキドキDREAM!!!	心跳DREAM!!!	心跳梦想
-ドクハク	棺材	独白
-ドラゴンエネルギー	龙之能量	龙能量
-ドーナツホール	甜甜圈洞
-ド屑	废屑
-ナイトメア☆パーティーナイト	噩梦☆派对之夜
-ナイト・オブ・ナイツ	夜之骑士	夜骑
-ナイト・オブ・ナイツ (Cranky Remix)	cranky也要当夜骑	dx夜骑	夜之骑士 (Cranky混音)	夜骑2
-ナミダと流星	眼泪与流星	眼泪流星
-ナンセンス文学	拍手文学	无意义文学	荒诞文学
-ネガティブ進化論	negative进化论	ネガティブ进化论	消极进化论	负进化论	逊
-ネクロファンタジア～Arr.Demetori	Necro Fantasia	亡灵幻想曲～Arr.Demetori	死灵幻想曲
-ネコ日和。	猫天气	猫日和	猫日和。
-ネトゲ廃人シュプレヒコール	ネトゲ废人シュプレヒコール	网游废人	网游废人呐喊
-ネ！コ！	neko	猫	猫！
-ノイローゼ	神经病	神经症
-ノンブレス・オブリージュ	无呼吸义务	无息义务
+デリヘル呼んだら君が来た	叫了上门服务结果你来了	呼君来	卡姿兰大眼睛	叫了应召女郎结果来的是你	应召女郎	粉毛
+デンパラダイム	电波	电磁范式	denparadigm	传送带	木棍入侵正方形他家	电波范式
+デーモンベット	恶魔赌注	daemon bet	deamon bet	恶魔赌博	恶魔赌局	恶魔赌约	男同	男同3
+トノサマビーム	殿样光束	领主光束	乙姬2	匕一么	殿下大人光线
+トラフィック・ジャム	traffic jam	交通堵塞	交通阻塞	jam	trafficjam	堵车	煮儿果实	黄埔	黄歌	黄谱
+トランスダンスアナーキー	电舞无政府	迷幻舞动无政府	trance	trance dance anarchy	女同9	尬舞姐妹
+トリアージ	triage	分诊	检伤分类	碑谷	纪念碑谷
+トリドリ⇒モリモリ！Lovely fruits☆	鸟飞林跃！可爱水果☆	鸟鸣⇒茂盛！可爱水果☆	可爱水果	可爱的水果	合成大西瓜	喵呼	水果	水果摊子	水果歌	美亚
+トルコ行進曲 - オワタ＼(^o^)／	トルコ行进曲 - オワタ＼(^o^)／	土耳其进行曲	土耳其进行曲 - 完蛋＼(^o^)／	\（^o^)／	土耳其	🇹🇷
+トンデモワンダーズ	怪奇大冒险	离谱奇迹	不可思议的wonders	不可思议的奇迹
+ドキドキDREAM!!!	心跳DREAM!!!	心跳梦想	dokidoki	五对柰子
+ドクハク	棺材	独白	⚰️	卜夕八夕	极恶	枪叔	照相馆	黑人抬棺
+ドラゴンエネルギー	龙之能量	龙能量	dragon energy	hero	冰火人2	披萨歌	薛之谦
+ドーナツホール	甜甜圈洞	甜圈洞	甜甜圈	🍩
+ド屑	废屑	人渣	兰立忠	卜屑	大人渣	头屑	屑	渣滓	追追
+ナイトメア☆パーティーナイト	噩梦☆派对之夜	nightmare party night	nightmarepartynight	初音小摩尔	初音月下舞	华	华月	噩梦派对之夜	噩梦派对夜	小丑初音	月下初音	月初音	月球miku	華月
+ナイト・オブ・ナイツ	夜之骑士	夜骑	dx夜骑	dx标夜骑	night of knights	nok	std夜骑	st夜骑	原版夜骑	夜骑士	幻梦	标准夜骑	标夜骑	骑士之夜
+ナイト・オブ・ナイツ (Cranky Remix)	cranky也要当夜骑	dx夜骑	夜之骑士 (Cranky混音)	夜骑2	cranky夜骑	night of knights	nok	nok2	十六夜咲夜	咲夜	夜骑	夜骑remix	盗版夜骑
+ナミダと流星	眼泪与流星	眼泪流星	dx流星	晓代主题曲	标准流星	泪与流星	流星
+ナンセンス文学	拍手文学	无意义文学	荒诞文学	latata	o.o	废话文学	文学	海底谭文学
+ネガティブ進化論	negative进化论	ネガティブ进化论	消极进化论	负进化论	逊	negative	弟中之弟	弟中之弟进化论	比倒拇指的女孩	达尔文	进化论	👎	👎🏻
+ネクロファンタジア～Arr.Demetori	Necro Fantasia	亡灵幻想曲～Arr.Demetori	死灵幻想曲	arr	demetori	ネクロファンタジア	亡灵幻想曲	少女幻葬曲	紫妈弹吉他	老太婆弹吉他
+ネコ日和。	猫天气	猫日和	猫日和。	大臣日和	猫咪日和
+ネトゲ廃人シュプレヒコール	ネトゲ废人シュプレヒコール	网游废人	网游废人呐喊	废人	网游废人的呐喊	网络废人	网络废人的呐喊	😉
+ネ！コ！	neko	猫	猫！	nero	ne！ko！	zood	ネコ	咪咪	流浪猫之心	节粮猫	野良猫
+ノイローゼ	神经病	神经症	neurose	兔子魔术师	神经官能症	神经质	米津玄师
+ノンブレス・オブリージュ	无呼吸义务	无息义务	non-breath oblige	不要呼吸	喘不上来气	喘不上气	我喘不上气	我喘不上气儿	无呼吸	看见光
 ノーポイッ!	没有点！	点兔
-ハウリング	嚎叫
-ハジマリノピアノ	yyut	初始的钢琴	羽岛里诺钢琴
-ハッピーシンセサイザ	快乐合成器
-ハム太郎とっとこうた	哈姆太郎	哈姆太郎快快歌
-ハロ／ハワユ	Hello，how are you	hay	你好你吃了吗	哈罗/哈瓦尤
-ハート・ビート	heart·beat	心跳节拍
-ハードコア・シンドローム	hardcore	哈的扣	打架第二名	梅西哥拆机	硬核综合征
-バイオレンストリガー	暴力扳机	暴力拆机	暴力触发
-バカ通信	笨蛋通信
-バグ	Bug	虫
-バッド・ダンス・ホール	bdh	坏舞厅
+ハウリング	嚎叫	howling	yellow	黄	黄灵梦
+ハジマリノピアノ	yyut	初始的钢琴	羽岛里诺钢琴	哈吉玛丽弄钢琴	大灵通	最初的钢琴	钢琴
+ハッピーシンセサイザ	快乐合成器	dx快乐合成器	断手器
+ハム太郎とっとこうた	哈姆太郎	哈姆太郎快快歌	仓鼠	哈姆	墨鼠	小耗子	老鼠	鸭脖	鸭脖太郎	鼠	鼠抓板	鼠爹	鼠鼠	🐹
+ハロ／ハワユ	Hello，how are you	hay	你好你吃了吗	哈罗/哈瓦尤	hello	hello how are you	hello/howareyou	hello/HowDearYou	ハロ	你好	你好/你咋了	八口
+ハート・ビート	heart·beat	心跳节拍	heart beat	serina	心跳	心跳2	架子鼓
+ハードコア・シンドローム	hardcore	哈的扣	打架第二名	梅西哥拆机	硬核综合征	creeping	hardcore syndrome	tanoc全明星	友人对战	哈德口	哈皮和tpz开音趴	哈皮打交	打交	打交第一名	打胶	硬核	硬核综合症	罚站
+バイオレンストリガー	暴力扳机	暴力拆机	暴力触发	jerry	megumegu	危险扳机	扳机	暴力板机	杰瑞	陶大冲
+バカ通信	笨蛋通信	baka通信	八力通信	八力通讯	八嘎通信	泡通信	琪露诺通信	笨蛋通讯	通信
+バグ	Bug	虫	mfy3	八夕	故障	月狼鸟了没分	紫皮糖
+バッド・ダンス・ホール	bdh	坏舞厅	bad dance hall	团长	奥尔加	小孩哥	希望之花	糟糕透顶的舞厅
 バベル	巴别塔
-バラバラ〜仮初レインボーローズ〜	バラバラ〜假初レインボーローズ〜	散落~暂借彩虹玫瑰~	散落~虚幻彩虹玫瑰~
-バラライカ	亚拉那一卡	巴拉莱卡	空手道
-バレリーコ	瓦雷莉可	芭蕾舞者
+バラバラ〜仮初レインボーローズ〜	バラバラ〜假初レインボーローズ〜	散落~暂借彩虹玫瑰~	散落~虚幻彩虹玫瑰~	一起扒拉	二次元田一名	巴拉巴拉巴拉	椎名唯华	榴莲姐
+バラライカ	亚拉那一卡	巴拉莱卡	空手道	空手
+バレリーコ	瓦雷莉可	芭蕾舞者	照镜子	芭蕾
 バーチャルダム ネーション	虚拟大坝国度
-バーチャルダム　ネーション	virtualdam nation	虚拟赛车
-パズルリボン	拼图丝带	拼图缎带
+バーチャルダム　ネーション	virtualdam nation	虚拟赛车	vn	七块钱	印度人3	印度赛车	小汽车	月儿子2	爸日儿子	赛车	越南
+パズルリボン	拼图丝带	拼图缎带	puzzle ribbon	东云彰人	未知无心	游乐王子	红发男	蝴蝶结
 パラドクスイヴ	悖论伊芙	悖论夏娃
-パラボラ	体育生	抛物线
-パラマウント☆ショータイム！！	paramount show time	至高☆秀场！！	至高的表演时间	魔法兔子
-パンダヒーロー	panda hero	熊猫英雄
-パーフェクション	perfection	完美
-パーフェクト生命	完美生命
-ヒステリックナイトガール	歇斯底里夜女郎	歇斯底里的深夜女孩
-ヒトガタ	人型	人形	匕卜力夕
-ヒバナ	7810	七八十	匕八十	匕八卜	火花	狙击小日本	瞄准fufu
-ヒバリ	两个羽毛球	云雀	匕八刂
+パラボラ	体育生	抛物线	parabola	二次元科比	梅西	沉淀	球男	白毛体育生	篮球男孩	网球王子	蓝毛体育生
+パラマウント☆ショータイム！！	paramount show time	至高☆秀场！！	至高的表演时间	魔法兔子	paramount	paramount showtime	showtime	兔子	兔子魔术师	小兔子	瑞秋	霜星	魔术兔	魔术兔子
+パンダヒーロー	panda hero	熊猫英雄	会员制餐厅
+パーフェクション	perfection	完美	完美物质
+パーフェクト生命	完美生命	✌🏻😎✌🏻	生命
+ヒステリックナイトガール	歇斯底里夜女郎	歇斯底里的深夜女孩	啊啊啊啊！	夜晚歇斯底里女孩	歇斯底里	歇斯底里夜晚女孩	歇斯底里女孩	眼保健操	竭斯底里
+ヒトガタ	人型	人形	匕卜力夕	himehina	hitogata	一棵树两个人	东雪莲跳舞	管人跳舞
+ヒバナ	7810	七八十	匕八十	匕八卜	火花	狙击小日本	瞄准fufu	fufu遇刺	hibana	k杀	tsubaki	初音未来被爆头	初音爆头	大狙怼脸	大狙架miku	大狙架初音	爆头初音	狙击fufu	狙击初音	狙击初音未来	狙初音
+ヒバリ	两个羽毛球	云雀	匕八刂	hibari	俩个羽毛球	姬雏鸟	羽毛球
 ヒビカセ	匕匕力也	比力也	让其响彻
-ヒミツCULT	保安	秘密崇拜
-ビターチョコデコレーション	苦巧克力	苦巧克力装饰
-ビビデバ	比比迪巴
+ヒミツCULT	保安	秘密崇拜	cult	t+p的海底谭	吹月2	我们都很棒	教程曲	秘密信徒
+ビターチョコデコレーション	苦巧克力	苦巧克力装饰	米开朗基罗	苦巧	🍽️
+ビビデバ	比比迪巴	星彗闪耀	星街彗星
 ピポピポ -People People- feat. ななひら	哔啵哔啵 -人们人们- feat. 七平
-ピュグマリオンの咒文	皮格马利翁的咒语
-ピリオドサイン	休止符	句号
-ピーマンたべたら	吃了青椒的话	鼠鼠
-ファンタジーゾーン OPA-OPA! -GMT remix-	奇幻地带 OPA-OPA! -GMT混音版-	幻想地带 OPA-OPA! -GMT混音-
-フィクサー	fixer	修人	修理者
-フェイクフェイス・フェイルセイフ	假面·安全失效
-フォニイ	phony	伪物	虚伪
-フォルテシモBELL	Fortissimo BELL	最强音BELL	极强音BELL
-フタタビ	再会	再次
-フラグメンツ -T.V. maimai edit-	fragments	碎片 -T.V. maimai edit-	碎片 -电视版 maimai edit-
-フラジール	fragile	易碎品	脆弱
-フリィダム ロリィタ	嘘嘘	自由洛丽塔
-ブレインジャックシンドローム	利香	脑控综合征
-プナイプナイせんそう	punai	噗奈噗奈战争	噗奶噗奶
-プラネタリウム・レヴュー	天文馆·秀	天文馆评论
-プリズム△▽リズム	棱镜△▽节奏	棱镜△▽韵律
-ヘルシーエンド	maimai你摸	健康结局
-ベノム	venom	毒液	猛毒
-ベースラインやってる？笑	bassline	妹妹恰个v	弹贝斯吗？笑	洽个V
-ホシシズク	fes主题曲	三小只2	星滴	星雫
-ボッカデラベリタ	博卡德拉维里塔	波卡德拉真理
-ポケットからぬりつぶせ！	从口袋涂满！	把它从你的口袋里掏出来！
-ポッピンキャンディ☆フィーバー！	candy	爆米花糖狂热！	糖果
-ポップミュージックは僕のもの	popmusic	ポップミュージックは仆のもの	流行音乐是我的	男同	男童歌
+ピュグマリオンの咒文	皮格马利翁的咒语	咒文	大黑塔	小魔女咒文	皮格马利翁的咒文	魔法小萝莉	黑塔
+ピリオドサイン	休止符	句号	period sign	ps	周期符号	枫原万叶	终点2
+ピーマンたべたら	吃了青椒的话	鼠鼠	cyber	柿子椒	青椒	青椒歌	🫑
+ファンタジーゾーン OPA-OPA! -GMT remix-	奇幻地带 OPA-OPA! -GMT混音版-	幻想地带 OPA-OPA! -GMT混音-	opa	三道理sayya	土著怪脸	幻想空间	申日月	🈸🌞🌝
+フィクサー	fixer	修人	修理者	牛头人喝酒	黑山羊	黑山羊吃席	黑暗海底谭
+フェイクフェイス・フェイルセイフ	假面·安全失效	fakefacefailsafe	fffs
+フォニイ	phony	伪物	虚伪	7才二亻	佛尼	凤梨	噗泥	奶龙跳舞	扶你
+フォルテシモBELL	Fortissimo BELL	最强音BELL	极强音BELL	bell	emu	千早爱音	粉毛弹吉他
+フタタビ	再会	再次	再度	凤笑梦
+フラグメンツ -T.V. maimai edit-	fragments	碎片 -T.V. maimai edit-	碎片 -电视版 maimai edit-	maimai edit	tv	东方穿心莲	碎片	风见幽香
+フラジール	fragile	易碎品	脆弱	七海娜娜米	易碎
+フリィダム ロリィタ	嘘嘘	自由洛丽塔	喂美少女嘘嘘	喂饭	洛丽塔	自由的洛丽塔
+ブレインジャックシンドローム	利香	脑控综合征	brainjack syndrome	内内内	吉他	墨镜女	墨镜女歌手	夜空梅露	头脑风暴	头脑风暴综合症	拽女唱歌	杰克逊综合症	话筒姐
+プナイプナイせんそう	punai	噗奈噗奈战争	噗奶噗奶	pnpn	punaipunai	噗奶	布乃布乃万岁	扑领姨
+プラネタリウム・レヴュー	天文馆·秀	天文馆评论	银河座
+プリズム△▽リズム	棱镜△▽节奏	棱镜△▽韵律	棱镜节奏
+ヘルシーエンド	maimai你摸	健康结局	healthy end	诈尸曲
+ベノム	venom	毒液	猛毒	咩	达咩	🙅
+ベースラインやってる？笑	bassline	妹妹恰个v	弹贝斯吗？笑	洽个V	lol	nanahira	什么什么笑	变态萝莉	女流氓	女痴汉	妹妹v50	学妹恰个v	痴女nanahira	笑	舞时	颜文字
+ホシシズク	fes主题曲	三小只2	星滴	星雫	三小只过节	星雨	繁星点点
+ボッカデラベリタ	博卡德拉维里塔	波卡德拉真理	真理之口
+ポケットからぬりつぶせ！	从口袋涂满！	把它从你的口袋里掏出来！	三小只	口袋涂鸦
+ポッピンキャンディ☆フィーバー！	candy	爆米花糖狂热！	糖果	poppin candy fever	poppin' candy fever	八千块钱	叭叭叭	女同3	怨！	流行糖果发烧了	流行糖果热
+ポップミュージックは僕のもの	popmusic	ポップミュージックは仆のもの	流行音乐是我的	男同	男童歌	南通	我徒弟呢	星星蛋白	流行音乐是我的东西	照镜子	男同歌	超市里莎莎	镜子
 マツケンサンバⅡ	松健桑巴Ⅱ
-マツヨイナイトバグ	待宵的萤火虫	松夜虫	绿毛虫
-マトリョシカ	俄罗斯套娃
-マネマネサイコトロピック	模仿模仿精神热带	金钱金钱心理热带
-マリアをはげませ	为玛丽亚加油	激励玛利亚
-マーシャル・マキシマイザー	核事故	马歇尔最大化器	马歇尔最大化者
-ミラクルポップ☆アドベンチャー!!!!!	奇迹流行☆冒险	奇迹流行☆冒险!!!!!
-ミラクル・ショッピング	奇迹购物
-ミルキースター・シューティングスター	Milky Star・Shooting Star	银河之星·流星	银河流星
+マツヨイナイトバグ	待宵的萤火虫	松夜虫	绿毛虫	nightbug	东方绿毛虫	绿头发	绿毛龟	绿色夜光虫	绿色女人	绿色苍蝇	苍蝇妹	莉格露	萤火虫	蠢虫	阿氯
+マトリョシカ	俄罗斯套娃	套娃	😋🤗
+マネマネサイコトロピック	模仿模仿精神热带	金钱金钱心理热带	manemane	manemane的精神回归	两人玩手机	二重身	分身	女同11	模仿模仿	模仿模仿psychotropic	模仿模仿的精神回归	精神回归
+マリアをはげませ	为玛丽亚加油	激励玛利亚	玛利亚
+マーシャル・マキシマイザー	核事故	马歇尔最大化器	马歇尔最大化者	marshall maximizer	maximizer	mm	可不听歌	可不戴耳机	最大化	最大化者	马修麦泽	马歇尔
+ミラクルポップ☆アドベンチャー!!!!!	奇迹流行☆冒险	奇迹流行☆冒险!!!!!	大奈子芙宁娜	大奶子芙宁娜	大奶芙宁娜	巨乳芙宁娜	巨如芙宁娜	炫彩芙宁娜	芙宁娜高潮	芙宁娜高超
+ミラクル・ショッピング	奇迹购物	miracle shopping	qq	qq企鹅	乱中取胜	企鹅超市	堂吉诃德	神奇阿呦	购物
+ミルキースター・シューティングスター	Milky Star・Shooting Star	银河之星·流星	银河流星	milky star	uni+主题曲	女同12	星代主题曲	牛奶4	牛奶流星	银河星
 メイトなやつら（FEAT. 天開司, 佐藤ホームズ, あっくん大魔王 & 歌衣メイカ）	メイトなやつら（FEAT. 天开司, 佐藤ホームズ, あっくん大魔王 & 歌衣メイカ）	伙伴们	伙伴们（FEAT. 天开司, 佐藤福尔摩斯, 阿君大魔王 & 歌衣梅卡）
-メグメグ☆ファイアーエンドレスナイト	Megu Megu☆无尽火夜	MeguMegu☆火焰无尽夜	megumegu☆fire endless night
-メズマライザー	催眠者
-メランコリック	忧郁症	忧郁的心情
-メルティランドナイトメア	melty land nightmare	mln	春卷饭	梦魇	融化乐园噩梦
-メルト	melt	融化
-モ°ルモ°ル	摩尔摩尔	毛儿毛儿
-モ°ルモ°ル (MZK Skippin' Remix)	摩尔摩尔 (MZK Skippin' Remix)	魔ル魔ル (MZK Skippin' Remix)
-モエチャッカファイア	萌茶卡火焰
-モザイクロール	绿毛	马赛克卷
+メグメグ☆ファイアーエンドレスナイト	Megu Megu☆无尽火夜	MeguMegu☆火焰无尽夜	megumegu☆fire endless night	megu	火柴人大战
+メズマライザー	催眠者	催眠术
+メランコリック	忧郁症	忧郁的心情	melancholic
+メルティランドナイトメア	melty land nightmare	mln	春卷饭	梦魇	融化乐园噩梦	melty	meltyland	原子能酸菜	可爱歌	小粉
+メルト	melt	融化	x儿卜	叉儿卜	熔化	简笔画
+モ°ルモ°ル	摩尔摩尔	毛儿毛儿	morumoru	么么	毛儿	毛肚儿毛肚儿	蹦蹦炸弹
+モ°ルモ°ル (MZK Skippin' Remix)	摩尔摩尔 (MZK Skippin' Remix)	魔ル魔ル (MZK Skippin' Remix)	mkz	晓山瑞希	毛儿毛儿2	毛儿毛儿mzk	毛儿毛儿remix
+モエチャッカファイア	萌茶卡火焰	绝区零	艾莲	艾莲乔	萌萌点火	鲨鱼娘
+モザイクロール	绿毛	马赛克卷	dx马赛克卷	mosaic roll	mozaik role	标准马赛克卷	绿毛永雏塔菲
 モンスターカミング	怪物来临
-モンダイナイトリッパー！	没问题	问题之夜旅行者！
+モンダイナイトリッパー！	没问题	问题之夜旅行者！	tripper	モンダイナイトリッパー	兔兔	名取纱那	指南针	旅行者	没问题tripper	没问题旅行家	没问题！Tripper！	萌呆奶
 ヤミツキ	沉迷	痴迷
-ユビキリ	拉勾勾	拉钩
-ユメヒバナ	梦7810	梦七八十	梦火花
-ヨミビトシラズ	东雪莲	冬雪莲	原批大战罕见	咏人不详	读人不知
-ライアーダンサー	谎言舞者
-ラグトレイン	延误列车	迟滞列车
-ラットが死んだnew words	老鼠死了new words	鼠之死
-ラビットホール	兔子洞	兔洞
-ラブって♡ジュエリー♪えんじぇる☆ブレイク！！	恋爱♡珠宝♪天使☆爆裂！！	爱恋♡宝石♪天使☆爆裂！！
-ラブチーノ	lovecino	爱情咖啡	爱情奇诺
-ラブリー☆えんじぇる!!	可爱☆天使!!	可爱天使
+ユビキリ	拉勾勾	拉钩	xql	勾手指	勾指起誓	拉勾	舞萌爱情故事
+ユメヒバナ	梦7810	梦七八十	梦火花	掉毛小哥哥	梦之火花
+ヨミビトシラズ	东雪莲	冬雪莲	原批大战罕见	咏人不详	读人不知	东雪莲打伞	佚名	作者不详	咏人不知	哇嘎得路哟	我不知道	東雪莲	東雪蓮	罕见	蓝屏
+ライアーダンサー	谎言舞者	ld	liardancer	哦多累	蓝牙	蓝牙单色	蓝牙舞者
+ラグトレイン	延误列车	迟滞列车	15列车	lag train	lagtrain	列车	少女终末旅行	延迟列车	打地鼠	烟雾列车	电车迟到
+ラットが死んだnew words	老鼠死了new words	鼠之死	死	疫医	白老鼠死掉了	硕鼠死亡	硕鼠死亡newwords	老鼠死掉了	老鼠死掉了newwords	芝麻街	鼠鼠似了
+ラビットホール	兔子洞	兔洞	rabbithole	初音未来下海
+ラブって♡ジュエリー♪えんじぇる☆ブレイク！！	恋爱♡珠宝♪天使☆爆裂！！	爱恋♡宝石♪天使☆爆裂！！	刺猬	快盗天使break
+ラブチーノ	lovecino	爱情咖啡	爱情奇诺	love	love cino
+ラブリー☆えんじぇる!!	可爱☆天使!!	可爱天使	女同14
 ラブ・ドラマティック feat. 伊原六花	Love Dramatic	哦辣妹迷死他哦迷死他
-ラヴィ	拉维
-リアライズ	实现	觉醒
-リスペク風神	リスペク风神	尊敬风神
-リッジでリッジでGO!GO!GO! -GMT mashup-	山脊山脊GO!GO!GO! -GMT串烧-	电车gogogo
-リフヴェイン	裂痕之雨
-リモコン	遥控器
-リリリリ★バーニングナイト	莉莉燃烧之夜	莉莉莉莉★燃烧之夜
-リンカーネイション	轮回转生
-ルカルカ★ナイトフィーバー	luka	儿力儿力	露卡露卡★夜狂热
-レッツゴー!陰陽師	レッツゴー!阴阳师	出发！阴阳师	阴阳师出击
-レーイレーイ	ray ray	rayray	来一来	雷伊雷伊
-ロウワー	lower	下层	低层
-ロキ	roki	ruaki	口≠	口丰	洛基
-ロストワンの号哭	lost one的号哭	失去1的号哭	失落之人的号哭
-ロストワードクロニカル	Lost word chronical	东方归言录编年史	失语编年史
-ロミオとシンデレラ	口三才	灰姑娘	罗密欧	罗密欧与灰姑娘	罗密欧与辛德瑞拉
-ロータスイーター	食莲者
-ローリンガール	rolling girl	滚动的女孩	滚女	翻滚少女
-ロールプレイングゲーム	rpg	火箭筒	角色扮演游戏
-ワンダーシャッフェンの法則	ワンダーシャッフェンの法则	创造奇迹的法则	奇迹创造法则	萝莉法则
+ラヴィ	拉维	lavie	拉比	拉薇	纳里纳里
+リアライズ	实现	觉醒	realize
+リスペク風神	リスペク风神	尊敬风神	dx风神	respec fujin	respect fujin	respect风神	东方电车	东方风神	东方风神录	东风风神	墨晨	小风神	瑞思拜风神	车万风神	风神	风神2
+リッジでリッジでGO!GO!GO! -GMT mashup-	山脊山脊GO!GO!GO! -GMT串烧-	电车gogogo	go学长	世嘉mashup	山脊赛车×电车go	电车	电车go	绝赞电车	键盘电车
+リフヴェイン	裂痕之雨	refvain	分身	青栗鼠
+リモコン	遥控器	switch	双子转转转	思维驰学习机
+リリリリ★バーニングナイト	莉莉燃烧之夜	莉莉莉莉★燃烧之夜	lily	lilylily	lilylilyburningnight	lilylily★burningnight	力力	美女躺着	酒吧	酒吧跳舞
+リンカーネイション	轮回转生	lexburner	reincarnation	灵魂转生	烈火战神	铃魂转生
+ルカルカ★ナイトフィーバー	luka	儿力儿力	露卡露卡★夜狂热	lukalukanightfever	rukaruka	和谐你全家	夜里发烧	河蟹你全家	绿坝娘	露卡露卡
+レッツゴー!陰陽師	レッツゴー!阴阳师	出发！阴阳师	阴阳师出击	let'go!阴阳师	仪式魔法	恶灵退散！恶灵退散！恶灵退散！	挑眉	林正英	超级蓝绿	阴阳师
+レーイレーイ	ray ray	rayray	来一来	雷伊雷伊	三色幽灵	幽灵	抓鬼	抓鬼星野爱	捉鬼	星野爱	胡桃	荷珀
+ロウワー	lower	下层	低层	mzk2	mzk二箱	堕落眼界	犹大	蛇女
+ロキ	roki	ruaki	口≠	口丰	洛基	㕩	口干	嘴巴吃烤串
+ロストワンの号哭	lost one的号哭	失去1的号哭	失落之人的号哭	kappa	lost one 的号哭	号哭	哭哭	没有1我要哭了	鹅哭
+ロストワードクロニカル	Lost word chronical	东方归言录编年史	失语编年史	lost word chronicle	lostword	lw	东方号哭	东方归言录	归言录
+ロミオとシンデレラ	口三才	灰姑娘	罗密欧	罗密欧与灰姑娘	罗密欧与辛德瑞拉	罗密欧与仙度瑞拉	罗密欧和辛德瑞拉	罗密欧辛德瑞拉	辛德瑞拉
+ロータスイーター	食莲者	lotus eater	浑噩度日之人	石楠花	莲花食者
+ローリンガール	rolling girl	滚动的女孩	滚女	翻滚少女	roiling giri	头皮屑
+ロールプレイングゲーム	rpg	火箭筒	角色扮演游戏	mafumafu	日屁股
+ワンダーシャッフェンの法則	ワンダーシャッフェンの法则	创造奇迹的法则	奇迹创造法则	萝莉法则	六翅一桶	奇迹法则	小扎萝莉	小百合咲	小萝莉2	小萝莉法则	法则	炼铜法则	百合咲	百合咲2	萝莉棋法则
 ワンダーラスト	luka	wander last	wanderlast
-ワードワードワード	word word word	词词词
-ワールズエンド・ダンスホール	世末舞厅	世界尽头舞厅	末世舞厅
-ワールドワイドワンダー	世界奇迹
+ワードワードワード	word word word	词词词	dx海底潭	dx海底谭	hudelou	touch海底潭	touch海底谭	www	二位一体	哇多哇多哇多	旋转胡德路	豪华海底潭
+ワールズエンド・ダンスホール	世末舞厅	世界尽头舞厅	末世舞厅	世终舞厅	双关门	漠河舞厅	舞厅
+ワールドワイドワンダー	世界奇迹	checkmate	世界漫游
 ワーワーワールド	哇哇世界
-ヱデン	伊甸园
-ヴァンパイア	吸血鬼
-ヴィラン	恶徒	恶棍
-一か罰	一か罚	一刀罚	一力罚	一或罚
-三妖精SAY YA!!!	三妖精说呀！！！	我们三
-下克上々	下克上上
-不思議の国のクリスマス	不可思议	不可思议国度的圣诞节	不思议の国のクリスマス
-不機嫌なスリーカード	不悦的三张牌	不机嫌なスリーカード
-不毛！	不毛
-乙女解剖	处女解剖	少女解剖
-二息歩行	二息步行	儿媳不行
-人マニア	人狂热	人类狂热
-人生リセットボタン	remake	人生reset button	人生重启键	人生重置	人生重置按钮	人生重置键
-人里に下ったアタイがいつの間にか社畜になっていた件	NO NO working	下凡后我竟成了社畜	下凡成社畜	人里に下ったアタイがいつの间にか社畜になっていた件
-人間が大好きなこわれた妖怪の唄	人间が大好きなこわれた妖怪の呗	深爱人类之破碎妖怪的歌	热爱人类之破碎妖怪的歌
-今、誰が為のかがり火へ	今、谁が为のかがり火へ	今为谁燃篝火	此刻，为谁燃起篝火
-偉大なる悪魔は実は大天使パトラちゃん様なのだ！	伟大なる恶魔は实は大天使パトラちゃん样なのだ！	伟大恶魔其实是天使帕特拉大人！
-僕の和風本当上手	仆の和风本当上手	我的和风真拿手	我的和风真的很牛逼
-僕は空気が嫁ない	仆は空气が嫁ない	我不要嫁给空气	我读不懂空气
-儚きもの人間	儚きもの人间	少女炼狱	梦人间	虚幻之人
-光線チューニング	光线turning	光线チューニング	光线调谐
-全人類ノ非想天則	全人类ノ非想天则	全人类的非想天则	全人类非想天则	全人类非想天則	绯想天
-全力ハッピーライフ	全力快乐生活
-六兆年と一夜物語	六兆年と一夜物语	六兆年与一夜物语	希腊奶
-共感覚おばけ	共感怪兽	共感觉おばけ	联觉怪
+ヱデン	伊甸园	eden	エデン	伊甸	阿罗娜
+ヴァンパイア	吸血鬼	miku口罩	nichan	vampire	做核酸	口罩妹	核酸检测	棒棒鸭	玩牌儿	玩牌呀	袁绍
+ヴィラン	恶徒	恶棍	villain	villan	反派	反派角色	恶者	碧浪	糜烂
+一か罰	一か罚	一刀罚	一力罚	一或罚	一罚	一罰	只有我最摇摆
+三妖精SAY YA!!!	三妖精说呀！！！	我们三	say ya	saya	tfgirls	三妖精	三妖精塞牙	三小只	三月精	三笨蛋	三铸币开大	萨莉亚
+下克上々	下克上上	0克1	下克上	少女炼狱2	正邪	田忌赛马
+不思議の国のクリスマス	不可思议	不可思议国度的圣诞节	不思议の国のクリスマス	不思议	不思议之国	不思议国	反海底谭	圣诞节	秘封俱乐部
+不機嫌なスリーカード	不悦的三张牌	不机嫌なスリーカード	不机嫌	心烦意乱three card	欢乐斗地主
+不毛！	不毛	木毛
+乙女解剖	处女解剖	少女解剖	乙女	乙女姐婆	紫璃	解剖
+二息歩行	二息步行	儿媳不行	citywalk	二息电摇	半块钱
+人マニア	人狂热	人类狂热	人狂	人狂热症	人狂热者
+人生リセットボタン	remake	人生reset button	人生重启键	人生重置	人生重置按钮	人生重置键	dame	人生	人生复位按钮	人生重启	人生重启按钮	人生重开	人生重来键	重开按钮
+人里に下ったアタイがいつの間にか社畜になっていた件	NO NO working	下凡后我竟成了社畜	下凡成社畜	人里に下ったアタイがいつの间にか社畜になっていた件	996	人里	人里社畜	社畜
+人間が大好きなこわれた妖怪の唄	人间が大好きなこわれた妖怪の呗	深爱人类之破碎妖怪的歌	热爱人类之破碎妖怪的歌	人间大好
+今、誰が為のかがり火へ	今、谁が为のかがり火へ	今为谁燃篝火	此刻，为谁燃起篝火	今	今谁	今谁为	今谁为火	现在，为了谁的篝火
+偉大なる悪魔は実は大天使パトラちゃん様なのだ！	伟大なる恶魔は实は大天使パトラちゃん样なのだ！	伟大恶魔其实是天使帕特拉大人！	一半恶魔一半天使	三只母牛	伟大恶魔	伟大恶魔大天使	伟大恶魔天使	呜喵呜喵	周防	周防パトラ	大天使	恶魔大天使	恶魔天使	母牛	母牛母牛	迷你世界
+僕の和風本当上手	仆の和风本当上手	我的和风真拿手	我的和风真的很牛逼	bokuno和风本当上手	上天	上手	僕の日本语本当上手	和风	和风本当上手	唢呐	我的和风非常厉害	本当上手
+僕は空気が嫁ない	仆は空气が嫁ない	我不要嫁给空气	我读不懂空气	嫁给空气	我不会察言观色	我不嫁给空气	我要嫁给空气	空气	空气嫁
+儚きもの人間	儚きもの人间	少女炼狱	梦人间	虚幻之人	人间
+光線チューニング	光线turning	光线チューニング	光线调谐	中二节奏	光线	🖐🏻️😐🖐🏻️
+全人類ノ非想天則	全人类ノ非想天则	全人类的非想天则	全人类非想天则	全人类非想天則	绯想天	全人类	全人类的飞上天	则	超级机器人	非想天则	非想天則	高达
+全力ハッピーライフ	全力快乐生活	兔女郎鱼尾	全力	全力happylife	全力哈皮	全力幸福	全力幸福生活	吉他女神2	铃仙	🐰👋
+六兆年と一夜物語	六兆年と一夜物语	六兆年与一夜物语	希腊奶	6000000000000年	6m	dx六兆年	dx希腊奶	六兆年	六兆年零一夜物语	安慕希	标六兆年
+共感覚おばけ	共感怪兽	共感觉おばけ	联觉怪	共感怪物	共感觉	共感觉怪物
 共鳴	共鸣
-円舞曲、君に	圆舞曲、君に	圆舞曲与你	圆舞曲，献给你
+円舞曲、君に	圆舞曲、君に	圆舞曲与你	圆舞曲，献给你	圆舞曲	舞曲
 冬のこもりうた	冬之摇篮曲	冬天低沉的歌
-分からない	不明白	吾伐晓得	哇卡拉奶	我不到啊	我不知道	我不道啊
-分解収束テイル	分解收敛之尾	分解收敛尾	分解收束テイル
-初音ミクの消失	初音未来的消失
-初音ミクの激唱	初音未来的激唱	机场
-初音天地開闢神話	初音天地开辟神话	初音开天辟地神话	盘古
-前衛的Landscape	亲爱滴小妹妹	前卫的Landscape	前卫风景	给我玩舞萌DX
+分からない	不明白	吾伐晓得	哇卡拉奶	我不到啊	我不知道	我不道啊	不知道	优质解答	发生什么事了	哇嘎啦乃	哇嘎拉奶	我哪知道	我怎么知道	暂时不能给你明确的答复	这	😵
+分解収束テイル	分解收敛之尾	分解收敛尾	分解收束テイル	分解收束
+初音ミクの消失	初音未来的消失	dx消失	初音没有来	初音没来	标准消失	标消失	消失	绿南十字	誓死守护公主殿下
+初音ミクの激唱	初音未来的激唱	机场	大葱天使	姬昌	激唱	鸡场	🐔🎤
+初音天地開闢神話	初音天地开辟神话	初音开天辟地神话	盘古	初音开天辟地	初音未来开天辟地	初音未来开辟神话	初音未来日天日地	初音未来毁天灭地	初音毁天灭地神话	天地开辟	开天辟地	开辟	开辟天地	开辟神话	毁天灭地	消失2	盘古开天辟地	盘古未来	神话
+前衛的Landscape	亲爱滴小妹妹	前卫的Landscape	前卫风景	给我玩舞萌DX	landepen	landscape	前卫	前卫的landepen	前卫的大都市	提纳里	阿努比斯
 剣を抜け！GCCX MAX	剑を拔け！GCCX MAX
-勦滅	剿灭	勦灭
-単一指向性オーバーブルーム	单一指向性overbloom	单一指向性オーバーブルーム	单指向性过度绽放
+勦滅	剿灭	勦灭	动减	勤减	明日方舟	苍蝇
+単一指向性オーバーブルーム	单一指向性overbloom	单一指向性オーバーブルーム	单指向性过度绽放	单一	单一手癖性	单一指向性	单向性	大额头	开花
 厨病激発ボーイ	厨病激发ボーイ	厨病激发男孩
 右に曲ガール	右转女孩
-吉原ラメント	吉原哀歌
+吉原ラメント	吉原哀歌	teto	千织	吉原	吉原怨妇	吉原拉面	吉原泼妇	清远鸡	留尾哀歌
 名探偵連続殺人事件	名侦探	名侦探连续杀人事件	名探侦联续杀人事件
 君の知らない物語	你不知道的故事	君の知らない物语	君知	君知物语
 吾輩よ猫であれ	吾辈よ猫であれ
-命に嫌われている	命嫌	嫌命长	被生命厌恶着	被生活讨厌
-命ばっかり	全是命	只为生命	命没	尽是生命
-咲キ誇レ常世ノ華	咲キ夸レ常世ノ华	常世之华	常世之花	常世华
-噛み係	96猫	咬人担当	咬系	啮み系	牙线	齿系
-四月の雨	四月的雨	四月雨
-四次元跳躍機関	四次元跳跃机关
-回る空うさぎ	回旋空兔	旋转的天空兔
-囲い無き世は一期の月影	围い无き世は一期の月影	无界世一期月影	无界世如一期月影
-地上の戦士	地上の战士	地上战士	地上的战士
+命に嫌われている	命嫌	嫌命长	被生命厌恶着	被生活讨厌	嫌命短	核客男神	被生命厌恶	被生命所厌恶	被生命所厌恶着	超羽天狼星
+命ばっかり	全是命	只为生命	命没	尽是生命	只有命	命	沙发太	蓝色男人坐沙发
+咲キ誇レ常世ノ華	咲キ夸レ常世ノ华	常世之华	常世之花	常世华	咲華	常世	永远盛开在世上的灿烂花
+噛み係	96猫	咬人担当	咬系	啮み系	牙线	齿系	啮	啮系	噛係	大教堂	神灵附体
+四月の雨	四月的雨	四月雨	114514月的臭雨	konmai	☂️	下北泽的雨	不要急挑战	伞	你先别急	别急	别急1	四月的shi	四月的别急	四月的史	四月的屎	四月的急	四月的星星	四月的粑粑	四月的粪	四月的💩	四月答辩	我为你撑一把伞	键盘歌	雨姐
+四次元跳躍機関	四次元跳跃机关	冰风	四次元	大小姐	机关	跳楼机	跳跃机关
+回る空うさぎ	回旋空兔	旋转的天空兔	回空	月下钢琴师	月兔	月兔回旋于空中
+囲い無き世は一期の月影	围い无き世は一期の月影	无界世一期月影	无界世如一期月影	妹红玉足	月影
+地上の戦士	地上の战士	地上战士	地上的战士	地上	樱花大战5	譜面-100号
 地獄	地狱
-壱雫空	一滴空	壹雫空
+壱雫空	一滴空	壹雫空	mygo	一滴雨	一雫空	五把伞	匕下工	卖狗	咕咕嘎嘎	士冖匕雨下空	壳卡空	它下空	木柜子	粉色奶龙	老下空	那啥空	高松灯	🐧
 夏祭り	Our Wrenally	夏祭
 夜に駆ける	夜に驱ける	夜驱
-夜咄ディセイブ	kano角色歌	夜咄	夜谈欺骗
-夜明けまであと３秒	夜明3秒	夜明三秒	失明前三秒	距黎明还有3秒
-夢現妄想世界	梦现妄想世界
-夢花火	乙姬角色歌	梦花火
-大輪の魂 (feat. AO, 司芭扶)	大轮の魂 (feat. AO, 司芭扶)	大轮之魂
-天ノ弱	天之弱	天弱
-天使の翼。	天使之翼	天使之翼。
+夜咄ディセイブ	kano角色歌	夜咄	夜谈欺骗	夜出	夜咄deceive
+夜明けまであと３秒	夜明3秒	夜明三秒	失明前三秒	距黎明还有3秒	3s	3秒	三秒	夜明	天亮的前三秒	距离黎明还有三秒	黎明的前三秒
+夢現妄想世界	梦现妄想世界	梦限大
+夢花火	乙姬角色歌	梦花火	u咩哈那比	马栏山	麻辣蒜
+大輪の魂 (feat. AO, 司芭扶)	大轮の魂 (feat. AO, 司芭扶)	大轮之魂	东方海底谭	元梦之星	大海底谭	大轮	大轮的魂	大轮魂
+天ノ弱	天之弱	天弱	dx天之弱	dx天弱	标准天之弱	若叶睦
+天使の翼。	天使之翼	天使之翼。	天使的翅膀
 天使光輪	天使光轮
-天国と地獄	天国と地狱	天国地狱	天堂与地狱
-天国と地獄 -言ノ葉リンネ-	天国と地狱 -言ノ叶リンネ-	天国与地狱 -言叶轮回-	天国地狱
-天火明命	天火
-天狗の落とし文 feat. ｙｔｒ	ytr	天狗	天狗落书 feat. ytr	犹太人
+天国と地獄	天国と地狱	天国地狱	天堂与地狱	为你而生	天国与地狱	康康舞曲	绝赞128	菠菜进行曲
+天国と地獄 -言ノ葉リンネ-	天国と地狱 -言ノ叶リンネ-	天国与地狱 -言叶轮回-	天国地狱	天国与地狱	言之叶轮回
+天火明命	天火	天火没命	舔会妹妹
+天狗の落とし文 feat. ｙｔｒ	ytr	天狗	天狗落书 feat. ytr	犹太人	天狗の落とし文	天狗之落	天狗的匿名信	天狗的无名文书	天狗落	天狗落文
 天蓋	天盖
-太陽系デスコ	太阳系disco	太阳系デスコ	太阳系迪斯科
-失敗作少女	失败作少女
-奏者はただ背中と提琴で語るのみ	奏者はただ背中と提琴で语るのみ	奏者只以背影与小提琴诉说	演奏者仅以背影与小提琴诉说
-妄想感傷代償連盟	妄想感伤代偿联盟	盲肠肝脏大肠年龄
-妖精村の月誕祭 ～Lunate Elf	妖精村の月诞祭 ～Lunate Elf	妖精村月诞祭	妖精村月诞祭～月精灵
-宛城、炎上！！	宛城炎上	宛城，火攻！！
-宵の鳥	夜鸟	宵の鸟	宵鸟
-宿星審判	宿星审判
-宿題が終わらないっ！	作业做不完！	宿题が终わらないっ！	触手调教
-寝起きヤシの木	刚醒的椰树	起床椰子树
-封焔の135秒	封焰135	封焰の135秒	封焰幺三五	封焰的135秒
-少女幻葬戦慄曲 ～ Necro Fantasia	少女幻葬战栗曲 ～ Necro Fantasia	死灵幻想曲
-居並ぶ穀物と溜息まじりの運送屋	居并ぶ谷物と溜息まじりの运送屋	排列的谷物与叹息的运输屋	木雕2	木雕二	老汉拉车	老汉推车	谷物运送屋
-届かない花束	届不到	届花束	无法传递的花束	未送达的花束
-幸せになれる隠しコマンドがあるらしい	似乎有着能够变得幸福的隐藏指令	幸せになれる隐しコマンドがあるらしい	幸福隐藏指令	幸隐	性瘾	😄🔫
-幻想に咲いた花	幻想中绽放的花	幻想绽放之花
-幻想のサテライト	幻想卫星
-幽闇に目醒めしは	幽暗に目醒めしは	幽暗觉醒	幽目
-幽霊東京	幽灵东京
-幾四音-Ixion-	几四音-Ixion-
-幾望の月	几望の月	几望之月	几望的月
-康莊大道	康庄大道
-廻廻奇譚	咒术回战	回回奇谭	廻廻奇谭	轮回奇谭
-弱虫モンブラン	弱虫	换手练习歌	胆小鬼蒙布朗
-強風オールバック	强风オールバック	强风全后梳	强风背头
-彗星ハネムーン	彗星蜜月
-待チ人ハ来ズ。	待人未至	待人来	等待之人不来。
-御旗のもとに	御旗之下
-心象蜃気楼	心象晨气楼	心象海市蜃楼	心象蜃气楼
-怒槌	Ikazuchi	怒捶	怒锤
-怪盗Rのテーマ	怪盗R主题曲	怪盗R的影之诗
-恋愛裁判	恋爱审判	恋爱裁判
-患部で止まってすぐ溶ける～狂気の優曇華院	优云华院	在患部停止并立即融化～疯狂的优昙华院	患部で止まってすぐ溶ける～狂气の优昙华院	患部止	马应龙
-悪戯	恶作剧	恶戏
-悪戯センセーション	恶作剧感觉	恶戏センセーション	调皮的感觉
-悪魔の踊り方	恶魔の踊り方	恶魔之舞	恶魔的舞蹈方式
-愛包ダンスホール	爱包ダンスホール	爱包舞厅
-感情ディシーブ	情感欺骗	感情欺骗
-拝啓ドッペルゲンガー	亲爱的分身	拜启ドッペルゲンガー	敬启分身	敬启我的分身
-撩乱乙女†無双劇	撩乱乙女†无双剧	撩乱少女†无双剧
-放課後ストライド	放学后大步走	放课后ストライド	放课后冲
-敗北の少年	败北の少年	败北少年	败北的少年
-教えて!! 魔法のLyric	告诉我!! 魔法歌词	教教
-新人類	新人类
+太陽系デスコ	太阳系disco	太阳系デスコ	太阳系迪斯科	太田顺也	太阳系	👇🏻😐👆🏻👇🏻😐👆🏻
+失敗作少女	失败作少女	失败作	成功当男娘	我肯定
+奏者はただ背中と提琴で語るのみ	奏者はただ背中と提琴で语るのみ	奏者只以背影与小提琴诉说	演奏者仅以背影与小提琴诉说	奏者	奏者背后的提琴在说话	提琴	月玲妹妹躺沙发	月玲那知	美少女躺沙发
+妄想感傷代償連盟	妄想感伤代偿联盟	盲肠肝脏大肠年龄	ghost	代偿联盟	啊咿呀咿呀	妄伤	妄想	妄想感伤	小海底谭	海底谭难民营	盲肠肛肠大肠联盟	联盟	阿姨压一压	鬼
+妖精村の月誕祭 ～Lunate Elf	妖精村の月诞祭 ～Lunate Elf	妖精村月诞祭	妖精村月诞祭～月精灵	大妖精	妖精村	恋恋	月诞祭
+宛城、炎上！！	宛城炎上	宛城，火攻！！	enjo	enjou	大宇宙	宛城	炎上	赤赤	钠离子
+宵の鳥	夜鸟	宵の鸟	宵鸟	宵之鸟	宵宵鸟	宵的鸟	小鸟	愤怒的小鸟
+宿星審判	宿星审判	原神草神	大慈树王	奏明天空	审判	宿	宿星	宿暗示	星怒审判	曹逸凡	爱蜜莉雅	竹雨	纳希坦	纳西妲	雷电法王
+宿題が終わらないっ！	作业做不完！	宿题が终わらないっ！	触手调教	-connect-少女与触手编织出的爱	不写作业	作业写不完了	作业还没做完	吱吱	宿题	宿题终	触手
+寝起きヤシの木	刚醒的椰树	起床椰子树	早起椰树头	歌爱冲刺
+封焔の135秒	封焰135	封焰の135秒	封焰幺三五	封焰的135秒	135	135秒	大战老头	封烟	封焰	封焰的135	封焰的2分15秒	橘优羽	激烈的战斗场面	老头大战少女
+少女幻葬戦慄曲 ～ Necro Fantasia	少女幻葬战栗曲 ～ Necro Fantasia	死灵幻想曲	少女幻葬	幻葬
+居並ぶ穀物と溜息まじりの運送屋	居并ぶ谷物と溜息まじりの运送屋	排列的谷物与叹息的运输屋	木雕2	木雕二	老汉拉车	老汉推车	谷物运送屋	木雕鲶鱼2	水手	牢大骑车	老爷爷	老登拉车
+届かない花束	届不到	届花束	无法传递的花束	未送达的花束	传达不到的花束	届不到的花束	花束	送不到的花束
+幸せになれる隠しコマンドがあるらしい	似乎有着能够变得幸福的隐藏指令	幸せになれる隐しコマンドがあるらしい	幸福隐藏指令	幸隐	性瘾	😄🔫	→↓↑→→↓→→↑↑↓↓←→←→	↓→↑→→↓→→↑↑↓↓←→←→	⭐🌧️	むちゃぶり	喵梦	幸福指令	紫砂	结月流汗	结月缘	结月缘黑丝兔女郎	视力检测	😅
+幻想に咲いた花	幻想中绽放的花	幻想绽放之花	幻想之花	幻想咲花	幻想花	弹幕神乐
+幻想のサテライト	幻想卫星	dx幻想卫星	homo	卫星	幻想的卫星	标准幻想卫星	标幻想卫星
+幽闇に目醒めしは	幽暗に目醒めしは	幽暗觉醒	幽目	东方四个女人躺草地	东方四女躺草地	在黑暗中醒来	幽暗	幽暗目醒	躺草坪
+幽霊東京	幽灵东京	东京	幽灵京东	幽灵北京	幽灵线东京	杨陵东京	汐子	诱0东京	黑子
+幾四音-Ixion-	几四音-Ixion-	几四音	幾四音	急死银	第四爱
+幾望の月	几望の月	几望之月	几望的月	几望	几望月	望月
+康莊大道	康庄大道	九洲大道	康	康庄	成华大道	星光大道	浇给	黑羊羊
+廻廻奇譚	咒术回战	回回奇谭	廻廻奇谭	轮回奇谭	保龄球	咒术回战主题曲	回回奇谈	奇谭	灰灰鸡蛋	🎳	🤞
+弱虫モンブラン	弱虫	换手练习歌	胆小鬼蒙布朗	iidx	胆小鬼	若虫
+強風オールバック	强风オールバック	强风全后梳	强风背头	强风大背头	强风才一儿
+彗星ハネムーン	彗星蜜月	彗星
+待チ人ハ来ズ。	待人未至	待人来	等待之人不来。	东方旋转木马	小伞	小伞歌	等人	等的人没有来
+御旗のもとに	御旗之下	dx御旗	妹妹v50	御旗
+心象蜃気楼	心象晨气楼	心象海市蜃楼	心象蜃气楼	心像楼	心绮楼	心象	心象晦气楼	心象楼	青岛地铁
+怒槌	Ikazuchi	怒捶	怒锤	努吹	愤怒的锤子	梅西哥打交	神之一锤	该罚	😡👊	😡🔨
+怪盗Rのテーマ	怪盗R主题曲	怪盗R的影之诗	怪盗	怪盗r	节奏怪盗
+恋愛裁判	恋爱审判	恋爱裁判	18z	情人节	有罪	逆转裁判
+患部で止まってすぐ溶ける～狂気の優曇華院	优云华院	在患部停止并立即融化～疯狂的优昙华院	患部で止まってすぐ溶ける～狂气の优昙华院	患部止	马应龙	dx患部	overdrive	一把米诺	优昙华院	兔子药	座药	患部	患部溶解	标准患部	标患部	狂气的优昙华院	绫地宁宁	肛塞
+悪戯	恶作剧	恶戏	恶习
+悪戯センセーション	恶作剧感觉	恶戏センセーション	调皮的感觉	二小姐	大妹	大小姐	恶戏	恶戏sensation	淘气感觉
+悪魔の踊り方	恶魔の踊り方	恶魔之舞	恶魔的舞蹈方式	恶魔	恶魔跳舞	恶魔踊	👁	👁️	👿👯
+愛包ダンスホール	爱包ダンスホール	爱包舞厅	爱包	爱派dancehall
+感情ディシーブ	情感欺骗	感情欺骗	感情	感情欺诈	欺骗感情
+拝啓ドッペルゲンガー	亲爱的分身	拜启ドッペルゲンガー	敬启分身	敬启我的分身	yhc	分身	影分身十字斩	我裂开来	拜启	敬启
+撩乱乙女†無双劇	撩乱乙女†无双剧	撩乱少女†无双剧	triedge	中间有个十字架	咚咚咚咚	女同14	女同3p	撩乱	撩乱乙女	撩乱乙女无双剧	无双剧	缭乱乙女
+放課後ストライド	放学后大步走	放课后ストライド	放课后冲	放课后
+敗北の少年	败北の少年	败北少年	败北的少年	败北	黑丝破洞
+教えて!! 魔法のLyric	告诉我!! 魔法歌词	教教	教	教我魔法	教我魔法歌词	教魔法
+新人類	新人类	镜音铃
 新宝島	新宝岛
-日本の米は世界一	日本大米世界第一	日本米
-明星ギャラクティカ	明星银河号
-明星ロケット	明星火箭	明星银河号
-星めぐり、果ての君へ。	星巡，致终焉的你。	星斗流转，赴你为终	星果君
-星屑ユートピア	星尘乌托邦	星屑乌托邦
-星界ちゃんと可不ちゃんのおつかい合騒曲	星界ちゃんと可不ちゃんのおつかい合骚曲	星界与可不的跑腿骚动曲
-星空パーティーチューン	星空派对曲
-星見草	星见草
-星詠みとデスペラード	星占师与亡命徒	星咏みとデスペラード	星咏与亡命徒
-春を告げる	宣告春天	报春	春告
-春嵐	春岚	春日风暴
-時空を超えて久しぶり！	puyopuyo	时空を超えて久しぶり！	穿越时空好久不见！	穿越时空的久别重逢
-時計の国のジェミニ	时计の国のジェミニ	时计之国	时计国	钟表国度的双子座	钟表国的双子
-曖昧mind	暧昧mind	暧昧之心	爱maimai
-最っ高のエンタメだ!!	最棒娱乐!!	至高娱乐
-最強 the サマータイム!!!!!	最强 the サマータイム!!!!!	最强夏日时光	最强夏日时光!!!!!
-最強STRONGER	最强STRONGER
-最終鬼畜妹フランドール・S	最终鬼畜妹フランドール・S	最终鬼畜妹芙兰朵露·S	蓝蓝路
-最終鬼畜妹・一部声	最终鬼畜妹·一部声	最终鬼畜妹・一部声	蓝蓝路
+日本の米は世界一	日本大米世界第一	日本米	kib青春版	东北大米世界第一	日本米世界一	日本绝赞世界第一	水稻	米米世界	🌾
+明星ギャラクティカ	明星银河号	丢人银河号	方向盘	明星	明星卡拉狄加	超级方向盘	银河号
+明星ロケット	明星火箭	明星银河号	幻想事变	明星
+星めぐり、果ての君へ。	星巡，致终焉的你。	星斗流转，赴你为终	星果君	星斗流转、赴你为终	星果	星间巡游致尽头的你	🥺
+星屑ユートピア	星尘乌托邦	星屑乌托邦	星屑
+星界ちゃんと可不ちゃんのおつかい合騒曲	星界ちゃんと可不ちゃんのおつかい合骚曲	星界与可不的跑腿骚动曲	星界	星界可不	星界可不合骚曲	星界小姐和可不小姐的外出合奏曲	星界酱和可不酱的采购合奏曲	马赛克	马赛克可不
+星空パーティーチューン	星空派对曲	party tune	兎花宮	兔花宫	奶子很大	新海天	星空	星空party tune	星空叙爱曲	童颜巨乳
+星見草	星见草	⭐️👁🌿	康庄小道
+星詠みとデスペラード	星占师与亡命徒	星咏みとデスペラード	星咏与亡命徒	星之咏唱者与亡命之徒	星咏	星诵
+春を告げる	宣告春天	报春	春告	cogito睡觉	春天的宣告	春日宣告	睡了	🛌
+春嵐	春岚	春日风暴	哈利路大旋风	哈姆风暴	春天的风暴	春风	蓝色妖姬	蓝色妖姬切尔西
+時空を超えて久しぶり！	puyopuyo	时空を超えて久しぶり！	穿越时空好久不见！	穿越时空的久别重逢	3d弹珠	3d弹球	噗呦噗呦	噗哟噗哟	时空	时空超	水滴君
+時計の国のジェミニ	时计の国のジェミニ	时计之国	时计国	钟表国度的双子座	钟表国的双子	时之国	时计	时针	时针之国	时针国	时钟	时钟之国	时钟国	钟表之国
+曖昧mind	暧昧mind	暧昧之心	爱maimai	哮喘	暧昧
+最っ高のエンタメだ!!	最棒娱乐!!	至高娱乐	最高
+最強 the サマータイム!!!!!	最强 the サマータイム!!!!!	最强夏日时光	最强夏日时光!!!!!	最强	泳装
+最強STRONGER	最强STRONGER	塔诺西	最屎shitter	最弱weaker	最强	最强2	血魔王
+最終鬼畜妹フランドール・S	最终鬼畜妹フランドール・S	最终鬼畜妹芙兰朵露·S	蓝蓝路	二妹	二小姐	最终鬼畜妹	鬼畜妹
+最終鬼畜妹・一部声	最终鬼畜妹·一部声	最终鬼畜妹・一部声	蓝蓝路	一部声	易卜生	月儿子青春版	月女儿	鬼叫	鬼畜妹	鬼畜妹一部声
 最速最高シャッターガール	文文	最快最高快门女孩	最速最高
-月に叢雲華に風	月に丛云华に风	月丛云	月映丛云花语风	月有丛云花有风	月风
+月に叢雲華に風	月に丛云华に风	月丛云	月映丛云花语风	月有丛云花有风	月风	丛云伴月	丛云华	小五	摇摆阳	月丛云华风	月云华风	月从云华风	月华	月映丛云	月映从云花语风	月遇丛云花遇风	闲云遮月清风袭花
 有明/Ariake	有明
-木彫り鯰と右肩ゾンビ	僵尸	右肩僵尸	木雕り鲶と右肩ゾンビ	木雕鲇鱼	木雕鲶鱼	木雕鲶鱼与右肩僵尸
-東京リアルワールド	东京リアルワールド	东京现实世界
-東方スイーツ！～鬼畜姉妹と受難メイド～	东方スイーツ！～鬼畜姉妹と受难メイド～	东方甜点！～鬼畜姐妹与受难女仆～
-東方妖々夢 ～the maximum moving about～	东方不可拘束	东方妖々梦 ～the maximum moving about～	东方妖妖梦 ～最大移动～
-林檎華憐歌	大妈唱歌	拜拜，拜拜	林檎华怜歌	苹果华怜歌
-果ての空、僕らが見た光。	尽头天空，我们所见之光。	果ての空、仆らが见た光。	终空所见之光
-極圏	极圈	鸡圈
-橙の幻想郷音頭	橙の幻想乡音头	橙之幻想乡音头	橙的幻想乡音头
-檄！帝国華撃団(改)	檄！帝国华击团(改)	滑稽团
+木彫り鯰と右肩ゾンビ	僵尸	右肩僵尸	木雕り鲶と右肩ゾンビ	木雕鲇鱼	木雕鲶鱼	木雕鲶鱼与右肩僵尸	右肩	大连海事大学校歌	拔小蒜	木彫	木雕	木鲶鱼	肩周炎	鲷鱼烧
+東京リアルワールド	东京リアルワールド	东京现实世界	东京	东京real world	东京塔	东京现充世界	东京铁塔	喝热排骨汤	塔	🗼
+東方スイーツ！～鬼畜姉妹と受難メイド～	东方スイーツ！～鬼畜姉妹と受难メイド～	东方甜点！～鬼畜姐妹与受难女仆～	东方受难	咲夜哭哭	鬼畜姐妹
+東方妖々夢 ～the maximum moving about～	东方不可拘束	东方妖々梦 ～the maximum moving about～	东方妖妖梦 ～最大移动～	东方妖妖梦	东方妖梦	妖妖梦	车万不可拘束
+林檎華憐歌	大妈唱歌	拜拜，拜拜	林檎华怜歌	苹果华怜歌	小苹果	拜拜	拜拜拜拜	林檎	苹果歌	马妈歌
+果ての空、僕らが見た光。	尽头天空，我们所见之光。	果ての空、仆らが见た光。	终空所见之光	果空
+極圏	极圈	鸡圈	sdvx	只因圈	寄圈	急圈	極圈	肌肉奶龙	🐔⭕	🐔⭕️
+橙の幻想郷音頭	橙の幻想乡音头	橙之幻想乡音头	橙的幻想乡音头	幻想乡音头	橙	橙之幻想乡	橙舞	橙音头	欢乐斗地主	音头	🐱
+檄！帝国華撃団(改)	檄！帝国华击团(改)	滑稽团	华击团	哈系列	帝国华击团	帝国滑稽团	樱花大战	樱花大战2	檄！
 残響散歌	残响散歌
-氷滅の135小節	冰灭135小节	冰灭の135小节	冰灭的135小节
-永遠にゲームで対戦したいキリタン	东北切蒲英	想永远在游戏中战斗的桐炭	想永远玩游戏的Kiritan	永远にゲームで对战したいキリタン	永远对战	永远都想对战游戏的切蒲英
-永遠のメロディ	永恒旋律	永远のメロディ	永远的melody
-泡沫、哀のまほろば	泡沫	泡沫哀之理想乡
+氷滅の135小節	冰灭135小节	冰灭の135小节	冰灭的135小节	冰灭	冰灭135
+永遠にゲームで対戦したいキリタン	东北切蒲英	想永远在游戏中战斗的桐炭	想永远玩游戏的Kiritan	永远にゲームで对战したいキリタン	永远对战	永远都想对战游戏的切蒲英	东北往事	主播	切蒲英	切蒲英打电动	对战	对战游戏	永远	永远都想对战游戏	永远都想玩对战游戏的切蒲英	猫耳	肝帝打不赢欧皇
+永遠のメロディ	永恒旋律	永远のメロディ	永远的melody	东方蓬千歌	永远	永远的旋律	永远的节奏
+泡沫、哀のまほろば	泡沫	泡沫哀之理想乡	妹红泡水	泡沫哀	藤原妹红
 泣き虫O'clock	泣虫	爱哭鬼	爱哭鬼O'clock
 泥の分際で私だけの大切を奪おうだなんて	区区污泥也想抢走我的至宝	泥の分际で私だけの大切を夺おうだなんて	泥分际大切夺	泥歌
 洗脳	洗脑
-深海シティアンダーグラウンド	深海城市地下
-渦状銀河のシンフォニエッタ	抽水马桶	涡状银河のシンフォニエッタ	漩涡星系小交响曲
-源平大戦絵巻テーマソング	原批大战罕见	源平大战绘卷テーマソング	源平大战绘卷主题曲
+深海シティアンダーグラウンド	深海城市地下	呜哇啊啊啊	水神7	深海	深海undergroundcity	深海地下城	深海地下都市	深海城市	深海都市
+渦状銀河のシンフォニエッタ	抽水马桶	涡状银河のシンフォニエッタ	漩涡星系小交响曲	冲水马桶	标抽水马桶	标涡状银河	标银河	标马桶	涡状伊岛	涡状台风	涡状银河	涡状银河交响曲	涡状银河的小交响曲	涡状马桶	漩涡马桶	银河	马桶	🚽
+源平大戦絵巻テーマソング	原批大战罕见	源平大战绘卷テーマソング	源平大战绘卷主题曲	op	op大战东雪莲	op大战汉奸	op大战罕见	东雪莲大战罕见	原批大战东雪莲	叩大战东雪莲	淳平大战德川	源平	源平1	源平大战	源平大战绘卷
 演劇	演剧
-火炎地獄	火炎地狱	火焰地狱
-炎歌 -ほむらうた-	凤凰传奇	炎歌
-炭★坑★節	炭★坑★节	炭坑节	碳坑节
-無敵We are one!!	我们是1	我们是无敌1	无敌We are one!!	无敌我们是1	无敌我们是一
+火炎地獄	火炎地狱	火焰地狱	dx地狱	dx火炎	dx火炎地狱	dx火焰地狱	光谷世界城	天虹	怪兽	打怪兽	标准火炎	标火炎地狱	火炎	绝赞地狱	羊头
+炎歌 -ほむらうた-	凤凰传奇	炎歌	dx炎歌	广场舞	阉割
+炭★坑★節	炭★坑★节	炭坑节	碳坑节	最新热歌慢摇	粪坑节
+無敵We are one!!	我们是1	我们是无敌1	无敌We are one!!	无敌我们是1	无敌我们是一	奢香夫人	我们是一	无敌	无敌we are one	无敌！我们是1
 無間嫉妬劇場『666』	无间嫉妒剧场『666』	无间嫉妬剧场『666』
-熱異常	热异常
-物凄いヴァイブスで魔理沙が物凄いラップ	以超强节奏魔理沙的超强说唱	魔理沙物凄
-物凄い勢いでけーねが物凄いうた	慧音	气势汹汹的慧音唱气势汹汹的歌	物凄い势いでけーねが物凄いうた
-犬日和。	狗天气	狗日子
-独りんぼエンヴィー	独行者的嫉妒
-猛進ソリストライフ！	猛进ソリストライフ！	猛进独奏人生！	猛进独奏生活
-猫猫的宇宙論	猫猫宇宙论	猫猫的宇宙论
-猫祭り	猫祭
-玩具狂奏曲 -終焉-	玩具狂奏曲 -终焉-	玩具狂奏曲-终焉-
-生きてるおばけは生きている	活着的幽灵	活着的幽灵是活着的
-生命不詳	不知死活	二蚌	生命不详
+熱異常	热异常	冷正常
+物凄いヴァイブスで魔理沙が物凄いラップ	以超强节奏魔理沙的超强说唱	魔理沙物凄	vibes	夜店魔理沙	妹红吸烟	妹红打永夜抄	妹红抽烟	消声器	物凄	物凄魔理沙	藤原妹红抽大烟	魔理沙抽烟
+物凄い勢いでけーねが物凄いうた	慧音	气势汹汹的慧音唱气势汹汹的歌	物凄い势いでけーねが物凄いうた	三倍ice☆cream	以惊人的气势发出了惊人的声音	物凄	物凄势	白泽球	罪
+犬日和。	狗天气	狗日子	哈皮	日和	犬日和	狗日和	狗日的
+独りんぼエンヴィー	独行者的嫉妒	孑然妒火	孜然炉火	孜然驴肉	虾	蛙	🦐
+猛進ソリストライフ！	猛进ソリストライフ！	猛进独奏人生！	猛进独奏生活	小提琴	庞德	月玲那知	猛进
+猫猫的宇宙論	猫猫宇宙论	猫猫的宇宙论	学猫叫	宇宙论	🖐🏻️🐱🖐🏻️
+猫祭り	猫祭	哈基米钻奈子	哈祭咪	喵卷	喵喵喵喵	学猫叫	洗面奶	猫	猫寄	猫抓板	绝赞101	😺
+玩具狂奏曲 -終焉-	玩具狂奏曲 -终焉-	玩具狂奏曲-终焉-	别急23	玩具	玩具狂奏曲	第五人格
+生きてるおばけは生きている	活着的幽灵	活着的幽灵是活着的	坟头蹦迪	欧巴给	活着的怪物会一直活着	生生
+生命不詳	不知死活	二蚌	生命不详	半死不活	死不明白	生母不详
 町かどタンジェント	城镇角切线
-疾走あんさんぶる	疾走	疾走合奏
-病み垢ステロイド	病态垢类固醇	病态类固醇
-白ゆき	白雪
-白花の天使	白花天使
-相思創愛	相思创爱
-真・ハンサム体操でズンドコホイ	super面筋人	五个小人发癫	学园帅哥	帅哥体操	真·帅哥体操之咚锵嘿	真体操
-砂の惑星 feat. HATSUNE MIKU	沙之行星	沙之行星 feat. 初音未来	沙星	砂之惑星	砂星
-神々が恋した幻想郷	东十字星	众神眷恋的幻想乡	神々が恋した幻想乡	翠十字
-神々の祈り	众神的祈祷	神祈
-神っぽいな	像神一样呐	神poi
-神室雪月花	如龙	雪月花
-福宿音屋魂音泉	魂音泉
-私のドッペルゲンガー	我的二重身
-私の中の幻想的世界観及びその顕現を想起させたある現実での出来事に関する一考察	关于我内心幻想世界观及其显现所想起的现实事件之考察	名字太长的歌	名字很长的歌	私の中の幻想的世界观及びその显现を想起させたある现实での出来事に关する一考察	私中幻想的世界观
-秋の未確認生物	秋の未确认生物	秋之未确认生物
+疾走あんさんぶる	疾走	疾走合奏	疾走乐队	骚灵三姐妹
+病み垢ステロイド	病态垢类固醇	病态类固醇	病垢	病郁账号类固醇
+白ゆき	白雪	女同亲嘴	月代雪	白yuki	白夜行	白雪歌送武判官归京	美少女亲嘴
+白花の天使	白花天使	东雪莲2	冬雪の莲莲	白花	白花的天使
+相思創愛	相思创爱	创创子	小米星	相思	相思創爱	相爱创思
+真・ハンサム体操でズンドコホイ	super面筋人	五个小人发癫	学园帅哥	帅哥体操	真·帅哥体操之咚锵嘿	真体操	体操	哇酷哇酷	四个人站着一个人躺着	四个站着一个躺着	学园handsome	憋笑挑战2	深海男同	火鸡帅哥
+砂の惑星 feat. HATSUNE MIKU	沙之行星	沙之行星 feat. 初音未来	沙星	砂之惑星	砂星	划龙舟	别急18	最速殿堂	沙之惑星	砂の惑星	砂之行星	砂惑
+神々が恋した幻想郷	东十字星	众神眷恋的幻想乡	神々が恋した幻想乡	翠十字	testify	东十字	东方南十字	众神眷恋的十字星	小南十字	幻想乡	神仙稀罕俺们屯	神恋	神眷	神都得意俺们屯	终神眷恋的南十字	青春版白南十字星
+神々の祈り	众神的祈祷	神祈	神明的祈祷	🍁
+神っぽいな	像神一样呐	神poi	像神一样	像神一样啊	神	神呐	风拂过之处	黑化初音
+神室雪月花	如龙	雪月花	别急4
+福宿音屋魂音泉	魂音泉	敬业福	福州温泉	福州男同
+私のドッペルゲンガー	我的二重身	my doppelganger	分身	可不拔大蒜	我的分身
+私の中の幻想的世界観及びその顕現を想起させたある現実での出来事に関する一考察	关于我内心幻想世界观及其显现所想起的现实事件之考察	名字太长的歌	名字很长的歌	私の中の幻想的世界观及びその显现を想起させたある现实での出来事に关する一考察	私中幻想的世界观	内心幻想世界观及相关事件考察	名字很长	名字鬼长	对现实的考察映照心中幻想世界
+秋の未確認生物	秋の未确认生物	秋之未确认生物	未确认生物	生物	秋的未确认生物
 秒針を噛む	咬住秒针	秒针を啮む
-究極焼肉レストラン！お燐の地獄亭！	究极烤肉店！阿燐的地狱亭！	究极烧肉レストラン！お燐の地狱亭！
-空威張りビヘイビア	空威张りビヘイビア	空威张行为	虚张声势行为
-立ち入り禁止	禁止入内	禁止进入	立入禁止
-立川浄穢捕物帳	立川净秽捕物帐	青岛侦探事务所
-管弦楽組曲 第3番 ニ長調「第2曲（G線上のアリア）」BWV.1068-2	G弦上的咏叹调	管弦乐组曲 第3番 ニ长调「第2曲（G线上のアリア）」BWV.1068-2
-系ぎて	系连
-約束	约定	约束
-紅に染まる恋の花	染红之恋花	染红恋花	红に染まる恋の花
-紅星ミゼラブル～廃憶編	红星ミゼラブル～废忆编	红星悲惨～废忆篇	红星悲歌·废忆篇
+究極焼肉レストラン！お燐の地獄亭！	究极烤肉店！阿燐的地狱亭！	究极烧肉レストラン！お燐の地狱亭！	烤肉	究极烧肉
+空威張りビヘイビア	空威张りビヘイビア	空威张行为	虚张声势行为	欧尼酱	欧欧欧欧欧欧尼酱	空威张	虚张声势behavior	虚张声势的行为
+立ち入り禁止	禁止入内	禁止进入	立入禁止	后入禁止	后入群主	禁止寸止	🚫
+立川浄穢捕物帳	立川净秽捕物帐	青岛侦探事务所	捕物帐	立川	青岛市公安局
+管弦楽組曲 第3番 ニ長調「第2曲（G線上のアリア）」BWV.1068-2	G弦上的咏叹调	管弦乐组曲 第3番 ニ长调「第2曲（G线上のアリア）」BWV.1068-2	g弦	二长调	妹妹拉小提琴	小女孩齐打交	管弦乐	管弦乐组曲
+系ぎて	系连	6a	aaaaaa	kop5	kop5th决胜曲	n⭐cream	tsunagite	つなぎて	丝	丝之歌	原神2	大系	寻迹	携手	携手前进	携手向前	新手教程2	牵绊	白丝	白系	系	系接头	连结
+約束	约定	约束	压库锁库	码头
+紅に染まる恋の花	染红之恋花	染红恋花	红に染まる恋の花	我把树叶都染红	染红的恋之花	烤红薯	秋姐妹	红染	红染恋花
+紅星ミゼラブル～廃憶編	红星ミゼラブル～废忆编	红星悲惨～废忆篇	红星悲歌·废忆篇	红星	蕾米吹zun号	蕾米吹喇叭	蕾米吹小号	蕾米莉亚吹喇叭	蕾米莉亚吹小号	蕾米莉亚吹滴答
 紅蓮華	红莲华
-終わりなき物語	无尽物语	无尽的故事	终わりなき物语	终物语
-終点	终点
-終焉逃避行	终焉逃亡	终焉逃避行
-結ンデ開イテ羅刹ト骸	结ンデ开イテ罗刹ト骸	结与开罗刹与骸	结骸	连起来又分开，罗刹与骨骸
-絡めトリック利己ライザー	纠缠诡计利己者	络めトリック利己ライザー	连环诡计利己者
-絡繰りドール	机关人偶	络缲りドール
-絶え間なく藍色	无尽的蓝色	绝え间なく蓝色	绝间蓝色
-絶対にチョコミントを食べるアオイチャン	琴叶葵	绝对にチョコミントを食べるアオイチャン	绝对要吃巧克力薄荷冰淇淋的葵酱	绝对要吃巧克力薄荷冰激淋的葵酱	绝对要吃巧克力薄荷的葵酱	绝对要吃薄荷巧克力的葵酱
-絶対敵対メチャキライヤー	绝对敌对メチャキライヤー	绝对敌对超讨厌者	绝对敌对超讨厌鬼
-緋色のDance	绯色のDance	绯色之舞
+終わりなき物語	无尽物语	无尽的故事	终わりなき物语	终物语	物语
+終点	终点	b50的起点	b50里有终点	小心地滑	怪兽	打怪兽	污点	🏁
+終焉逃避行	终焉逃亡	终焉逃避行	嵯峨	提桶跑路	终焉
+結ンデ開イテ羅刹ト骸	结ンデ开イテ罗刹ト骸	结与开罗刹与骸	结骸	连起来又分开，罗刹与骨骸	八爷	分分合合的罗刹与骨骸	罗刹	罗刹骨骸
+絡めトリック利己ライザー	纠缠诡计利己者	络めトリック利己ライザー	连环诡计利己者	dx+主题曲	利己	华代主题曲	络	络利己	绿头人
+絡繰りドール	机关人偶	络缲りドール	奶奶狐狸	絡繰	络繰	络缲	老太婆和九尾狐妖	老奶奶与狐狸精
+絶え間なく藍色	无尽的蓝色	绝え间なく蓝色	绝间蓝色	无尽之蓝	无尽蓝色	绝绝子蓝色	绝蓝	绝间蓝	蓝色	超羽天狼星
+絶対にチョコミントを食べるアオイチャン	琴叶葵	绝对にチョコミントを食べるアオイチャン	绝对要吃巧克力薄荷冰淇淋的葵酱	绝对要吃巧克力薄荷冰激淋的葵酱	绝对要吃巧克力薄荷的葵酱	绝对要吃薄荷巧克力的葵酱	chocomint ice	冰淇凌	冰淇淋	巧克力冰淇淋	必须要吃薄荷巧克力味冰淇淋的琴叶葵酱	绝对	绝对食	薄荷巧克力	薄荷巧克力冰淇淋	超级小喵
+絶対敵対メチャキライヤー	绝对敌对メチャキライヤー	绝对敌对超讨厌者	绝对敌对超讨厌鬼	宿敌就是宿敌啊	绝对敌对	绝对敌对大讨厌	绝对敌对超级讨厌
+緋色のDance	绯色のDance	绯色之舞	绯色	绯色dance
 美しく燃える森	美丽燃烧的森林	美燃森
 美夜月鏡	美夜月镜
-群青シグナル	群青信号	群青讯号
+群青シグナル	群青信号	群青讯号	体育生2	群青	群青2
 群青讃歌	群青赞歌
-胡蝶乃舞	胡蝶之舞
-脳天直撃	脑天直击	脑门直击
-脳漿炸裂ガール	脑浆炸裂ガール	脑浆炸裂女孩
-腐れ外道とチョコレゐト	堕落恶徒与巧克力	外道	腐外道
+胡蝶乃舞	胡蝶之舞	蝴蝶乃舞
+脳天直撃	脑天直击	脑门直击	头部受到打击	生鱼片蘸芥末	脑天	脑天直寄	脑瘫直击	脑瘫至极	脑花
+脳漿炸裂ガール	脑浆炸裂ガール	脑浆炸裂女孩	dx脑浆	dx脑浆炸裂	力一儿	吸溜	标准脑浆	标脑	标脑浆	标🤯	脑浆	脑浆炸裂	脑浆炸裂力一儿	脑浆炸裂少女	脑浆炸裂谱	脑瘫炸裂	脑裂	麦当劳1+1	🤯	🤯👧
+腐れ外道とチョコレゐト	堕落恶徒与巧克力	外道	腐外道	巧克力	异端	红雷小曲	该死的异端及巧克力	🍫
 自傷無色	自伤无色
-色は匂へど散りぬるを	伊洛瓦	色散	花开艳丽终散落
-花と、雪と、ドラムンベース。	有好姐妹一起出勤吗	花一轮	花与雪与鼓打贝斯。	花雪
-花となれ	化作花
-若い力	年轻之力	年轻的力量
-若い力 -SEGA HARD GIRLS MIX-	年轻力量 -世嘉硬妹混音-	若力
-華の集落、秋のお届け	华の聚落、秋のお届け	华の集落、秋のお届け	华落	华集	花之村落，秋之送达
-華鳥風月	华鸟风月	花鸟风月
-蒼穹舞楽	苍穹舞乐
-蒼空に舞え、墨染の桜	墨染樱	苍空に舞え、墨染の樱	苍空舞墨樱
-虹と太陽	彩虹与太阳	虹と太阳	虹太阳
-蜘蛛の糸	蜘蛛の丝	蜘蛛丝
-表裏一体	硬币两面	表里一体
-裏表ラバーズ	表里恋人	里表ラバーズ
-解けないように	无法解开	解不开
-言ノ葉カルマ	言ノ叶カルマ	言叶业
-言ノ葉遊戯	言ノ叶游戏	言叶游戏
-記憶、記録	恐怖谷	记忆、记录	记忆记录
-赤心性：カマトト荒療治	赤心性：カマトト荒疗治	赤心性：装傻粗暴疗法	赤心性：骗人荒疗
-超常マイマイン	超常maimai	超常我的mine
-超熊猫的周遊記（ワンダーパンダートラベラー）	超熊猫周游记	超熊猫的周游记（ワンダーパンダートラベラー）
-超絶！Superlative	超绝！Superlative
-踊	舞
-踊れオーケストラ	舞动管弦乐团	起舞吧管弦乐团
-躯樹の墓守	欧内的守	躯树の墓守	躯树守墓人
+色は匂へど散りぬるを	伊洛瓦	色散	花开艳丽终散落	dx色散	老年人活动中心	花朵艳丽终会散落	花艳终散
+花と、雪と、ドラムンベース。	有好姐妹一起出勤吗	花一轮	花与雪与鼓打贝斯。	花雪	六块钱	冬之花	别急6	四月的雪	快慢刀	昭和金曲	舞萌金曲	花花花花花花一轮	花雪一堆日本字	花，雪和bass	花😋、雪🤤、😘😨🥵🤢😈🤣😅。	雪球	雪鸡	🌸1⃣️🛞	🌸❄️
+花となれ	化作花	像花一样呐	化成花	变成一朵花	变成花	可不呲牙	幻化成花	成为一朵花	成为花朵
+若い力	年轻之力	年轻的力量	sbga	sbga社歌	sega	sega大楼	sega社歌	世嘉	世嘉社歌	本社	本社爆破	社歌	若之力	若以力	若力
+若い力 -SEGA HARD GIRLS MIX-	年轻力量 -世嘉硬妹混音-	若力	sbga	sega	sega社歌	世嘉女孩	世嘉少女	世嘉硬件女孩	世嘉社歌	年轻的力量	若以力
+華の集落、秋のお届け	华の聚落、秋のお届け	华の集落、秋のお届け	华落	华集	花之村落，秋之送达	华之集落	华之集落，致以秋意	华的集落	华秋	华集落	标华集	标华集落	滑稽	皇女	秋届	花村	菲谢尔	蛋糕店里卖蛋糕	集落
+華鳥風月	华鸟风月	花鸟风月	かちょうふうげつ	四季	四季映姬	花鸟市场
+蒼穹舞楽	苍穹舞乐	妍酱	斗破苍穹	神里绫人	苍穹	菅穹舞乐
+蒼空に舞え、墨染の桜	墨染樱	苍空に舞え、墨染の樱	苍空舞墨樱	墨染	妖梦	糯香柠檬茶	苍空	苍空舞	苍空飞舞墨染之樱
+虹と太陽	彩虹与太阳	虹と太阳	虹太阳	\😭/	☀	太阳	彩虹太阳	虹与太阳	金正恩
+蜘蛛の糸	蜘蛛の丝	蜘蛛丝	spider’s thread	四百块	滴嘟丝	蜘蛛的丝	蜘蛛的糸	蜘蛛系	🕸️
+表裏一体	硬币两面	表里一体	表里	表里如一
+裏表ラバーズ	表里恋人	里表ラバーズ	◐	里表	里表恋人	里表情人
+解けないように	无法解开	解不开	为不被解开	为了不被解开	愿这绳结不被解开	解	黑化灵梦
+言ノ葉カルマ	言ノ叶カルマ	言叶业	soraru	因果	言叶	言叶之业
+言ノ葉遊戯	言ノ叶游戏	言叶游戏	文字游戏	游戏
+記憶、記録	恐怖谷	记忆、记录	记忆记录	lopit	命脉	敲锣打鼓	爆裂鼓手	菜头	记忆纪录
+赤心性：カマトト荒療治	赤心性：カマトト荒疗治	赤心性：装傻粗暴疗法	赤心性：骗人荒疗	赤心性
+超常マイマイン	超常maimai	超常我的mine	咕噜咕噜	大逼圈入门曲	超常	超常滴蜡熊
+超熊猫的周遊記（ワンダーパンダートラベラー）	超熊猫周游记	超熊猫的周游记（ワンダーパンダートラベラー）	周游记	四川禁曲	超熊猫	超熊猫的周游记	超能猫	超雄猫
+超絶！Superlative	超绝！Superlative	超绝
+踊	舞	ko	odo	哦哇哇哦哇哦	桶	红眼果蝇	耶耶耶耶耶耶	起舞	跳舞	长舌妇
+踊れオーケストラ	舞动管弦乐团	起舞吧管弦乐团	踊	随管弦乐起舞
+躯樹の墓守	欧内的守	躯树の墓守	躯树守墓人	噔噔	墓守	守墓人	小红帽	树	洛茜	红色羽毛球	躯树的墓守	🌳
 転生林檎	转生林檎	转生苹果
-迷える音色は恋の唄	迷える音色は恋の呗	迷惘音色是恋歌	迷音恋歌
-進め！イッスン軍団 -Rebellion of the Dwarfs-	前进军团	前进！一寸军团 -矮人叛乱-	小人国	小小兵团	进め！イッスン军团 -Rebellion of the Dwarfs-
-進捗どうですか？	进度	进度如何？	进捗どうですか？	进步
-過去を喰らう	吞噬过去	噬食过往	过去を喰らう
-遺伝子レベル∞スパイラル	基因等级∞螺旋	基因螺旋∞	遗传子レベル∞スパイラル
-酔いどれ知らず	醉いどれ知らず	醉不知	醉汉不知
-采配の刻 Power of order	指挥时刻 Power of order	采配之刻
-銀のめぐり	银のめぐり	银之巡
-閃鋼のブリューナク	闪钢のブリューナク	闪钢之布里欧纳克
-阿修羅ちゃん	阿修罗ちゃん	阿修罗酱
-阿吽のビーツ	阿吽的节拍	阿吽节拍
-隠密あんみつDX	隐密あんみつDX	隐密豆沙DX	隐秘蜜豆DX
+迷える音色は恋の唄	迷える音色は恋の呗	迷惘音色是恋歌	迷音恋歌	恋歌
+進め！イッスン軍団 -Rebellion of the Dwarfs-	前进军团	前进！一寸军团 -矮人叛乱-	小人国	小小兵团	进め！イッスン军团 -Rebellion of the Dwarfs-	一尺军团	军团	小碗	绣花针	进军团	针	针妙丸	针妙丸军团
+進捗どうですか？	进度	进度如何？	进捗どうですか？	进步	八云橙	进展如何	进度如何
+過去を喰らう	吞噬过去	噬食过往	过去を喰らう	花谱
+遺伝子レベル∞スパイラル	基因等级∞螺旋	基因螺旋∞	遗传子レベル∞スパイラル	光剑打架	星球大战	遗伝子	遗传	遗传基因 level ♾️ spiral	遗传子
+酔いどれ知らず	醉いどれ知らず	醉不知	醉汉不知	不知醉
+采配の刻 Power of order	指挥时刻 Power of order	采配之刻	采配
+銀のめぐり	银のめぐり	银之巡	古明地觉	银	银的循环	银的轮回
+閃鋼のブリューナク	闪钢のブリューナク	闪钢之布里欧纳克	闪钢
+阿修羅ちゃん	阿修罗ちゃん	阿修罗酱	阿修罗
+阿吽のビーツ	阿吽的节拍	阿吽节拍	小灵通青春版	阿吽	阿吽的节奏	阿哞	阿哞的节奏	阿牛	阿牛小卖铺
+隠密あんみつDX	隐密あんみつDX	隐密豆沙DX	隐秘蜜豆DX	王小桃	隐密	隐密dx	隐密馅密dx	隐秘dx	隐秘馅密dx
 隠然	引燃	隐然
-雨とペトラ	雨与佩特拉
-零號車輛	零号车辆
-雷切-RAIKIRI-	雷切
-電光石火	电光石火
-電車で電車でGO!GO!GO!GC! -GMT remix-	电车で电车でGO!GO!GO!GC! -GMT remix-	电车电车GO!GO!GO!GC! -GMT混音-	电车电车GO!GO!GO!GC! -GMT混音版-
-電車で電車でOPA!OPA!OPA! -GMT mashup-	星星电车	电车で电车でOPA!OPA!OPA! -GMT mashup-	电车电车OPA!OPA!OPA! -GMT串烧-
+雨とペトラ	雨与佩特拉	☂	伞	佩特拉	雨	雨伞	雨和佩特拉
+零號車輛	零号车辆	灵车	零号列车	零车
+雷切-RAIKIRI-	雷切	两把刀	你们怎么解读出我和他切割的	噔噔噔噔	地雷女切手手	影刃	梦想一心	纯粹的强大
+電光石火	电光石火	俄洛伊	妖艳魔男2	电光火石	🤨
+電車で電車でGO!GO!GO!GC! -GMT remix-	电车で电车でGO!GO!GO!GC! -GMT remix-	电车电车GO!GO!GO!GC! -GMT混音-	电车电车GO!GO!GO!GC! -GMT混音版-	电车	电车go	电车难题
+電車で電車でOPA!OPA!OPA! -GMT mashup-	星星电车	电车で电车でOPA!OPA!OPA! -GMT mashup-	电车电车OPA!OPA!OPA! -GMT串烧-	0000	⭐🚎	南梦宫mashup	电车	电车go×幻想空间	电车opa
 青空のラプソディ	蓝天的狂想曲
-響け！CHIREI MY WAY!	响け！CHIREI MY WAY!	响彻！我的路	响彻！我的道路！
-響縁	响缘	响缘不是响绿
-頓珍漢の宴	盾震撼	顿珍汉の宴	顿珍汉之宴
-願いを呼ぶ季節	唤愿之季	愿いを呼ぶ季节	祈愿之季
+響け！CHIREI MY WAY!	响け！CHIREI MY WAY!	响彻！我的路	响彻！我的道路！	响	地灵殿偶像
+響縁	响缘	响缘不是响绿	dx响缘	梦花火2	猫耳灵梦	響緣	響绿
+頓珍漢の宴	盾震撼	顿珍汉の宴	顿珍汉之宴	初音上菜	吃饭	汉尼拔之宴	珍顿汉	顿珍汉	顿珍汉吃席	顿珍汉宴	顿震撼	🙏	🥓
+願いを呼ぶ季節	唤愿之季	愿いを呼ぶ季节	祈愿之季	呼唤愿望的季节	季节	愿呼季节	梦想夏乡	梦想夏乡主题曲	红蓝
 馬と鹿	笨和蛋	马と鹿	马和鹿
-骸骨楽団とリリア	莉莉亚	骸骨乐团とリリア	骸骨乐团与莉莉娅
-高気圧ねこロック	高气压ねこロック	高气压猫摇滚	高气压猫猫头	高血压
+骸骨楽団とリリア	莉莉亚	骸骨乐团とリリア	骸骨乐团与莉莉娅	腿子	骸骨	骸骨乐团	骸骨乐团与莉莉亚	👉🏻😕👈🏻
+高気圧ねこロック	高气压ねこロック	高气压猫摇滚	高气压猫猫头	高血压	马香远	高气压	高气压猫	高血压流汗黄豆
 魂のルフラン	灵魂轮回	魂之轮回
-魔ジョ狩リ	魔女狩猎	魔狩
-魔法少女とチョコレゐト	魔法少女与巧克力
-魔法少女になるしかねぇ	只能成为魔法少女
-魔理沙は大変なものを盗んでいきました	魔理沙は大变なものを盗んでいきました	魔理沙偷走了重要的东西	魔理沙大便	魔理沙大变
-鼓動	鼓动
-＊ハロー、プラネット。	hello planet	你好，行星	＊你好，星球。
-ｉｓｏｐｈｏｔｅ	isophote	等照线
+魔ジョ狩リ	魔女狩猎	魔狩	骑士之夜remix版	魔女的夜宴	魔法少女的魔女审判
+魔法少女とチョコレゐト	魔法少女与巧克力	巧克力	巧克力2	腐外道2	马猴烧酒和巧克力	魔法少女	魔法少女和巧克力	魔法少女巧克力
+魔法少女になるしかねぇ	只能成为魔法少女	只好成为魔法少女了	脏	马猴烧酒	魔法少女
+魔理沙は大変なものを盗んでいきました	魔理沙は大变なものを盗んでいきました	魔理沙偷走了重要的东西	魔理沙大便	魔理沙大变	123	123123	大盗魔理沙	魔理沙	魔理沙偷走重要的东西	魔理沙大变态	魔理沙大变盗	魔理沙痴
+鼓動	鼓动	别急22	咕咚	如龙3	如龙维新	星召大惊讶	鼓励
+＊ハロー、プラネット。	hello planet	你好，行星	＊你好，星球。	dx你好星球	你好星球	八口一	标准hello planet	标准你好星球
+ｉｓｏｐｈｏｔｅ	isophote	等照线	iso	vrchat	全角英文	女同10	姛	恋爱裁判2	打字带空格	琪芽	等照度线
+"　"	双押弱虫	口口	如月	如月站台	如月车站	无名歌	无题	月光列车	没名字	没名字的歌	没有名字	空格	空白
+39	dx39	三九	初音未来	标39	标准39	谢谢
+ATLAS RUSH	rice	米饭	🍚
+Fraq	fq
+HAGAKIRI	hgkr	健身环	光圈科技	八云紫拿着乾坤圈	憋憋	橘花	牛顿环	老妹环
+IF:U	ifu	如果:并集	如果:电压	如果:铀	如果你	如果电压	如果：电压	妈宝蓝2	欧美定律
+KHYMΞXΛ	khym	khymexa	khym三xa	kop5预选	大奇美拉	奇美拉	奇美拉2
+PinqPiq (xovevox Remix)	pinq	pinqpiq	粉猪
+QuiQ	qq	上早八	哈基q	堵门起晚了	快克	早八	早八迟到	牛奶猫迟到	白猫良弹	睡觉	赫拉3
+UniTas	吉他女神	吉他姐	吉他神	有你他死	油腻汰渍	电吉他
+VeRForTe αRtE:VEiN	verforte	vft	十块钱	大钟	大钟楼	钟楼
+YKWTD	游客玩特大
+ZIGG-ZAGG	zigg	zigg zagg
+再会	see you again	码头
+前前前世	上上上辈子	你的名字	推荐乐曲排行榜	韦一敏
+匿名M	请不要人肉我哦
+地球	dq	奶龙	神曲	立秋发癫	立秋窜稀	🌍
+宙天	肘天
+月面基地	月抛基地
+深海少女	dx深海少女	初音未来跳海2	水神4	水神5	深海和少女相比	深海邵壮	深海魔男	溺水双马尾	胖猫2
+田中	tanaka
+神威	太湖之光
+竹	take	ta↓ke↑	↑↓	🎍
+雨露霜雪	四个雨	雨雨雨雨
+麒麟	70	kirin	星召跳劈	淇淋	长颈鹿	骑0	鬣狗	鹿	🦌	🦒


### PR DESCRIPTION
将柚子别名库（[Yuri-YuzuChaN/maimaiDX](https://github.com/Yuri-YuzuChaN/maimaiDX)，MIT）全量合并进 maimai 歌曲别名表。该库由社区投票维护，EasyMai 等查分应用均在使用，覆盖面远大于现有别名表。

## 数据

- 来源：公开接口 `https://www.yuzuchan.moe/api/v2/aliases/maimaidx/aliases`（快照 2026-07-06），共 1356 曲 / 9598 条别名
- 按水鱼曲目 id 对应本地 `SongInfo.json` 标题合并：**新增别名 6688 条**（扩展现有 1156 行、新增 25 行），与现有条目大小写不敏感去重 2898 条
- 仅 2 首国服无此曲（残響散歌、アマカミサマ）跳过

## 合并规则

- 存量行只在行尾追加，不改写、不删除；死行（标题已不在曲库中）原样保留
- 剥离零宽字符、丢弃含制表符/换行的条目
- 首尾为引号或空白的 cell 按现有 TSV 转义惯例以引号包裹（如标题为全角空格的曲目 `"　"`，否则读取时会被 `Trim()` 吞掉）

## 验证

- 按 `SongDb.GetSongAliases` 的读取语义（`Trim` + `UnEscapeTsvCell` + 跳过已删除曲）比对合并前后：存量「别名 → 曲名」映射零丢失，新增映射全部可溯源到柚子库
- `SongDbTest` 与 Mai 系列测试通过（`All_Song_Should_Have_Cover`、`Score_Should_Be_Fetched` 为预存环境失败，与本改动无关）

## 后续问题

柚子库持续更新，静态合并会逐渐过时。是否需要跟进运行时自动同步（maimaiDX 插件的模式：启动/定期拉取接口、本地文件兜底，另有 WebSocket 推送可选）？如需要我再开一个 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
