### PR TITLE
fix(maimai): 适配 maimai-score-hub v1 API，修复 mai 导 404

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -8,10 +8,12 @@ namespace Marisa.Plugin.Shared.MaiMaiDx;
 ///     用于 <c>maimai 导</c> 命令把玩家的华立成绩推到他【本人】的水鱼 / 落雪查分器。
 ///     MSH 官方开放接入（公开 OpenAPI + 全开 CORS）；我们带一个专门的 User-Agent 表明身份。
 ///     契约见 https://github.com/bakapiano/maimai-score-hub/blob/main/shared/openapi/openapi.yaml
+///     2026-07 起 MSH 迁移到 /api/v1 并拆分任务模型：登录任务只负责建立好友关系并下发 JWT，
+///     抓分是独立的 update_score 任务（POST /me/dxnet-jobs），向查分器导出为异步任务需轮询结果。
 /// </summary>
 public class MaiScoreHubClient
 {
-    public const string BaseUrl = "https://maimai.bakapiano.com/api";
+    public const string BaseUrl = "https://maimai.bakapiano.com/api/v1";
 
     private const string UserAgent = "MarisaBot-maimai-sync/1.0 (+https://github.com/QingQiz/MarisaBot)";
 
@@ -26,49 +28,53 @@ public class MaiScoreHubClient
 
     public sealed record LoginStatusResult(bool Done, string Status, string? Stage, string? Token, string? Message, string? BotFriendCode);
 
-    public sealed record ProfileResult(bool HasLxns, bool HasDivingFish, bool AutoLxns, bool AutoDivingFish);
+    public sealed record ProfileResult(bool HasLxns, bool HasDivingFish);
 
     public sealed record ExportResult(bool Success, int Exported, int Scores, string? Message);
 
     public sealed record JobResult(string Status, string? Stage, string? Error);
 
-    /// <summary>POST /auth/login-request — 用好友码发起登录+抓分任务。</summary>
+    private static string? S(JsonElement e, string k) =>
+        e.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    /// <summary>POST /auth/login-requests — 用好友码发起登录任务（Bot 向用户发好友申请）。</summary>
     public async Task<LoginRequestResult> LoginRequestAsync(string friendCode)
     {
-        var json = await Req("/auth/login-request")
-            .PostJsonAsync(new { friendCode, skipUpdateScore = false, useIdleUpdate = false })
+        var json = await Req("/auth/login-requests")
+            .PostJsonAsync(new { friendCode, method = "bot_sends_request" })
             .ReceiveString();
 
         using var doc = JsonDocument.Parse(json);
         var root  = doc.RootElement;
-        var jobId = root.TryGetProperty("jobId", out var j) ? j.GetString() ?? "" : "";
+        var jobId = S(root, "jobId") ?? "";
 
-        string? bot = null;
-        if (root.TryGetProperty("job", out var job) && job.ValueKind == JsonValueKind.Object &&
-            job.TryGetProperty("botUserFriendCode", out var b) && b.ValueKind == JsonValueKind.String)
+        // Bot 好友码可能位于根级（botFriendCode）或嵌套任务对象（botUserFriendCode，任务被
+        // 调度前为空），两处都取
+        var bot = S(root, "botFriendCode");
+        if (bot == null && root.TryGetProperty("job", out var job) && job.ValueKind == JsonValueKind.Object)
         {
-            bot = b.GetString();
+            bot = S(job, "botUserFriendCode");
         }
 
-        var authToken = root.TryGetProperty("authToken", out var a) && a.ValueKind == JsonValueKind.String ? a.GetString() : null;
-        var msg = root.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String ? m.GetString() : null;
-        return new LoginRequestResult(jobId, bot, authToken, msg);
+        var authToken = S(root, "authToken") ?? S(root, "token");
+        return new LoginRequestResult(jobId, bot, authToken, S(root, "message"));
     }
 
-    /// <summary>GET /auth/login-status?jobId= — 轮询任务，完成时附带 JWT。</summary>
+    /// <summary>
+    ///     GET /auth/login-requests/{jobId} — 轮询登录任务。好友关系确认（status 变为
+    ///     completed）时响应为根级 {status, token, user}；进行中为 {status, job}，
+    ///     stage / 失败原因 / Bot 好友码位于嵌套的 job 对象。
+    /// </summary>
     public async Task<LoginStatusResult> LoginStatusAsync(string jobId)
     {
-        var json = await Req("/auth/login-status").SetQueryParam("jobId", jobId).GetStringAsync();
+        var json = await Req($"/auth/login-requests/{jobId}").GetStringAsync();
 
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        string? S(JsonElement e, string k) => e.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
-
         var status = S(root, "status") ?? "";
         var token  = S(root, "token");
 
-        // 实测 stage / 失败原因 / 机器人好友码均位于嵌套的 job 对象中（根级没有这些字段；完成时 job 整体缺失）
         string? stage = null, error = null, botFriendCode = null;
         if (root.TryGetProperty("job", out var job) && job.ValueKind == JsonValueKind.Object)
         {
@@ -77,82 +83,155 @@ public class MaiScoreHubClient
             botFriendCode = S(job, "botUserFriendCode");
         }
 
-        // token 在 update_score（抓分进行中）阶段就会随响应下发，不能作为完成依据：
-        // 抓分记录要等 status 变为 completed 之后才创建，过早导出会报 Sync not found（首次使用必现）
-        var done = status == "completed";
+        var done = status == "completed" || !string.IsNullOrEmpty(token);
 
         return new LoginStatusResult(done, status, stage, token, error ?? S(root, "message"), botFriendCode);
     }
 
     /// <summary>
-    ///     GET /job/{jobId} — 轻量的任务状态查询（无需鉴权）。
-    ///     login-status 在抓分期间每次调用都伴随数据库写入与 JWT 签发，持续轮询会撞上服务端长时间停滞；
-    ///     MSH 自家前端跟踪抓分进度用的就是本接口。
+    ///     POST /me/dxnet-jobs（Bearer）— 创建抓分任务。登录任务不再包含抓分，须在好友关系
+    ///     确认后单独创建；friendshipJobId 传刚完成的登录任务号作为好友关系凭证，服务端可
+    ///     立即开始抓分而无需等待 Bot 好友列表快照刷新。
     /// </summary>
-    public async Task<JobResult> GetJobAsync(string jobId)
+    public async Task<string> CreateUpdateScoreJobAsync(string jwt, string friendshipJobId)
     {
-        var json = await Req($"/job/{jobId}").GetStringAsync();
+        var resp = await Authed("/me/dxnet-jobs", jwt)
+            .AllowHttpStatus("400-499")
+            .PostJsonAsync(new { jobType = "update_score", friendshipJobId });
+
+        var json = await resp.GetStringAsync();
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (resp.StatusCode >= 400)
+        {
+            throw new InvalidOperationException(S(root, "message") ?? S(root, "error") ?? $"HTTP {resp.StatusCode}");
+        }
+
+        var jobId = S(root, "jobId");
+        if (string.IsNullOrEmpty(jobId)) throw new InvalidOperationException("创建抓分任务失败（响应中无任务号）");
+        return jobId!;
+    }
+
+    /// <summary>GET /me/dxnet-jobs/{jobId}（Bearer）— 查询抓分任务状态。</summary>
+    public async Task<JobResult> GetJobAsync(string jwt, string jobId)
+    {
+        var json = await Authed($"/me/dxnet-jobs/{jobId}", jwt).GetStringAsync();
 
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        string? S(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
-
-        return new JobResult(S("status") ?? "", S("stage"), S("error"));
+        return new JobResult(S(root, "status") ?? "", S(root, "stage"), S(root, "error"));
     }
 
-    /// <summary>GET /users/profile（Bearer）— 看 MSH 里已配置了哪些查分器令牌。</summary>
+    /// <summary>GET /me（Bearer）— 看 MSH 里已配置了哪些查分器令牌。</summary>
     public async Task<ProfileResult> GetProfileAsync(string jwt)
     {
-        var json = await Authed("/users/profile", jwt).GetStringAsync();
+        var json = await Authed("/me", jwt).GetStringAsync();
 
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
         bool B(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.True;
 
-        return new ProfileResult(B("hasLxnsImportToken"), B("hasDivingFishImportToken"), B("autoExportLxns"), B("autoExportDivingFish"));
+        return new ProfileResult(B("hasLxnsImportToken"), B("hasDivingFishImportToken"));
     }
 
-    /// <summary>PATCH /users/profile（Bearer）— 设置某查分器导入令牌并开启自动导出。</summary>
+    /// <summary>
+    ///     PATCH /me（Bearer）— 设置某查分器的导入令牌。抓分完成后向已配置令牌的查分器
+    ///     推送由本客户端显式触发；不改动 autoUpdate（那是 MSH 的定时自动更新开关，
+    ///     是否开启应由用户在网站上自行决定）。
+    /// </summary>
     public async Task SetTokenAsync(string jwt, string prober, string token)
     {
         object body = prober == "lxns"
-            ? new { lxnsImportToken = token, autoExportLxns = true }
-            : new { divingFishImportToken = token, autoExportDivingFish = true };
+            ? new { lxnsImportToken = token }
+            : new { divingFishImportToken = token };
 
-        await Authed("/users/profile", jwt).PatchJsonAsync(body);
+        await Authed("/me", jwt).PatchJsonAsync(body);
     }
 
-    /// <summary>POST /sync/latest/{prober}（Bearer）— 把抓到的成绩推到用户自己的查分器。</summary>
+    /// <summary>
+    ///     POST /me/sync/latest/exports/{prober}（Bearer）— 把抓到的成绩推到用户自己的查分器。
+    ///     导出已改为异步任务：创建后轮询 GET /me/sync/prober-export-jobs/{id} 直至终态，
+    ///     单查分器的回执位于任务 result 的对应字段（divingFish / lxns）。
+    /// </summary>
     public async Task<ExportResult> ExportAsync(string jwt, string prober)
     {
-        var path = prober == "lxns" ? "/sync/latest/lxns" : "/sync/latest/diving-fish";
+        var path = prober == "lxns" ? "/me/sync/latest/exports/lxns" : "/me/sync/latest/exports/diving-fish";
 
-        var json = await Authed(path, jwt)
+        var resp = await Authed(path, jwt)
             .AllowHttpStatus("400-499")
-            .PostJsonAsync(new { })
-            .ReceiveString();
+            .PostJsonAsync(new { });
 
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
+        var json = await resp.GetStringAsync();
 
-        int I(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var n) ? n : 0;
-
-        // 实测返回（HTTP 201）无顶层 success 字段：{"status":200,"scores":N,"exported":N,"response":{...}}
-        var success = root.TryGetProperty("status", out var s) && s.ValueKind == JsonValueKind.Number &&
-                      s.TryGetInt32(out var code) && code == 200;
-
-        // 查分器的回执位于嵌套的 response 对象中（水鱼为 message="更新成功"，落雪仅有 success 标志）；出错时回退到顶层 message
-        string? msg = null;
-        if (root.TryGetProperty("response", out var resp) && resp.ValueKind == JsonValueKind.Object &&
-            resp.TryGetProperty("message", out var rm) && rm.ValueKind == JsonValueKind.String)
+        if (resp.StatusCode >= 400)
         {
-            msg = rm.GetString();
+            using var err = JsonDocument.Parse(json);
+            return new ExportResult(false, 0, 0, S(err.RootElement, "message") ?? S(err.RootElement, "error") ?? $"HTTP {resp.StatusCode}");
         }
 
-        msg ??= root.TryGetProperty("message", out var m) && m.ValueKind == JsonValueKind.String ? m.GetString() : null;
+        string exportJobId;
+        {
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+            if (TryParseExportJob(root, prober, out var immediate)) return immediate;
+            exportJobId = S(root, "exportJobId") ?? "";
+        }
 
-        return new ExportResult(success, I("exported"), I("scores"), msg);
+        if (exportJobId.Length == 0) return new ExportResult(false, 0, 0, "创建导出任务失败（响应中无任务号）");
+
+        // 队列繁忙时导出任务需要排队，容忍偶发的查询失败，最长等待 5 分钟
+        var deadline = DateTime.UtcNow.AddMinutes(5);
+        var failures = 0;
+        while (DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(3000);
+
+            string body;
+            try
+            {
+                body     = await Authed($"/me/sync/prober-export-jobs/{exportJobId}", jwt).GetStringAsync();
+                failures = 0;
+            }
+            catch
+            {
+                if (++failures >= 6) return new ExportResult(false, 0, 0, "查询导出任务状态失败");
+                continue;
+            }
+
+            using var doc = JsonDocument.Parse(body);
+            if (TryParseExportJob(doc.RootElement, prober, out var result)) return result;
+        }
+
+        return new ExportResult(false, 0, 0, "导出任务等待超时");
+    }
+
+    /// <summary>任务达到终态时解析对应查分器的回执；job 既可能是响应根级也可能嵌套于 job 字段。</summary>
+    private static bool TryParseExportJob(JsonElement root, string prober, out ExportResult result)
+    {
+        var job = root.TryGetProperty("job", out var j) && j.ValueKind == JsonValueKind.Object ? j : root;
+
+        var status = S(job, "status") ?? S(root, "status") ?? "";
+        if (status is not ("completed" or "partial_failed" or "failed" or "skipped"))
+        {
+            result = default!;
+            return false;
+        }
+
+        var key = prober == "lxns" ? "lxns" : "divingFish";
+        if (job.TryGetProperty("result", out var r) && r.ValueKind == JsonValueKind.Object &&
+            r.TryGetProperty(key, out var pr) && pr.ValueKind == JsonValueKind.Object)
+        {
+            int I(string k) => pr.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var n) ? n : 0;
+
+            var ok = S(pr, "status") == "success";
+            result = new ExportResult(ok, I("exported"), I("scores"), S(pr, "message"));
+            return true;
+        }
+
+        result = new ExportResult(status == "completed", 0, 0, S(job, "error") ?? status);
+        return true;
     }
 }

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -423,11 +423,10 @@ public partial class MaiMaiDx
             announced = true;
         }
 
