### PR TITLE
fix(maimai): 适配 MSH DXNet 任务截止与好友申请状态

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -4,12 +4,7 @@ using Flurl.Http;
 namespace Marisa.Plugin.Shared.MaiMaiDx;
 
 /// <summary>
-///     bakapiano 的 maimai-score-hub (MSH) 公开 API 的轻量客户端。
-///     用于 <c>maimai 导</c> 命令把玩家的华立成绩推到他【本人】的水鱼 / 落雪查分器。
-///     MSH 官方开放接入（公开 OpenAPI + 全开 CORS）；我们带一个专门的 User-Agent 表明身份。
-///     契约见 https://github.com/bakapiano/maimai-score-hub/blob/main/shared/openapi/openapi.yaml
-///     2026-07 起 MSH 迁移到 /api/v1 并拆分任务模型：登录任务只负责建立好友关系并下发 JWT，
-///     抓分是独立的 update_score 任务（POST /me/dxnet-jobs），向查分器导出为异步任务需轮询结果。
+///     通过 maimai-score-hub 创建 DXNet 抓分任务，并将结果导出到用户配置的查分器。
 /// </summary>
 public class MaiScoreHubClient
 {

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -10,8 +10,6 @@ namespace Marisa.Plugin.Shared.MaiMaiDx;
 ///     契约见 https://github.com/bakapiano/maimai-score-hub/blob/main/shared/openapi/openapi.yaml
 ///     2026-07 起 MSH 迁移到 /api/v1 并拆分任务模型：登录任务只负责建立好友关系并下发 JWT，
 ///     抓分是独立的 update_score 任务（POST /me/dxnet-jobs），向查分器导出为异步任务需轮询结果。
-///     2026-08 routing v2 会在任务创建时先分配 Bot；只有 friendRequestSentAt 或 wait_acceptance
-///     才表示好友申请已经实际发出。
 /// </summary>
 public class MaiScoreHubClient
 {

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -10,6 +10,8 @@ namespace Marisa.Plugin.Shared.MaiMaiDx;
 ///     契约见 https://github.com/bakapiano/maimai-score-hub/blob/main/shared/openapi/openapi.yaml
 ///     2026-07 起 MSH 迁移到 /api/v1 并拆分任务模型：登录任务只负责建立好友关系并下发 JWT，
 ///     抓分是独立的 update_score 任务（POST /me/dxnet-jobs），向查分器导出为异步任务需轮询结果。
+///     2026-08 routing v2 会在任务创建时先分配 Bot；只有 friendRequestSentAt 或 wait_acceptance
+///     才表示好友申请已经实际发出。
 /// </summary>
 public class MaiScoreHubClient
 {
@@ -27,18 +29,58 @@ public class MaiScoreHubClient
     private static IFlurlRequest Authed(string path, string jwt) => Req(path)
         .WithHeader("Authorization", "Bearer " + jwt);
 
-    public sealed record LoginRequestResult(string JobId, string? BotFriendCode, string? AuthToken, string? Message);
+    public sealed record LoginRequestResult(
+        string JobId,
+        string? BotFriendCode,
+        string? AuthToken,
+        string? Message,
+        string? Stage,
+        string? FriendRequestSentAt,
+        string? ErrorCode,
+        DateTimeOffset? DeadlineAt)
+    {
+        public bool FriendRequestSent =>
+            !string.IsNullOrEmpty(FriendRequestSentAt) || Stage == "wait_acceptance";
+    }
 
-    public sealed record LoginStatusResult(bool Done, string Status, string? Stage, string? Token, string? Message, string? BotFriendCode);
+    public sealed record LoginStatusResult(
+        bool Done,
+        string Status,
+        string? Stage,
+        string? Token,
+        string? Message,
+        string? BotFriendCode,
+        string? FriendRequestSentAt,
+        string? ErrorCode,
+        DateTimeOffset? DeadlineAt)
+    {
+        public bool FriendRequestSent =>
+            !string.IsNullOrEmpty(FriendRequestSentAt) || Stage == "wait_acceptance";
+
+        public bool DeadlineExceeded => IsDeadlineExceeded(ErrorCode, Message);
+    }
 
     public sealed record ProfileResult(bool HasLxns, bool HasDivingFish);
 
     public sealed record ExportResult(bool Success, int Exported, int Scores, string? Message);
 
-    public sealed record JobResult(string Status, string? Stage, string? Error);
+    public sealed record JobStartResult(string JobId, DateTimeOffset? DeadlineAt);
+
+    public sealed record JobResult(
+        string Status,
+        string? Stage,
+        string? Error,
+        string? ErrorCode,
+        DateTimeOffset? DeadlineAt)
+    {
+        public bool DeadlineExceeded => IsDeadlineExceeded(ErrorCode, Error);
+    }
 
     private static string? S(JsonElement e, string k) =>
         e.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
+
+    private static DateTimeOffset? D(JsonElement e, string k) =>
+        DateTimeOffset.TryParse(S(e, k), out var value) ? value : null;
 
     /// <summary>POST /auth/login-requests — 用好友码发起登录任务（Bot 向用户发好友申请）。</summary>
     public async Task<LoginRequestResult> LoginRequestAsync(string friendCode)
@@ -53,14 +95,28 @@ public class MaiScoreHubClient
 
         // Bot 好友码可能位于根级（botFriendCode）或嵌套任务对象（botUserFriendCode，任务被
         // 调度前为空），两处都取
-        var bot = S(root, "botFriendCode");
-        if (bot == null && root.TryGetProperty("job", out var job) && job.ValueKind == JsonValueKind.Object)
+        JsonElement? job = null;
+        if (root.TryGetProperty("job", out var nestedJob) && nestedJob.ValueKind == JsonValueKind.Object)
         {
-            bot = S(job, "botUserFriendCode");
+            job = nestedJob;
         }
 
+        var bot = S(root, "botFriendCode") ?? (job is { } j ? S(j, "botUserFriendCode") : null);
         var authToken = S(root, "authToken") ?? S(root, "token");
-        return new LoginRequestResult(jobId, bot, authToken, S(root, "message"));
+        var stage = (job is { } stageJob ? S(stageJob, "stage") : null) ?? S(root, "stage");
+        var friendRequestSentAt = (job is { } sentJob ? S(sentJob, "friendRequestSentAt") : null) ??
+                                  S(root, "friendRequestSentAt");
+        var errorCode = (job is { } errorJob ? S(errorJob, "errorCode") : null) ?? S(root, "errorCode");
+        var deadlineAt = (job is { } deadlineJob ? D(deadlineJob, "deadlineAt") : null) ?? D(root, "deadlineAt");
+        return new LoginRequestResult(
+            jobId,
+            bot,
+            authToken,
+            S(root, "message"),
+            stage,
+            friendRequestSentAt,
+            errorCode,
+            deadlineAt);
     }
 
     /// <summary>
@@ -78,17 +134,31 @@ public class MaiScoreHubClient
         var status = S(root, "status") ?? "";
         var token  = S(root, "token");
 
-        string? stage = null, error = null, botFriendCode = null;
+        string? stage = null, error = null, botFriendCode = null, friendRequestSentAt = null;
+        string? errorCode = null;
+        DateTimeOffset? deadlineAt = null;
         if (root.TryGetProperty("job", out var job) && job.ValueKind == JsonValueKind.Object)
         {
             stage         = S(job, "stage");
             error         = S(job, "error");
             botFriendCode = S(job, "botUserFriendCode");
+            friendRequestSentAt = S(job, "friendRequestSentAt");
+            errorCode     = S(job, "errorCode");
+            deadlineAt    = D(job, "deadlineAt");
         }
 
         var done = status == "completed" || !string.IsNullOrEmpty(token);
 
-        return new LoginStatusResult(done, status, stage, token, error ?? S(root, "message"), botFriendCode);
+        return new LoginStatusResult(
+            done,
+            status,
+            stage ?? S(root, "stage"),
+            token,
+            error ?? S(root, "message"),
+            botFriendCode ?? S(root, "botUserFriendCode"),
+            friendRequestSentAt ?? S(root, "friendRequestSentAt"),
+            errorCode ?? S(root, "errorCode"),
+            deadlineAt ?? D(root, "deadlineAt"));
     }
 
     /// <summary>
@@ -96,7 +166,7 @@ public class MaiScoreHubClient
     ///     确认后单独创建；friendshipJobId 传刚完成的登录任务号作为好友关系凭证，服务端可
     ///     立即开始抓分而无需等待 Bot 好友列表快照刷新。
     /// </summary>
-    public async Task<string> CreateUpdateScoreJobAsync(string jwt, string friendshipJobId)
+    public async Task<JobStartResult> CreateUpdateScoreJobAsync(string jwt, string friendshipJobId)
     {
         var resp = await Authed("/me/dxnet-jobs", jwt)
             .AllowHttpStatus("400-499")
@@ -113,7 +183,11 @@ public class MaiScoreHubClient
 
         var jobId = S(root, "jobId");
         if (string.IsNullOrEmpty(jobId)) throw new InvalidOperationException("创建抓分任务失败（响应中无任务号）");
-        return jobId!;
+
+        var deadlineAt = root.TryGetProperty("job", out var job) && job.ValueKind == JsonValueKind.Object
+            ? D(job, "deadlineAt")
+            : D(root, "deadlineAt");
+        return new JobStartResult(jobId!, deadlineAt);
     }
 
     /// <summary>GET /me/dxnet-jobs/{jobId}（Bearer）— 查询抓分任务状态。</summary>
@@ -124,7 +198,12 @@ public class MaiScoreHubClient
         using var doc = JsonDocument.Parse(json);
         var root = doc.RootElement;
 
-        return new JobResult(S(root, "status") ?? "", S(root, "stage"), S(root, "error"));
+        return new JobResult(
+            S(root, "status") ?? "",
+            S(root, "stage"),
+            S(root, "error"),
+            S(root, "errorCode"),
+            D(root, "deadlineAt"));
     }
 
     /// <summary>GET /me（Bearer）— 看 MSH 里已配置了哪些查分器令牌。</summary>
