### PR TITLE
fix(chunithm): GetScores OAuth 移除 level_index 硬过滤 + DeletedSongs 新增

### DIFF
--- a/Marisa.Plugin.Shared/Chunithm/DataFetcher/DataFetcher.cs
+++ b/Marisa.Plugin.Shared/Chunithm/DataFetcher/DataFetcher.cs
@@ -12,7 +12,7 @@ public abstract class DataFetcher(SongDb<ChunithmSong> songDb)
     protected static readonly HashSet<long> DeletedSongs =
     [
         156, 343, 1046, 1049, 1050, 1051, 1054, 2007, 2008, 2014, 2016, 2020, 2021,
-        2027, 2039, 2075, 2076, 2095, 2141, 2211, 2212, 2213
+        2027, 2039, 2075, 2076, 2095, 2141, 2211, 2212, 2213, 921
     ];
 
     protected SongDb<ChunithmSong> SongDb { get; } = songDb;

--- a/Marisa.Plugin.Shared/Chunithm/DataFetcher/LxnsDataFetcher.cs
+++ b/Marisa.Plugin.Shared/Chunithm/DataFetcher/LxnsDataFetcher.cs
@@ -147,8 +147,7 @@ public class LxnsDataFetcher(SongDb<ChunithmSong> songDb) : DataFetcher(songDb),
         foreach (var s in root.EnumerateArray())
         {
             var lvlIdx = s.TryGetProperty("level_index", out var li) ? li.GetInt32() : -1;
-            // 只收 MASTER / ULTIMA
-            if (lvlIdx != 3 && lvlIdx != 4) continue;
+            if (lvlIdx < 0) continue;
 
             var score = new ChunithmScore
             {


### PR DESCRIPTION
### 1. GetScores 移除 level_index 硬过滤

`LxnsDataFetcher.GetScoresViaOAuth()` 中硬编码了 `if (lvlIdx != 3 && lvlIdx != 4) continue;`，导致 `sum lv` 等指令拿不到 EXPERT 及以下难度的成绩。

**修复**：移除抓取层的 level_index 过滤。MASTER/ULTIMA 筛选由 Vue 层负责（`OpLevel.vue` / `OpBase.vue` 的 `shouldSkip`）。

### 2. DeletedSongs 新增 921

补充已从游戏删除的曲目 ID `921`，避免 OP 和 Rating 计算计入已删除曲目导致的偏差。

---

| 文件 | 说明 |
|------|------|
| `LxnsDataFetcher.cs` | 移除 GetScoresViaOAuth 的 level_index 硬过滤 |
| `DataFetcher.cs` | DeletedSongs 列表追加 921（6月新删的融城噩梦） |
