### PR TITLE
fix(maimai): 真代真实存在的牌子完成表排除ジングルベル(SD)

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -291,6 +291,18 @@ public static class PlateData
     public static bool IsRevivalSong(long songId) => RevivalSongIds.Contains(songId);
 
     /// <summary>
+    ///     ジングルベル(SD, 70)出身是圣诞期间限定（ORANGE PLUS 起才常驻），游戏内三个真牌
+    ///     （真極/真神/真舞舞）的条件历来不含它；舞/霸者则计入。仅当查询就是显示真实牌子的
+    ///     真代完成表（<see cref="NamePlateImage"/> 命中）时整曲排除。
+    /// </summary>
+    private const long JingleBellSdSongId = 70;
+
+    public static bool IsPlateExcludedSong(Query query, MaiMaiSong song) =>
+        song.Id == JingleBellSdSongId
+        && query.Selectors is [Selector.Plate { Kanji: "真" }]
+        && NamePlateImage(query) != null;
+
+    /// <summary>
     ///     代字 → diving-fish 版本字符串集合。
     ///     繁简体差异（暁/晓 櫻/樱 菫/堇 輝/辉 華/华 鏡/镜）双向都收录指向同一个版本集合。
     ///     真：两个 from 字段都查（旧版 PLUS 在 diving-fish 是独立条目）。

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -1268,6 +1268,36 @@ public class MaiMaiDxPlateDataTest
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // ジングルベル(SD, 70)：圣诞期间限定出身，游戏内三个真牌（真極/真神/真舞舞）的
+    // 条件历来不含它；真将不存在、舞/霸者与其余查询照常计入。
+    // ──────────────────────────────────────────────────────────────────────
+
+    [TestCase("真极完成表")]
+    [TestCase("真神完成表")]
+    [TestCase("真舞舞完成表")]
+    [TestCase("真极红谱完成表")]  // 显示牌子的难度子视图同样排除
+    public void JingleBellExcludedFromRealShinPlates(string raw)
+    {
+        Assert.That(PlateData.IsPlateExcludedSong(MustParse(raw), CreateSong(70, "maimai")), Is.True);
+    }
+
+    [TestCase("真将完成表")]   // 真将不是真实存在的牌子
+    [TestCase("真完成表")]     // 默认阈值=将
+    [TestCase("舞极完成表")]   // 舞系计入
+    [TestCase("舞舞舞完成表")]
+    [TestCase("霸者完成表")]
+    public void JingleBellKeptOutsideRealShinPlates(string raw)
+    {
+        Assert.That(PlateData.IsPlateExcludedSong(MustParse(raw), CreateSong(70, "maimai")), Is.False);
+    }
+
+    [Test]
+    public void ShinPlateExclusionOnlyTargetsJingleBell()
+    {
+        Assert.That(PlateData.IsPlateExcludedSong(MustParse("真极完成表"), CreateSong(17, "maimai")), Is.False);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // 难度别名剥离（curve 等按曲命令的可选难度字段，句首/句尾均可、空格可省略）。
     // 纯语法层测试：「白金ディスコ」这类以色字开头的真实歌名由调用方保护——handler
     // 整串优先搜歌，仅无结果时才用剥离结果重搜。

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -1343,6 +1343,7 @@ public partial class MaiMaiDx
                 .SelectMany(song => song.Constants.Select((constant, i) => (constant, i, song)))
                 .Where(t => levelIdxes.Contains(t.i))
                 .Where(t => q.Selectors.All(sel => MatchSelector(sel, t.constant, t.i, t.song, includeRevival)))
+                .Where(t => !PlateData.IsPlateExcludedSong(q, t.song))
                 .Select(t => (t.constant, t.i, t.song))
                 .ToList();
         }


### PR DESCRIPTION
ジングルベル(SD, id 70) 出身是圣诞期间限定（12/23-12/25 三天，ORANGE PLUS 起才常驻），游戏内三个真牌（真極/真神/真舞舞）的条件历来不含它（[考据](https://yonedu2629.hatenablog.com/entry/2023/12/24/155130)：「真プレートの条件にジングルベルが入っていないのはこの名残」）；舞/霸者的对象曲则包含它。此前完成表把它计入了真代所有表。

## 修法

新增 `PlateData.IsPlateExcludedSong(query, song)`：仅当查询就是**显示真实存在牌子**的真代完成表（`NamePlateImage` 命中 = 单一「真」代字 + 極/神/舞舞 阈值，含其难度子视图）时整曲排除 id 70。

不受影响、照常计入的查询：真将（游戏内无此牌）、「真完成表」默认阈值（将）、真+谱师/类别等组合查询、舞/霸者（游戏内这些牌子确实要求它）。DX 谱（id 10070，FESTiVAL）本就不在真代范围。

## 验证

- 新增 10 条测试（排除面 4 + 保留面 5 + 仅针对 id 70）；
- `--filter FullyQualifiedName~PlateData` 298/298 过；`~Mai` 353 过 / 2 失败为预存环境项（All_Song_Should_Have_Cover、Score_Should_Be_Fetched）。

*本 PR 的代码与文案由 Claude Fable 5 撰写。*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