@@ -237,4 +316,7 @@ public class MaiScoreHubClient
         result = new ExportResult(status == "completed", 0, 0, S(job, "error") ?? status);
         return true;
     }
+
+    private static bool IsDeadlineExceeded(string? errorCode, string? error) =>
+        errorCode == "job_deadline_exceeded" || error == "DXNet job deadline exceeded";
 }

--- a/Marisa.Plugin.Test/MaiScoreHubClientTest.cs
+++ b/Marisa.Plugin.Test/MaiScoreHubClientTest.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Threading.Tasks;
+using Flurl.Http.Testing;
+using Marisa.Plugin.Shared.MaiMaiDx;
+using NUnit.Framework;
+
+namespace Marisa.Plugin.Test;
+
+[TestFixture]
+public class MaiScoreHubClientTest
+{
+    private const string FriendCode = "000000000000000";
+    private const string BotFriendCode = "999999999999999";
+
+    [Test]
+    public async Task LoginRequest_AssignedBotBeforeRequestSent_IsNotReportedAsSent()
+    {
+        using var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            jobId = "login-job",
+            job = new
+            {
+                status = "queued",
+                stage = "send_request",
+                botUserFriendCode = BotFriendCode,
+                friendRequestSentAt = (string?)null,
+                deadlineAt = "2026-08-28T04:40:00.000Z"
+            }
+        });
+
+        var result = await new MaiScoreHubClient().LoginRequestAsync(FriendCode);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.BotFriendCode, Is.EqualTo(BotFriendCode));
+            Assert.That(result.FriendRequestSent, Is.False);
+            Assert.That(result.DeadlineAt, Is.EqualTo(DateTimeOffset.Parse("2026-08-28T04:40:00.000Z")));
+        });
+    }
+
+    [Test]
+    public async Task LoginRequest_WaitingForAcceptance_IsReportedAsSent()
+    {
+        using var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            jobId = "login-job",
+            job = new
+            {
+                status = "processing",
+                stage = "wait_acceptance",
+                botUserFriendCode = BotFriendCode,
+                friendRequestSentAt = (string?)null,
+                deadlineAt = "2026-08-28T04:40:00.000Z"
+            }
+        });
+
+        var result = await new MaiScoreHubClient().LoginRequestAsync(FriendCode);
+
+        Assert.That(result.FriendRequestSent, Is.True);
+    }
+
+    [Test]
+    public async Task LoginStatus_DeadlineFailure_IsRecognized()
+    {
+        using var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            status = "failed",
+            job = new
+            {
+                status = "failed",
+                stage = "send_request",
+                error = "DXNet job deadline exceeded",
+                deadlineAt = "2026-08-28T04:40:00.000Z"
+            }
+        });
+
+        var result = await new MaiScoreHubClient().LoginStatusAsync("login-job");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.DeadlineExceeded, Is.True);
+            Assert.That(result.ErrorCode, Is.Null);
+            Assert.That(result.Message, Is.EqualTo("DXNet job deadline exceeded"));
+        });
+    }
+
+    [Test]
+    public async Task CreateUpdateScoreJob_ParsesServerDeadline()
+    {
+        using var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            jobId = "crawl-job",
+            job = new
+            {
+                status = "queued",
+                stage = "update_score",
+                deadlineAt = "2026-08-28T04:55:00.000Z"
+            }
+        }, 201);
+
+        var result = await new MaiScoreHubClient().CreateUpdateScoreJobAsync("jwt", "login-job");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.JobId, Is.EqualTo("crawl-job"));
+            Assert.That(result.DeadlineAt, Is.EqualTo(DateTimeOffset.Parse("2026-08-28T04:55:00.000Z")));
+        });
+    }
+
+    [Test]
+    public async Task DxNetJob_DeadlineFailure_IsRecognized()
+    {
+        using var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            status = "failed",
+            stage = "update_score",
+            error = "DXNet job deadline exceeded",
+            errorCode = "job_deadline_exceeded",
+            deadlineAt = "2026-08-28T04:55:00.000Z"
+        });
+
+        var result = await new MaiScoreHubClient().GetJobAsync("jwt", "crawl-job");
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(result.DeadlineExceeded, Is.True);
+            Assert.That(result.ErrorCode, Is.EqualTo("job_deadline_exceeded"));
+            Assert.That(result.DeadlineAt, Is.EqualTo(DateTimeOffset.Parse("2026-08-28T04:55:00.000Z")));
+        });
+    }
+}

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -364,11 +364,6 @@ public partial class MaiMaiDx
         }
     }
 
