### PR TITLE
feat(maimai): 排名表列头与两卡脚注精简（曲线排名界面后续）

### DIFF
--- a/Marisa.Frontend/src/components/maimai/MaiCurveRank.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiCurveRank.vue
@@ -11,6 +11,13 @@
             <!-- ── ranking columns（列内从上到下，列间接续） ── -->
             <div class="flex gap-6 mt-6 items-start">
                 <div v-for="(col, ci) in columns" :key="ci" class="flex-1 min-w-0 flex flex-col gap-[6px]">
+                    <div class="rank-head">
+                        <span class="rh-rank">#</span>
+                        <span class="rh-song">曲目</span>
+                        <span class="rh-diff">难度</span>
+                        <span class="rh-ds">定数</span>
+                        <span class="rh-val">{{ valueHead }}</span>
+                    </div>
                     <div v-for="r in col" :key="r.songId + '-' + r.li" class="rank-row">
                         <span class="rr-rank tabular-nums">#{{ r.rank }}</span>
                         <img :src="coverSrcOf(r.songId)" @error="onCoverErr" alt="" class="rr-cover">
@@ -23,12 +30,9 @@
                 </div>
             </div>
 
-            <footer class="mt-5">
-                <div class="foot-note">数据来源：水鱼查分器（diving-fish.com）成绩聚合统计 · {{ legend }}</div>
-                <div class="flex items-baseline justify-between gap-4">
-                    <span class="foot-note">拟合算法与水鱼拟合定数不同</span>
-                    <span class="footer-text shrink-0">MARISA BOT · DIFFICULTY RANKING</span>
-                </div>
+            <footer class="mt-5 flex items-baseline justify-between gap-6">
+                <div class="foot-note min-w-0 whitespace-nowrap">数据来源：水鱼查分器 · {{ legend }}</div>
+                <span class="footer-text shrink-0">MARISA BOT · DIFFICULTY RANKING</span>
             </footer>
     </MaiCardShell>
 
@@ -113,8 +117,9 @@ const heading = computed(() => dsQ.value != null
     ? `定数 ${dsQ.value.toFixed(1)} 拟合难度排名`
     : `等级 ${levelQ.value} 拟合难度排名`)
 const legend = computed(() => isDsKind.value
-    ? '排序依据：综合拟合定数（全体玩家聚合的拟合难度）'
-    : '排序依据：同等级难度百分位（100 = 组内最难）')
+    ? '排序依据：综合拟合定数'
+    : '排序依据：同等级难度百分位')
+const valueHead = computed(() => isDsKind.value ? '拟合定数' : '百分位')
 
 // 列数按体量：>240 三列、>80 两列，卡宽随列数
 const colCount = computed(() => rows.value.length > 240 ? 3 : rows.value.length > 80 ? 2 : 1)
@@ -138,6 +143,14 @@ function onCoverErr(e: Event) {
 <style scoped lang="postcss">
 .rank-title { font-family: 'Microsoft YaHei',sans-serif; font-weight: bold; font-size: 26px; color: #fff; text-shadow: 0 2px 4px rgba(0,0,0,0.5); white-space: nowrap; }
 .count-chip { font-size: 14px; letter-spacing: 0.14em; color: rgba(255,255,255,0.55); white-space: nowrap; }
+
+.rank-head { display: flex; align-items: center; gap: 8px; padding: 0 10px 0 8px; margin-bottom: -2px; }
+.rank-head > span { font-family: 'Torus','Microsoft YaHei',sans-serif; font-weight: bold; font-size: 11px; letter-spacing: 0.05em; color: rgba(255,255,255,0.42); }
+.rh-rank { flex: 0 0 44px; }
+.rh-song { flex: 1 1 auto; min-width: 0; }
+.rh-diff { flex: 0 0 40px; text-align: center; }
+.rh-ds { flex: 0 0 36px; text-align: right; }
+.rh-val { flex: 0 0 50px; text-align: right; white-space: nowrap; }
 
 .rank-row { display: flex; align-items: center; gap: 8px; height: 34px; padding: 0 10px 0 8px; border-radius: 8px; background: rgba(0,0,0,0.30); border: 1px solid rgba(255,255,255,0.08); }
 .rr-rank { flex: 0 0 44px; font-family: 'Torus',sans-serif; font-weight: bold; font-size: 15px; color: rgba(255,255,255,0.6); }

--- a/Marisa.Frontend/src/components/maimai/MaiDifficultyCurve.vue
+++ b/Marisa.Frontend/src/components/maimai/MaiDifficultyCurve.vue
@@ -73,12 +73,9 @@
                 </div>
             </div>
 
-            <footer class="mt-5">
-                <div class="foot-note">数据来源：水鱼查分器（diving-fish.com）成绩聚合统计（n={{ chart.n.toLocaleString() }}）；Rating 轴按活跃玩家口径校准</div>
-                <div class="flex items-baseline justify-between gap-4">
-                    <span class="foot-note">曲线为各段位玩家的拟合难度，算法与水鱼拟合定数不同</span>
-                    <span class="footer-text shrink-0">MARISA BOT · DIFFICULTY CURVE</span>
-                </div>
+            <footer class="mt-5 flex items-baseline justify-between gap-6">
+                <div class="foot-note min-w-0 whitespace-nowrap">数据来源：水鱼查分器</div>
+                <span class="footer-text shrink-0">MARISA BOT · DIFFICULTY CURVE</span>
             </footer>
     </MaiCardShell>
 


### PR DESCRIPTION
`#92` 的界面打磨后续（原分支上晚于合并的三个改动收拢为两个 commit）：

- **排名表列头**：每个列表列顶部加轻量列头（# / 曲目 / 难度 / 定数 / 数值列），数值列在定数与等级视图显示「拟合定数」、低等级百分位视图显示「百分位」，多列排布时各列独立带头。
- **两卡脚注精简为单行**：与品牌字同基线左右分置。曲线卡为「数据来源：水鱼查分器」，排名表为「数据来源：水鱼查分器 · 排序依据：…」；删去的算法差异与 Rating 校准说明保留在数据导出 meta 与 `#92` 说明中。

`npm run build` 通过；三种视图（定数 / 等级 / 百分位）渲染验证通过。

## 预览

| 曲线卡 | 排名表（定数 14.7） |
|---|---|
| ![redemption](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-curve-va-axis/redemption.png) | ![rank147](https://github.com/NakashimaYuki/MarisaBot/releases/download/preview-curve-va-axis/rank_ds147.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
