### PR TITLE
fix(maimai): 完成表不再误拆谱师与曲师名

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -787,6 +787,16 @@ public static class PlateData
             return false;
         }
 
+        // 已知谱师/作曲家名先作为整体抽出，避免名称内部的 S、舞舞、MASTER、数字等被后续字段解析吞掉；
+        // 名称外部的字段仍留在 parsePart 中按原顺序解析，恰好等于保留 token 的输入仍保持原语义。
+        var selectors = new List<Selector>();
+        var parsePart = inner;
+        if (TryExtractKnownName(inner, out var nameStart, out var nameLength, out var nameSelector))
+        {
+            selectors.Add(nameSelector!);
+            parsePart = (inner[..nameStart] + inner[(nameStart + nameLength)..]).Trim();
+        }
+
         // 1. 阈值 token —— 字段位置可任意（"真代EXPERT将"=阈值在末尾、"将真EXPERT"=阈值在开头都接受）。
         //    longest-first 顺序遍历表，找 rightmost 满足"边界合法"的出现位置，strip 掉得到剩余字符串。
         //    边界规则：纯 ASCII 字母 token（如 "A"、"AAA"、"FC+"）必须 word boundary（前后不是 ASCII 字母），
@@ -796,7 +806,7 @@ public static class PlateData
         int thresholdAt = -1, thresholdLen = 0;
         foreach (var (token, t) in ThresholdEntriesLongestFirst)
         {
-            var pos = FindBoundedRightmost(inner, token);
+            var pos = FindBoundedRightmost(parsePart, token);
             if (pos >= 0)
             {
                 threshold    = t;
@@ -808,8 +818,8 @@ public static class PlateData
 
         // 默认阈值延后到 selector 解析后再定（完整牌名如「霸者」可能自带阈值档）。
         var afterThreshold = thresholdAt >= 0
-            ? (inner[..thresholdAt] + inner[(thresholdAt + thresholdLen)..]).Trim()
-            : inner;
+            ? (parsePart[..thresholdAt] + parsePart[(thresholdAt + thresholdLen)..]).Trim()
+            : parsePart;
 
         // 2. 难度 token（可选，同样 anywhere + rightmost + 同样的 ASCII letter 边界规则）。
         //    缺省时回落到 DefaultLevelIdxes ([3, 4] = MASTER + Re:MASTER)；显式给一个就是单元素。
@@ -831,7 +841,7 @@ public static class PlateData
             ? (afterThreshold[..diffAt] + afterThreshold[(diffAt + diffLen)..]).Trim()
             : afterThreshold;
 
-        if (selectorPart.Length == 0)
+        if (selectorPart.Length == 0 && selectors.Count == 0)
         {
             error = new(ErrorKind.UnknownSelector, inner);
             return false;
@@ -844,7 +854,6 @@ public static class PlateData
         //
         //    冲突规则：同类 selector 出现两次（含 Level + Constant 互斥，因为 Constant 隐含确定 Level）
         //    → ConflictingSelector 错误。
-        var selectors = new List<Selector>();
         var workingPart = selectorPart;
 
         while (true)
@@ -1000,6 +1009,84 @@ public static class PlateData
 
         query = new Query(selectors, threshold, levelIdxes);
         return true;
+
+        bool TryExtractKnownName(string input, out int start, out int length, out Selector? selector)
+        {
+            start = -1;
+            length = 0;
+            selector = null;
+
+            if (!IsReservedStandaloneToken(input) && TryCreateKnownNameSelector(input, out selector))
+            {
+                start = 0;
+                length = input.Length;
+                return true;
+            }
+
+            var candidate = knownCharters.Select(name => (Name: name, IsCharter: true, IsArtist: false))
+                .Concat(CharterIdentityMap.Keys.Select(name => (Name: name, IsCharter: true, IsArtist: false)))
+                .Concat(knownArtists.Select(name => (Name: name, IsCharter: false, IsArtist: true)))
+                .GroupBy(x => x.Name, StringComparer.OrdinalIgnoreCase)
+                .Select(group =>
+                {
+                    var name = group.Key;
+                    return (
+                        Name: name,
+                        Start: input.LastIndexOf(name, StringComparison.OrdinalIgnoreCase),
+                        IsCharter: group.Any(x => x.IsCharter),
+                        IsArtist: group.Any(x => x.IsArtist));
+                })
+                .Where(x => x.Start >= 0 &&
+                            !IsReservedStandaloneToken(x.Name) &&
+                            (x.Start + x.Name.Length >= input.Length ||
+                             input[x.Start + x.Name.Length] != OptionalDaiSuffix[0]))
+                .OrderByDescending(x => x.Name.Length)
+                .ThenByDescending(x => x.Start)
+                .FirstOrDefault();
+
+            if (candidate.Name is null) return false;
+
+            start = candidate.Start;
+            length = candidate.Name.Length;
+            selector = candidate.IsCharter && candidate.IsArtist
+                ? new Selector.CharterOrArtist(input.Substring(start, length))
+                : candidate.IsCharter
+                    ? new Selector.Charter(input.Substring(start, length))
+                    : new Selector.Artist(input.Substring(start, length));
+            return true;
+
+            bool TryCreateKnownNameSelector(string name, out Selector? knownNameSelector)
+            {
+                var charterHit = knownCharters.Any(c => c.Contains(name, StringComparison.OrdinalIgnoreCase)) ||
+                                 CharterIdentityMap.Keys.Any(c => c.Contains(name, StringComparison.OrdinalIgnoreCase));
+                var artistHit = knownArtists.Any(a => a.Contains(name, StringComparison.OrdinalIgnoreCase));
+                knownNameSelector = charterHit && artistHit
+                    ? new Selector.CharterOrArtist(name)
+                    : charterHit
+                        ? new Selector.Charter(name)
+                        : artistHit
+                            ? new Selector.Artist(name)
+                            : null;
+                return knownNameSelector is not null;
+            }
+        }
+
+        bool IsReservedStandaloneToken(string candidate)
+        {
+            if (ThresholdEntries.Any(x => x.Token.Equals(candidate, StringComparison.OrdinalIgnoreCase)) ||
+                DifficultyAliasMap.ContainsKey(candidate) ||
+                CharterAliasMap.ContainsKey(candidate) ||
+                candidate.Equals(RevivalGenreToken, StringComparison.Ordinal) ||
+                GenreAliasMap.ContainsKey(candidate) ||
+                GenreAliasMap.Values.Contains(candidate, StringComparer.Ordinal) ||
+                TryResolveLevel(candidate, out _) ||
+                TryResolveConstant(candidate, out _))
+            {
+                return true;
+            }
+
+            return TryResolvePlate(candidate, out _, out var plateError) || plateError is not null;
+        }
     }
 
     /// <summary>

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.IO;
 using System.Linq;
+using System.Text.Json;
 using Marisa.Plugin.Shared.MaiMaiDx;
 using NUnit.Framework;
 
@@ -17,12 +19,14 @@ public class MaiMaiDxPlateDataTest
         "超七味星人", "隅田川星人", // 名字含版本代字（超=GreeN / 星=UNiVERSE），验证反查保护
         "Revo@LC",                 // 别名"Revo"是它的子串，验证 CharterAlias 反查保护
         "JAQ", "Jack & Licorice Gunjyo", "群青リコリス", // Jack/群青リコリス 未设别名（可打），验证解析正确
+        "某S氏", "舞舞10年ズ（チャンとはっぴー）",
     ];
 
     // 含合作名义"sasakure.UK x DECO*27"，验证 substring 命中；"HIMEHINA" 验证纯 artist 单边命中。
     private static readonly IReadOnlyCollection<string> Artists =
     [
         "DECO*27", "sasakure.UK x DECO*27", "HIMEHINA", "rintaro soma", "Various Artists",
+        "A-One", "SAMBA MASTER 佐藤",
     ];
 
     private static PlateData.Query MustParse(string raw)
@@ -37,6 +41,30 @@ public class MaiMaiDxPlateDataTest
         var ok = PlateData.TryParse(raw, Charters, Artists, out _, out var error);
         Assert.That(ok, Is.False, $"parse unexpectedly succeeded for '{raw}'");
         return error!;
+    }
+
+    private static (IReadOnlyCollection<string> Charters, IReadOnlyCollection<string> Artists) LoadKnownNames()
+    {
+        var repositoryRoot = Directory.GetParent(Environment.CurrentDirectory)!.Parent!.Parent!.Parent!.ToString();
+        var path = Path.Join(repositoryRoot, "Marisa.Frontend", "public", "assets", "maimai", "SongInfo.json");
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+
+        var charters = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var artists = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var song in document.RootElement.EnumerateArray())
+        {
+            var basicInfo = song.GetProperty("basic_info");
+            var artist = basicInfo.GetProperty("artist").GetString();
+            if (!string.IsNullOrWhiteSpace(artist)) artists.Add(artist);
+
+            foreach (var chart in song.GetProperty("charts").EnumerateArray())
+            {
+                var charter = chart.GetProperty("charter").GetString();
+                if (!string.IsNullOrWhiteSpace(charter) && charter != "-") charters.Add(charter);
+            }
+        }
+
+        return (charters, artists);
     }
 
     private static MaiMaiSong CreateSong(long id, string version)
