### PR TITLE
fix(maimai): MSH 迁移域名致 mai 导必现 Missing bearer token

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -13,7 +13,10 @@ namespace Marisa.Plugin.Shared.MaiMaiDx;
 /// </summary>
 public class MaiScoreHubClient
 {
-    public const string BaseUrl = "https://maimai.bakapiano.com/api/v1";
+    // 2026-07 中旬 MSH 迁移域名：旧域名 maimai.bakapiano.com 对全部路径返回 308 跳转，
+    // 而 HttpClient 跨主机重定向时按安全惯例剥除 Authorization 头，导致所有带 Bearer 的
+    // 调用在旧域名下必现 Missing bearer token，故必须直连新域名
+    public const string BaseUrl = "https://maiscorehub.bakapiano.com/api/v1";
 
     private const string UserAgent = "MarisaBot-maimai-sync/1.0 (+https://github.com/QingQiz/MarisaBot)";
 


### PR DESCRIPTION
## 问题

近两日所有用户执行 `mai 导` 均失败：「同步失败：创建抓分任务未成功（Missing bearer token）」（本地用户报告）。

## 根因

MSH 于 2026-07 中旬把 API 域名从 `maimai.bakapiano.com` 迁移到 `maiscorehub.bakapiano.com`，旧域名对全部路径返回 308 跳转（实测 `curl -w "%{http_code} %{redirect_url}"` 全路径 308）。

HttpClient 跨主机跟随重定向时按安全惯例剥除 Authorization 头（浏览器同源请求不受此限，故 MSH 自家前端一切正常）。于是：

- 未认证的登录/好友申请流程经跳转照常走通——用户能一路走到抓分阶段；
- 第一个携带 Bearer 的调用（创建抓分任务 `POST /me/dxnet-jobs`）到达新主机时已无凭据，服务端守卫回 `Missing bearer token`——与报错文案、发生位置、波及所有用户三点完全吻合（守卫源码中该文案仅在 Authorization 头缺失时抛出，token 无效是另一条 `Invalid or expired token`）。

## 修复

`MaiScoreHubClient.BaseUrl` 直连新域名，一行改动（含注释说明迁移背景）。

## 验证

- 新域名直连、坏 token 经客户端 `Authed()` 路径实测返回 `Invalid or expired token`——Authorization 头送达，原故障点反转；登录接口参数校验回显正常。
- 仓库内旧域名引用仅此一处（已全局检索）。
- 构建通过；Mai 过滤测试 343 过 / 2 预存环境败 / 1 跳过，与 master 基线逐一一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)