-        // 第一阶段：轮询 login-status 等 JWT 下发，直到拿到 token / 失败 / 超时。
+        // 第一阶段：轮询登录任务等 JWT 下发，直到拿到 token / 失败 / 超时。
         // MSH 繁忙时 send_request 阶段排队可达数分钟，故总超时放宽到 15 分钟。
-        // 注意只轮询到拿到 token 为止：login-status 在抓分（update_score）期间每次调用都伴随
-        // 数据库写入与 JWT 签发，持续轮询会撞上服务端 30 秒以上的响应停滞（实测连续超时），
-        // MSH 自家前端同样在拿到 token 后就不再调用该接口
+        // 新版任务模型中登录任务只负责建立好友关系，JWT 在好友关系确认（任务 completed）时下发，
+        // 抓分由第二阶段单独创建的 update_score 任务完成
         MaiScoreHubClient.LoginStatusResult? status = null;
         var waitStart      = DateTime.UtcNow;
         var deadline       = waitStart.AddMinutes(15);
@@ -485,7 +484,7 @@ public partial class MaiMaiDx
             return;
         }
 
-        // 实测 JWT 在 update_score（抓分开始）阶段即随 login-status 下发；login-request 的 authToken 仅作回退
+        // JWT 随登录任务完成（好友关系确认）下发；创建登录任务时的 authToken 仅作回退
         var jwt = !string.IsNullOrEmpty(status.Token) ? status.Token! : login.AuthToken;
         if (string.IsNullOrEmpty(jwt))
         {
@@ -501,52 +500,58 @@ public partial class MaiMaiDx
             retryHint = "重试「mai 导」即可。"; // 令牌已存入 MSH，后续失败无需再带令牌重发
         }
 