@@ -138,6 +166,81 @@ public class MaiMaiDxPlateDataTest
         var c = (PlateData.Selector.Charter)query.Selectors.Single();
         Assert.That(c.Name, Is.EqualTo(charter));
         Assert.That(query.Threshold.Level, Is.EqualTo(level));
+    }
+
+    [TestCase("某S氏")]
+    [TestCase("舞舞10年ズ")]
+    public void ReservedThresholdTokenInsideCharterNameIsNotStripped(string charter)
+    {
+        var query = MustParse($"{charter}完成表");
+
+        Assert.That(query.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Charter>());
+        Assert.That(((PlateData.Selector.Charter)query.Selectors.Single()).Name, Is.EqualTo(charter));
+        Assert.That(query.Threshold.DisplayName, Is.EqualTo("SSS"));
+    }
+
+    [TestCase("A-One")]
+    [TestCase("SAMBA MASTER 佐藤")]
+    public void ReservedTokenInsideArtistNameIsNotStripped(string artist)
+    {
+        var query = MustParse($"{artist}完成表");
+
+        Assert.That(query.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Artist>());
+        Assert.That(((PlateData.Selector.Artist)query.Selectors.Single()).Name, Is.EqualTo(artist));
+        Assert.That(query.Threshold.DisplayName, Is.EqualTo("SSS"));
+    }
+
+    [TestCase("某S氏S完成表")]
+    [TestCase("S某S氏完成表")]
+    public void ExplicitRankOutsideCharterNameStillParses(string raw)
+    {
+        var query = MustParse(raw);
+
+        Assert.That(((PlateData.Selector.Charter)query.Selectors.Single()).Name, Is.EqualTo("某S氏"));
+        Assert.That(query.Threshold.DisplayName, Is.EqualTo("S"));
+    }
+
+    [TestCase("某S氏MST完成表")]
+    [TestCase("MST某S氏完成表")]
+    public void ExplicitDifficultyOutsideCharterNameStillParses(string raw)
+    {
+        var query = MustParse(raw);
+
+        Assert.That(((PlateData.Selector.Charter)query.Selectors.Single()).Name, Is.EqualTo("某S氏"));
+        Assert.That(query.LevelIdxes, Is.EqualTo(new[] { 3 }));
+    }
+
+    [Test]
+    public void KnownNamesSurviveReservedTokenParsingAloneAndWithFields()
+    {
+        var (charters, artists) = LoadKnownNames();
+        var failures = new List<string>();
+
+        foreach (var name in charters.Concat(artists).Distinct(StringComparer.OrdinalIgnoreCase))
+        {
+            Check($"{name}完成表", name, "SSS", PlateData.DefaultLevelIdxes);
+            Check($"神{name}完成表", name, "AP", PlateData.DefaultLevelIdxes);
+            Check($"{name}神完成表", name, "AP", PlateData.DefaultLevelIdxes);
+            Check($"MST{name}完成表", name, "SSS", [3]);
+            Check($"{name}MST完成表", name, "SSS", [3]);
+        }
+
+        Assert.That(failures, Is.Empty, string.Join(Environment.NewLine, failures));
+
+        void Check(string raw, string expectedName, string threshold, IReadOnlyList<int> levelIdxes)
+        {
+            var ok = PlateData.TryParse(raw, charters, artists, out var query, out var error);
+            var nameSelectors = query?.Selectors.Where(x => x is
+                PlateData.Selector.Charter or PlateData.Selector.Artist or PlateData.Selector.CharterOrArtist).ToList();
+            if (!ok || nameSelectors is not { Count: 1 } || nameSelectors[0].Display != expectedName ||
+                query!.Selectors.Count != 1 || query.Threshold.DisplayName != threshold ||
+                !query.LevelIdxes.SequenceEqual(levelIdxes))
+            {
+                failures.Add($"{raw} => {error?.Kind}/{error?.Detail}; " +
+                             $"selectors={string.Join(',', query?.Selectors.Select(x => $"{x.GetType().Name}:{x.Display}") ?? [])}; " +
+                             $"threshold={query?.Threshold.DisplayName}; levels={string.Join(',', query?.LevelIdxes ?? [])}");
+            }
+        }
     }
 
     [TestCase("术力口将完成表",  "niconico & VOCALOID")]