-    /// <summary>
-    ///     在后台启动一次完整同步并立即返回。
-    ///     同步需要等待 MSH 调度、用户在游戏内同意好友申请和成绩抓取，可能超过消息处理时限：
-    ///     BotDriver 对每条消息有 10 分钟硬超时，且对话挂起期间会拦截该用户的所有后续消息。
-    /// </summary>
     private static void StartSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
     {
         if (!Syncing.TryAdd(message.Sender.Id, 0))
@@ -423,10 +418,6 @@ public partial class MaiMaiDx
             announced = true;
         }
 
-        // 第一阶段：轮询登录任务等 JWT 下发，直到拿到 token / 失败 / 超时。
-        // routing v2 响应带服务端硬截止时间；旧响应缺失该字段时回退到 15 分钟。
-        // 新版任务模型中登录任务只负责建立好友关系，JWT 在好友关系确认（任务 completed）时下发，
-        // 抓分由第二阶段单独创建的 update_score 任务完成
         MaiScoreHubClient.LoginStatusResult? status = null;
         var waitStart      = DateTime.UtcNow;
         var deadline       = login.DeadlineAt?.UtcDateTime.AddMinutes(1) ?? waitStart.AddMinutes(15);
@@ -444,7 +435,6 @@ public partial class MaiMaiDx
             }
             catch (Exception e)
             {
-                // 容忍偶发的瞬时失败（5xx/超时），连续多次失败才放弃
                 if (++pollFailures < 6) continue;
                 ReplyAt(message, $"同步中断：连续多次查询任务状态失败（{e.Message}）。稍后{retryHint}");
                 return;
@@ -469,7 +459,6 @@ public partial class MaiMaiDx
                 return;
             }
 