-        // 第二阶段：抓分仍在进行则改用轻量的 GET /job/{id} 等任务完成——
-        // 抓分记录在 status 变为 completed 之后才落库，过早导出会推送旧记录或报 Sync not found
-        if (!status.Done)
+        // 第二阶段：创建独立的抓分任务并等待完成。登录任务不再包含抓分，把登录任务号作为
+        // 好友关系凭证传入可立即开始抓分。抓分阶段单独计时：第一阶段需等待好友申请送达并被
+        // 接受，繁忙时可能已耗去大部分时间，共用截止时间会使抓分预算所剩无几
+        string crawlJobId;
+        try
         {
-            // 抓分阶段单独计时：第一阶段需等待好友申请送达并被接受，MSH 机器人账号繁忙时好友申请
-            // 的发出会排队数分钟，可能已耗去第一阶段的大部分时间；若与抓分共用同一截止时间，抓分等待
-            // 会因预算所剩无几而超时。此处好友申请已被接受，仅需等待服务端抓分（其自带 30 分钟硬上限）
-            deadline = DateTime.UtcNow.AddMinutes(20);
-            var crawlStart = DateTime.UtcNow;
+            crawlJobId = await msh.CreateUpdateScoreJobAsync(jwt, login.JobId);
+        }
+        catch (Exception e)
+        {
+            ReplyAt(message, $"同步失败：创建抓分任务未成功（{e.Message}）。{retryHint}");
+            return;
+        }
 