### PR DESCRIPTION
## 问题

本地用户报告：执行 `mai 某S氏完成表` 时，解析器会把谱师名中的 `S` 当作达成率评级，实际查询对象被改成“某氏”，最终回复“没有找到 某氏 对应的歌曲”。

根因是完成表此前先从整条命令中剥离评级和难度字段，再识别谱师或作曲家。ASCII 词边界只能保护 `HIMEHINA` 这类两侧仍是英文字母的名称；当保留 token 紧邻中文、日文、空格或标点时，仍会被当作独立字段。

## 同类问题审计

对仓库当前 `SongInfo.json` 的 1362 首歌曲做了全量检查：共 173 个唯一谱师名、866 个唯一作曲家名，合并去重后为 1038 个名称。修复前有 50 个实际名称会被错误拆分，覆盖多种字段：

- 评级：`某S氏`、`A-One`、`Team-D`、`M.S.S Project`；
- 中文评级别名：`舞舞10年ズ`、包含“神”的署名；
- 难度：`SAMBA MASTER 佐藤`、`猫叉Master`、`<advanced mix>`；
- 等级数字：`舞舞10年ズ`、`Crush 40「ソニックアドベンチャー2」`；
- 版本代字：包含“丸岡”的作曲家署名此前可能触发“不支持的版本代字”。