-            // routing v2 在创建时就会分配 Bot；只有进入 wait_acceptance 才能确认好友申请已经发出
             if (!announced && status.Stage == "wait_acceptance" && !string.IsNullOrEmpty(status.BotFriendCode))
             {
                 ReplyAt(message, $"Bot 账号（好友码{status.BotFriendCode}）已发出好友申请，请尽快到 NET 同意。若任务随后超时，按提示重试即可。");

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -366,7 +366,7 @@ public partial class MaiMaiDx
 
     /// <summary>
     ///     在后台启动一次完整同步并立即返回。
-    ///     同步需要等待用户在游戏内同意好友申请（最长 10 分钟），不能阻塞消息处理管线：
+    ///     同步需要等待 MSH 调度、用户在游戏内同意好友申请和成绩抓取，可能超过消息处理时限：
     ///     BotDriver 对每条消息有 10 分钟硬超时，且对话挂起期间会拦截该用户的所有后续消息。
     /// </summary>
     private static void StartSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
@@ -417,21 +417,21 @@ public partial class MaiMaiDx
 
         var login = await msh.LoginRequestAsync(friendCode);
         var announced = false;
-        if (!string.IsNullOrEmpty(login.BotFriendCode))
+        if (login.FriendRequestSent && !string.IsNullOrEmpty(login.BotFriendCode))
         {
-            ReplyAt(message, $"Bot 账号（好友码{login.BotFriendCode}）已发出好友申请，请尽快到 NET 同意。服务繁忙时申请可能排队，若超时按提示重试即可。");
+            ReplyAt(message, $"Bot 账号（好友码{login.BotFriendCode}）已发出好友申请，请尽快到 NET 同意。若任务随后超时，按提示重试即可。");
             announced = true;
         }
 
         // 第一阶段：轮询登录任务等 JWT 下发，直到拿到 token / 失败 / 超时。
-        // MSH 繁忙时 send_request 阶段排队可达数分钟，故总超时放宽到 15 分钟。
+        // routing v2 响应带服务端硬截止时间；旧响应缺失该字段时回退到 15 分钟。
         // 新版任务模型中登录任务只负责建立好友关系，JWT 在好友关系确认（任务 completed）时下发，
         // 抓分由第二阶段单独创建的 update_score 任务完成
         MaiScoreHubClient.LoginStatusResult? status = null;
         var waitStart      = DateTime.UtcNow;
-        var deadline       = waitStart.AddMinutes(15);
+        var deadline       = login.DeadlineAt?.UtcDateTime.AddMinutes(1) ?? waitStart.AddMinutes(15);
         var pollFailures   = 0;
-        var sawAcceptance  = false;
+        var sawAcceptance  = login.FriendRequestSent;
         var queuedNotified = false;
         while (DateTime.UtcNow < deadline)
         {
@@ -444,26 +444,35 @@ public partial class MaiMaiDx
             }
             catch (Exception e)
             {
-                // 退避轮询下 15 分钟约 60 次，容忍偶发的瞬时失败（5xx/超时），连续多次失败才放弃
+                // 容忍偶发的瞬时失败（5xx/超时），连续多次失败才放弃
                 if (++pollFailures < 6) continue;
                 ReplyAt(message, $"同步中断：连续多次查询任务状态失败（{e.Message}）。稍后{retryHint}");
                 return;
             }
 
+            if (status.FriendRequestSent) sawAcceptance = true;
+
             if (status.Done || !string.IsNullOrEmpty(status.Token)) break;
 
             if (status.Status is "failed" or "canceled")
             {
-                ReplyAt(message, $"同步失败：{status.Message ?? status.Status}。{retryHint}");
+                if (status.DeadlineExceeded)
+                {
+                    ReplyAt(message, sawAcceptance
+                        ? $"同步失败：MSH 好友验证任务已超过服务端截止时间，好友申请虽已发出，但未能及时确认好友关系。稍后{retryHint}"
+                        : $"同步失败：MSH 未能在服务端截止前发出好友申请（服务排队超时，与你是否同意无关）。稍后{retryHint}");
+                }
+                else
+                {
+                    ReplyAt(message, $"同步失败：{status.Message ?? status.Status}。{retryHint}");
+                }
                 return;
             }
 
-            if (status.Stage == "wait_acceptance") sawAcceptance = true;
-
-            // 实测 botUserFriendCode 仅在轮询返回的 job 对象中下发（login-request 不携带），在等待好友同意阶段提示一次
+            // routing v2 在创建时就会分配 Bot；只有进入 wait_acceptance 才能确认好友申请已经发出
             if (!announced && status.Stage == "wait_acceptance" && !string.IsNullOrEmpty(status.BotFriendCode))
             {
-                ReplyAt(message, $"Bot 账号（好友码{status.BotFriendCode}）已发出好友申请，请尽快到 NET 同意。服务繁忙时申请可能排队，若超时按提示重试即可。");
+                ReplyAt(message, $"Bot 账号（好友码{status.BotFriendCode}）已发出好友申请，请尽快到 NET 同意。若任务随后超时，按提示重试即可。");
                 announced = true;
             }
 
@@ -503,10 +512,10 @@ public partial class MaiMaiDx
         // 第二阶段：创建独立的抓分任务并等待完成。登录任务不再包含抓分，把登录任务号作为
         // 好友关系凭证传入可立即开始抓分。抓分阶段单独计时：第一阶段需等待好友申请送达并被
         // 接受，繁忙时可能已耗去大部分时间，共用截止时间会使抓分预算所剩无几
-        string crawlJobId;
+        MaiScoreHubClient.JobStartResult crawl;
         try
         {
-            crawlJobId = await msh.CreateUpdateScoreJobAsync(jwt, login.JobId);
+            crawl = await msh.CreateUpdateScoreJobAsync(jwt, login.JobId);
         }
         catch (Exception e)
         {
@@ -514,7 +523,8 @@ public partial class MaiMaiDx
             return;
         }
 
-        deadline = DateTime.UtcNow.AddMinutes(20);
+        var crawlJobId = crawl.JobId;
+        deadline = crawl.DeadlineAt?.UtcDateTime.AddMinutes(1) ?? DateTime.UtcNow.AddMinutes(20);
         var crawlStart = DateTime.UtcNow;
 
         var crawlDone = false;
@@ -543,7 +553,9 @@ public partial class MaiMaiDx
 
             if (job.Status is "failed" or "canceled")
             {
-                ReplyAt(message, $"同步失败：{job.Error ?? job.Status}。{retryHint}");
+                ReplyAt(message, job.DeadlineExceeded
+                    ? $"同步失败：MSH 未能在服务端截止前完成成绩抓取，本次任务已结束。稍后{retryHint}"
+                    : $"同步失败：{job.Error ?? job.Status}。{retryHint}");
                 return;
             }
         }