-            var crawlDone = false;
-            while (DateTime.UtcNow < deadline)
+        deadline = DateTime.UtcNow.AddMinutes(20);
+        var crawlStart = DateTime.UtcNow;
+
+        var crawlDone = false;
+        while (DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(PollDelayMs(DateTime.UtcNow - crawlStart));
+
+            MaiScoreHubClient.JobResult job;
+            try
             {
-                await Task.Delay(PollDelayMs(DateTime.UtcNow - crawlStart));
-
-                MaiScoreHubClient.JobResult job;
-                try
-                {
-                    job          = await msh.GetJobAsync(login.JobId);
-                    pollFailures = 0;
-                }
-                catch (Exception e)
-                {
-                    if (++pollFailures < 6) continue;
-                    ReplyAt(message, $"同步中断：连续多次查询任务状态失败（{e.Message}）。稍后{retryHint}");
-                    return;
-                }
-
-                if (job.Status == "completed")
-                {
-                    crawlDone = true;
-                    break;
-                }
-
-                if (job.Status is "failed" or "canceled")
-                {
-                    ReplyAt(message, $"同步失败：{job.Error ?? job.Status}。{retryHint}");
-                    return;
-                }
+                job          = await msh.GetJobAsync(jwt, crawlJobId);
+                pollFailures = 0;
             }
-
-            if (!crawlDone)
+            catch (Exception e)
             {
-                ReplyAt(message, $"等待超时（服务繁忙，成绩抓取未在限定时间内完成）。稍后{retryHint}");
+                if (++pollFailures < 6) continue;
+                ReplyAt(message, $"同步中断：连续多次查询任务状态失败（{e.Message}）。稍后{retryHint}");
                 return;
             }
+
+            if (job.Status == "completed")
+            {
+                crawlDone = true;
+                break;
+            }
+
+            if (job.Status is "failed" or "canceled")
+            {
+                ReplyAt(message, $"同步失败：{job.Error ?? job.Status}。{retryHint}");
+                return;
+            }
+        }
+
+        if (!crawlDone)
+        {
+            ReplyAt(message, $"等待超时（服务繁忙，成绩抓取未在限定时间内完成）。稍后{retryHint}");
+            return;
         }
 
         // 查询 MSH 中已配置的查分器