## 修复

- 在解析评级、难度、版本、类别、等级和定数之前，先用当前曲库的已知谱师/作曲家集合识别名称，并把名称作为不可拆分的整体。
- 只对名称外部的剩余文本继续执行原有字段解析，因此 `S某S氏`、`某S氏S`、`MST某S氏`、`某S氏MST` 仍能正确识别显式字段。
- 输入恰好等于评级、难度、版本、类别、等级、定数、复活曲或谱师别名 token 时，继续保持原有语义。
- 保留“谱师名后接 `代` 不应被当作版本后缀”的既有行为。

## 验证

- `dotnet build Marisa.Plugin/Marisa.Plugin.csproj --no-restore`：6 个项目，0 error，0 warning。
- `MaiMaiDxPlateDataTest`：307/307 通过。
- 全曲库名称回归：1038 个唯一名称分别验证单独查询、`神` 前缀、`神` 后缀、`MST` 前缀、`MST` 后缀，共 5190 个组合，全部通过。
- 完整 Mai 测试：371 通过、2 个既有环境失败、1 跳过；失败仍仅为 `All_Song_Should_Have_Cover`、`Score_Should_Be_Fetched`。
- `git diff --check upstream/master`：通过。

---

本 PR 的代码实现、测试与验证由 **GPT-5.6 Sol** 完成。

PR Body 由 **GPT-5.6 Sol** 撰写。