### PR DESCRIPTION
## 背景与根因

继 `#94` 适配 MSH v1 API 后，maimai-score-hub 于 2026-08-15 引入 DXNet routing v2。新契约有两项会影响 `mai 导`：

1. 创建好友任务时返回的 `botUserFriendCode` 现在只表示任务已分配 Bot；此时 `stage` 仍可能是 `send_request`，`friendRequestSentAt` 也仍为空，不能据此宣称好友申请已经发出。
2. 服务端为好友任务和抓分任务分别返回 `deadlineAt`，硬截止后以 `errorCode=job_deadline_exceeded` 结束任务。旧客户端忽略这两个字段，并把 `DXNet job deadline exceeded` 原样回复给用户。

因此，服务繁忙时 Bot 可能先误报“已发出好友申请”，随后再显示无法判断阶段的英文 deadline 错误。

上游契约依据：

- [routing v2 的任务截止配置](https://github.com/bakapiano/maimai-score-hub/blob/6177d7b548d803e0236bc85b5dd268953fe5ffa2/shared/src/modules/job/job-routing.ts)
- [任务状态、friendRequestSentAt、errorCode 与 deadlineAt](https://github.com/bakapiano/maimai-score-hub/blob/6177d7b548d803e0236bc85b5dd268953fe5ffa2/shared/src/modules/job/job.schema.ts)

## 修复

- 解析登录任务和抓分任务的 `stage`、`friendRequestSentAt`、`errorCode`、`deadlineAt`。
- 只有 `friendRequestSentAt` 已设置或任务进入 `wait_acceptance` 后，才提示好友申请已经实际发出。
- 轮询优先采用服务端声明的截止时间，并额外保留一分钟供服务端 deadline sweep 写入终态；旧响应缺失该字段时保留原有本地上限。
- 分别处理好友阶段与抓分阶段的 `job_deadline_exceeded`，向用户说明具体失败阶段，不再透传原始英文错误。
- 增加 MSH routing v2 契约回归测试，包含“已分配但未发出”的反例和 `wait_acceptance` 正例。

## 验证

- `dotnet build Marisa.Plugin/Marisa.Plugin.csproj --no-restore`：0 error，0 warning。
- `MaiScoreHubClientTest`：5/5 通过。
- 全部 Mai 测试：367 通过、2 个既有环境失败、1 跳过；失败仍仅为 `All_Song_Should_Have_Cover`、`Score_Should_Be_Fetched`。
- 生产安全探针：公开统计 200、空登录请求 400、未认证 `/me` 401。
- Windows/.NET 8 真实全链路：进入 `wait_acceptance` 后完成好友确认，约 15 秒取得 JWT，约 36 秒完成抓分；落雪与水鱼均成功导出 2202/2202 条成绩。

---

本 PR 的初始实现、测试与验证由 **GPT-5.6 Sol** 完成；review 修订由 **Codex（GPT-5）** 完成。

PR Body 初稿由 **GPT-5.6 Sol** 撰写；review 更新由 **Codex（GPT-5）** 撰写。