@@ -568,14 +573,8 @@ public partial class MaiMaiDx
             var name = p == "lxns" ? "落雪" : "水鱼";
             try
             {
+                // 导出为异步任务，ExportAsync 内部轮询至终态后返回该查分器的回执
                 var r = await msh.ExportAsync(jwt, p);
-
-                // 抓分记录在任务 completed 之后才异步落库，导出可能恰好跑在落库之前，稍候重试
-                for (var retry = 0; retry < 5 && !r.Success && r.Message == "Sync not found"; retry++)
-                {
-                    await Task.Delay(3000);
-                    r = await msh.ExportAsync(jwt, p);
-                }
 
                 sb.AppendLine(r.Success ? $"{name} ✅ 导入 {r.Exported}/{r.Scores} 条" : $"{name} ❌ {r.Message ?? "失败"}");
             }


### PR DESCRIPTION
修复 `mai 导` 必现的 404：上游 maimai-score-hub（MSH）近期整体迁移到 `/api/v1` 并重构了任务模型，我们此前对接的接口已全部下线。

## 根因

`POST /api/auth/login-request` 已不存在（路由级 404）。对照 MSH 仓库的 shared 契约（ts-rest + zod）与后端实现，变化有四处：

1. **路由前缀与形态**：全局前缀 `/api` → `/api/v1`；登录接口 REST 化为 `POST /auth/login-requests` + `GET /auth/login-requests/{jobId}`，请求体新增必填 `method` 字段（本命令使用 `bot_sends_request`，即 Bot 向用户发好友申请）。
2. **登录与抓分拆分**：登录任务只负责建立好友关系，JWT 在好友关系确认时下发；抓分需拿到 JWT 后单独创建 `update_score` 任务（`POST /me/dxnet-jobs`），把登录任务号作为好友关系凭证传入可立即开始，无需等待 Bot 好友列表快照刷新。
3. **用户资料**：`/users/profile` → `/me`；`autoExportLxns` / `autoExportDivingFish` 字段已被移除，设置令牌不再附带自动导出开关（MSH 新增的 `autoUpdate` 是定时自动更新，语义不同，不代用户开启）。
4. **导出异步化**：`POST /sync/latest/{prober}` → `POST /me/sync/latest/exports/{prober}`，返回导出任务号，需轮询 `GET /me/sync/prober-export-jobs/{id}` 至终态，回执位于任务 `result` 的对应查分器字段。旧的 Sync not found 竞态重试随原同步接口一并移除。

命令的用户侧流程与文案不变（发起 → 同意好友申请 → 抓分 → 推送）。

## 验证

- 新路由已逐一在线探通：空请求体返回 400 且精确回显 `friendCode` / `method` 必填；`/me` 系列无令牌返回 401；旧路由确认为路由级 404
- `dotnet build` 通过；Mai 测试 343 过（`All_Song_Should_Have_Cover`、`Score_Should_Be_Fetched` 为预存环境失败，与本改动无关）
- **完整链路已用真实账号实测通过**（直接驱动本 PR 的客户端代码）：发起登录 → `wait_acceptance`（Bot 好友码自嵌套任务对象正确解析）→ 游戏内同意后任务 `completed` 且 JWT 随响应下发 → 以登录任务号为凭证创建抓分任务并即时开始 → 约 1 分钟抓分完成 → 服务端存量令牌识别正常 → 异步导出轮询至终态，**落雪与水鱼均成功导入 2177/2177 条**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
