### PR TITLE
fix(maimai): 停止在聊天中接收查分器长期凭据

### DIFF
--- a/Marisa.Backend.NapCat/NapCatBackend.cs
+++ b/Marisa.Backend.NapCat/NapCatBackend.cs
@@ -46,7 +46,7 @@ public class NapCatBackend : BotDriver.BotDriver
         _logger   = LogManager.GetCurrentClassLogger();
         _dict     = dict;
         _config   = ConfigurationManager.Configuration.NapCat;
-        _endpoint = BuildEndpoint(string.IsNullOrWhiteSpace(_config.Endpoint) ? "ws://127.0.0.1:3001" : _config.Endpoint, _config.Token);
+        _endpoint = BuildEndpoint(string.IsNullOrWhiteSpace(_config.Endpoint) ? "ws://127.0.0.1:3001" : _config.Endpoint);
 
         if (long.TryParse(_config.SelfId, out var selfId))
         {
@@ -117,17 +117,24 @@ public class NapCatBackend : BotDriver.BotDriver
             }
             catch (Exception ex) when (IsUnavailableGroupFailure(s, ex))
             {
-                _logger.Warn(ex, $"Skipped sending group message to unavailable group {s.ReceiverId}: {s.MessageChain}");
+                _logger.Warn(
+                    "event=napcat_send_skipped {0} error_type={1}",
+                    OutboundAudit(s.MessageChain, s.Type, s.ReceiverId, s.GroupId),
+                    ex.GetType().FullName ?? ex.GetType().Name);
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, $"Failed to send {s.Type} to {DescribeTarget(s)}: {s.MessageChain}");
+                _logger.Error(
+                    "event=napcat_send_failed {0} error_type={1} hresult={2}",
+                    OutboundAudit(s.MessageChain, s.Type, s.ReceiverId, s.GroupId),
+                    ex.GetType().FullName ?? ex.GetType().Name,
+                    ex.HResult);
             }
         }
 
         async Task SendGroupMessage(MessageChain message, long target, long? quote = null)
         {
-            _logger.Info($"{target} <= {message}");
+            _logger.Info("event=napcat_send {0}", OutboundAudit(message, MessageType.GroupMessage, target, null));
             await SendAction("send_group_msg", new Dictionary<string, object?>
             {
                 ["group_id"] = target.ToString(),
@@ -137,7 +144,7 @@ public class NapCatBackend : BotDriver.BotDriver
 
         async Task SendFriendMessage(MessageChain message, long target, long? quote = null)
         {
-            _logger.Info($"{target} <- {message}");
+            _logger.Info("event=napcat_send {0}", OutboundAudit(message, MessageType.FriendMessage, target, null));
             await SendAction("send_private_msg", new Dictionary<string, object?>
             {
                 ["user_id"] = target.ToString(),
@@ -147,7 +154,7 @@ public class NapCatBackend : BotDriver.BotDriver
 
         async Task SendTempMessage(MessageChain message, long target, long? groupId, long? quote = null)
         {
-            _logger.Info($"{target} <-[temp:{groupId}] {message}");
+            _logger.Info("event=napcat_send {0}", OutboundAudit(message, MessageType.TempMessage, target, groupId));
 
             // OneBot keeps temporary sessions on send_private_msg with an optional group_id context.
             // NapCat accepts this shape for private.group events reported from group temporary sessions.
@@ -172,19 +179,17 @@ public class NapCatBackend : BotDriver.BotDriver
                 return false;
             }
 
-            return ex.Message.Contains("你已被移出该群", StringComparison.Ordinal) ||
-                   ex.Message.Contains("群聊不存在", StringComparison.Ordinal) ||
-                   ex.Message.Contains("\"result\": 110", StringComparison.Ordinal) ||
-                   ex.Message.Contains("\"result\":110", StringComparison.Ordinal);
+            return ex is NapCatActionException { IsUnavailableGroup: true };
         }
 
-        static string DescribeTarget(MessageToSend s)
+        static string OutboundAudit(MessageChain message, MessageType type, long target, long? groupId)
         {
-            return s.Type switch
-            {
-                MessageType.TempMessage => $"user {s.ReceiverId} (temp group {s.GroupId?.ToString() ?? "?"})",
-                _ => s.ReceiverId.ToString()
-            };
+            var targetRef = MessageAuditContext.Pseudonymize($"napcat-target:{type}", target);
+            var groupRef = groupId is null
+                ? "none"
+                : MessageAuditContext.Pseudonymize("napcat-temp-group", groupId.Value);
+            return $"type={type} target_ref={targetRef} group_ref={groupRef} " +
+                   $"segments={MessageAuditContext.SummarizeSegments(message)}";
         }
     }
 
@@ -216,7 +221,10 @@ public class NapCatBackend : BotDriver.BotDriver
         }
         catch (Exception ex)
         {
-            _logger.Warn(ex, "Failed to initialize NapCat login info; set napCat.selfId if @ triggers are needed before the first message");
+            _logger.Warn(
+                "event=napcat_login_info_failed error_type={0} hresult={1}",
+                ex.GetType().FullName ?? ex.GetType().Name,
+                ex.HResult);
         }
     }
 
@@ -251,7 +259,10 @@ public class NapCatBackend : BotDriver.BotDriver
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "NapCat WebSocket receive loop failed; reconnecting in 5 seconds");
+                _logger.Error(
+                    "event=napcat_receive_failed error_type={0} hresult={1} retry_seconds=5",
+                    ex.GetType().FullName ?? ex.GetType().Name,
+                    ex.HResult);
                 FailPendingActions(ex);
                 CloseSocket();
                 await Task.Delay(TimeSpan.FromSeconds(5), ShutdownToken);
@@ -327,7 +338,7 @@ public class NapCatBackend : BotDriver.BotDriver
             default:
                 if (postType is not null)
                 {
-                    _logger.Debug($"Not implemented NapCat event: `{root.GetRawText()}`");
+                    _logger.Debug("event=napcat_event_ignored");
                 }
 
                 break;
@@ -693,7 +704,7 @@ public class NapCatBackend : BotDriver.BotDriver
 
             if (ReadString(response, "status") != "ok" || ReadLong(response, "retcode", 0) != 0)
             {
-                throw new InvalidOperationException($"NapCat action `{action}` failed: {response.GetRawText()}");
+                throw CreateActionException(action, response);
             }
 
             return response.TryGetProperty("data", out var data) ? data.Clone() : default;
@@ -783,12 +794,16 @@ public class NapCatBackend : BotDriver.BotDriver
 
                     await socket.ConnectAsync(_endpoint, ShutdownToken);
                     _socket = socket;
-                    _logger.Info($"Connected to NapCat OneBot WebSocket: {_endpoint}");
+                    _logger.Info("event=napcat_connected endpoint={0}", EndpointForLog(_endpoint));
                     return;
                 }
                 catch (Exception ex)
                 {
-                    _logger.Warn(ex, $"Failed to connect NapCat OneBot WebSocket {_endpoint}; retrying in 5 seconds");
+                    _logger.Warn(
+                        "event=napcat_connect_failed endpoint={0} error_type={1} hresult={2} retry_seconds=5",
+                        EndpointForLog(_endpoint),
+                        ex.GetType().FullName ?? ex.GetType().Name,
+                        ex.HResult);
                     await Task.Delay(TimeSpan.FromSeconds(5), ShutdownToken);
                 }
             }
@@ -824,12 +839,44 @@ public class NapCatBackend : BotDriver.BotDriver
         _dict["QQ"] = selfId;
     }
 
-    private static Uri BuildEndpoint(string endpoint, string? token)
+    private static Uri BuildEndpoint(string endpoint)
     {
-        if (string.IsNullOrEmpty(token)) return new Uri(endpoint);
+        return new Uri(endpoint);
+    }
 
-        var separator = endpoint.Contains('?') ? '&' : '?';
-        return new Uri($"{endpoint}{separator}access_token={Uri.EscapeDataString(token)}");
+    private static string EndpointForLog(Uri endpoint)
+    {
+        var sanitized = new UriBuilder(endpoint)
+        {
+            UserName = string.Empty,
+            Password = string.Empty,
+            Query = string.Empty,
+            Fragment = string.Empty
+        };
+        return sanitized.Uri.GetLeftPart(UriPartial.Path);
+    }
+
+    private static NapCatActionException CreateActionException(string action, JsonElement response)
+    {
+        var retCode = ReadLong(response, "retcode", 0);
+        var resultCode = response.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Object
+            ? ReadLong(data, "result", 0)
+            : 0;
+        var wording = ReadString(response, "message") ?? ReadString(response, "wording") ?? string.Empty;
+        var unavailableGroup = resultCode == 110 ||
+                               wording.Contains("你已被移出该群", StringComparison.Ordinal) ||
+                               wording.Contains("群聊不存在", StringComparison.Ordinal);
+        return new NapCatActionException(action, retCode, resultCode, unavailableGroup);
+    }
+
+    private sealed class NapCatActionException(
+        string action,
+        long retCode,
+        long resultCode,
+        bool isUnavailableGroup)
+        : InvalidOperationException($"NapCat action `{action}` failed with retcode {retCode} and result {resultCode}")
+    {
+        public bool IsUnavailableGroup { get; } = isUnavailableGroup;
     }
 
     private static string? ReadString(JsonElement element, string name)

--- a/Marisa.BotDriver.Test/ExceptionDumpTest.cs
+++ b/Marisa.BotDriver.Test/ExceptionDumpTest.cs
@@ -33,9 +33,30 @@ public class ExceptionDumpTest
     }
 
     [Test]
-    public void Save_Should_Write_Exception_And_Related_Message_To_Temp_Root()
+    public void Save_Should_Write_Safe_Exception_Metadata_Without_Messages()
     {
-        var path = ExceptionDump.Save(new InvalidOperationException("boom"), "test message", "unit-test");
+        const string sentinel = "SECRET_SENTINEL";
+        var queue = new MessageQueueProvider();
+        var sender = new MessageSenderProvider(queue);
+        var message = new Message(new MessageChain(
+            new MessageDataId(1, 0),
+            new MessageDataText(sentinel)), sender)
+        {
+            Type = MessageType.FriendMessage,
+            Sender = new SenderInfo(114514, "tester")
+        };
+
+        Exception exception;
+        try
+        {
+            throw new InvalidOperationException(sentinel, new ArgumentException(sentinel));
+        }
+        catch (Exception caught)
+        {
+            exception = caught;
+        }
+
+        var path = ExceptionDump.Save(exception, message.AuditContext, "unit-test");
 
         Assert.That(path, Is.Not.Null);
         Assert.That(NormalizePath(path!), Does.StartWith(NormalizePath(Path.Join(_tempRoot, "exceptions"))));
@@ -45,9 +66,12 @@ public class ExceptionDumpTest
         Assert.Multiple(() =>
         {
             Assert.That(content, Does.Contain("InvalidOperationException"));
-            Assert.That(content, Does.Contain("boom"));
-            Assert.That(content, Does.Contain("test message"));
+            Assert.That(content, Does.Contain("ArgumentException"));
             Assert.That(content, Does.Contain("unit-test"));
+            Assert.That(content, Does.Contain(message.AuditContext.CorrelationId));
+            Assert.That(content, Does.Not.Contain(sentinel));
+            Assert.That(content, Does.Not.Contain("RelatedMessage"));
+            Assert.That(content, Does.Not.Contain("Detail"));
         });
 
         static string NormalizePath(string value) =>
@@ -74,7 +98,7 @@ public class ExceptionDumpTest
 
         Assert.Multiple(() =>
         {
-            Assert.That(text, Is.EqualTo("出现异常，已上报开发者"));
+            Assert.That(text, Does.StartWith("出现异常，已上报开发者（故障编号："));
             Assert.That(text, Does.Not.Contain("boom"));
             Assert.That(text, Does.Not.Contain("InvalidOperationException"));
         });

--- a/Marisa.BotDriver.Test/MessageAuditSecurityTest.cs
+++ b/Marisa.BotDriver.Test/MessageAuditSecurityTest.cs
@@ -1,0 +1,250 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Text.Json;
+using Marisa.Backend.NapCat;
+using Marisa.BotDriver.DI;
+using Marisa.BotDriver.DI.Message;
+using Marisa.BotDriver.Entity.Message;
+using Marisa.BotDriver.Entity.MessageData;
+using Marisa.BotDriver.Entity.MessageSender;
+using Marisa.BotDriver.Plugin;
+using Marisa.BotDriver.Plugin.Attributes;
+using Marisa.BotDriver.Plugin.Trigger;
+using Marisa.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using NUnit.Framework;
+
+namespace Marisa.BotDriver.Test;
+
+[NonParallelizable]
+public class MessageAuditSecurityTest
+{
+    private const string Sentinel = "SECRET_SENTINEL";
+
+    private string _tempRoot = null!;
+    private MemoryTarget _memory = null!;
+    private AuditTestDriver _driver = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _tempRoot = Path.Join(Path.GetTempPath(), "Marisa.BotDriver.Test", Guid.NewGuid().ToString("N"));
+        ConfigurationManager.SetConfigFilePath(CreateTestConfig(_tempRoot));
+        ResetDispatcherCaches();
+
+        _memory = new MemoryTarget("AuditSecurityMemory")
+        {
+            Layout = "${message}|${all-event-properties}|${exception:format=tostring}"
+        };
+        var logging = new LoggingConfiguration();
+        logging.AddRuleForAllLevels(_memory);
+        LogManager.Configuration = logging;
+
+        _driver = AuditTestDriver.Create();
+        AuditPlugin.LastCommand = null;
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _driver.Dispose();
+        LogManager.Shutdown();
+        ResetDispatcherCaches();
+
+        if (Directory.Exists(_tempRoot)) Directory.Delete(_tempRoot, true);
+    }
+
+    [Test]
+    public async Task Normal_Dispatch_Should_Preserve_Command_And_Omit_Body_From_Audit_Logs()
+    {
+        var message = _driver.CreateMessage($"audit ok {Sentinel}");
+
+        await _driver.Process(message);
+        LogManager.Flush();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(AuditPlugin.LastCommand, Is.EqualTo($"ok {Sentinel}"));
+            Assert.That(message.ToString(), Does.Not.Contain(Sentinel));
+            Assert.That(_memory.Logs, Has.Some.Contains("event=message_received"));
+            Assert.That(_memory.Logs, Has.Some.Contains("event=handler_completed"));
+            Assert.That(_memory.Logs, Has.Some.Contains("text_length="));
+            Assert.That(_memory.Logs, Has.None.Contains(Sentinel));
+        });
+    }
+
+    [Test]
+    public async Task Plugin_Exception_Should_Omit_Message_And_Exception_Text_From_Logs_And_Dump()
+    {
+        var message = _driver.CreateMessage($"audit throw {Sentinel}");
+
+        await _driver.Process(message);
+        LogManager.Flush();
+
+        var dump = Directory.GetFiles(Path.Join(_tempRoot, "exceptions"), "*.json").Single();
+        var dumpContent = File.ReadAllText(dump);
+        Assert.Multiple(() =>
+        {
+            Assert.That(_memory.Logs, Has.Some.Contains("event=plugin_exception"));
+            Assert.That(_memory.Logs, Has.None.Contains(Sentinel));
+            Assert.That(dumpContent, Does.Contain("InvalidOperationException"));
+            Assert.That(dumpContent, Does.Contain(message.AuditContext.CorrelationId));
+            Assert.That(dumpContent, Does.Not.Contain(Sentinel));
+        });
+    }
+
+    [Test]
+    public async Task Timeout_Should_Omit_Message_Body_From_Error_Log()
+    {
+        var message = _driver.CreateMessage($"audit timeout {Sentinel}");
+
+        await _driver.Process(message);
+        LogManager.Flush();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(_memory.Logs, Has.Some.Contains("event=message_timeout"));
+            Assert.That(_memory.Logs, Has.None.Contains(Sentinel));
+        });
+    }
+
+    [Test]
+    public void NapCat_Endpoint_Log_Should_Drop_UserInfo_Query_And_Fragment()
+    {
+        var build = typeof(NapCatBackend).GetMethod("BuildEndpoint", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var forLog = typeof(NapCatBackend).GetMethod("EndpointForLog", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var endpoint = (Uri)build.Invoke(null, [$"ws://user:{Sentinel}@localhost:3001/onebot?access_token={Sentinel}#fragment"])!;
+        var logged = (string)forLog.Invoke(null, [endpoint])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(build.GetParameters(), Has.Length.EqualTo(1));
+            Assert.That(endpoint.Query, Does.Contain(Sentinel));
+            Assert.That(logged, Is.EqualTo("ws://localhost:3001/onebot"));
+            Assert.That(logged, Does.Not.Contain(Sentinel));
+        });
+    }
+
+    [Test]
+    public void NapCat_Action_Exception_Should_Not_Include_Response_Body()
+    {
+        using var response = JsonDocument.Parse($$"""
+            { "status": "failed", "retcode": 1200, "message": "{{Sentinel}}", "data": { "result": 110 } }
+            """);
+        var create = typeof(NapCatBackend).GetMethod("CreateActionException", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var exception = (Exception)create.Invoke(null, ["send_group_msg", response.RootElement])!;
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(exception.ToString(), Does.Contain("retcode 1200"));
+            Assert.That(exception.ToString(), Does.Not.Contain(Sentinel));
+        });
+    }
+
+    private static void ResetDispatcherCaches()
+    {
+        foreach (var fieldName in new[] { "_plugins", "_commands", "_subCommands" })
+        {
+            typeof(MessageDispatcher).GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic)!
+                .SetValue(null, null);
+        }
+    }
+
+    private static string CreateTestConfig(string tempRoot)
+    {
+        var sourceConfigPath = Path.Join(FindRepositoryRoot(), "Marisa.StartUp", "config.yaml");
+        var escapedTempRoot = tempRoot.Replace('\\', '/');
+        var config = File.ReadAllText(sourceConfigPath);
+        config = Regex.Replace(config, @"^tempPath:\s*.*$", $"tempPath:     {escapedTempRoot}", RegexOptions.Multiline);
+        config = Regex.Replace(config, @"^databasePath:\s*.*$", "databasePath: bot.db", RegexOptions.Multiline);
+        var configPath = Path.Join(tempRoot, "config.yaml");
+
+        Directory.CreateDirectory(tempRoot);
+        File.WriteAllText(configPath, config);
+        return configPath;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(Environment.CurrentDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Join(directory.FullName, "Marisa.sln"))) return directory.FullName;
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from current test directory.");
+    }
+
+    [MarisaPlugin]
+    [MarisaPluginCommand("audit")]
+    private sealed class AuditPlugin : MarisaPluginBase
+    {
+        public static string? LastCommand { get; set; }
+
+        [MarisaPluginCommand]
+        private static async Task<MarisaPluginTaskState> Handle(Message message)
+        {
+            LastCommand = message.Command.ToString();
+            if (message.Command.Span.StartsWith("throw", StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException(Sentinel);
+            }
+
+            if (message.Command.Span.StartsWith("timeout", StringComparison.Ordinal))
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5));
+            }
+
+            return MarisaPluginTaskState.CompletedTask;
+        }
+    }
+
+    private sealed class AuditTestDriver(
+        IServiceProvider serviceProvider,
+        IEnumerable<MarisaPluginBase> plugins,
+        DictionaryProvider dictionary,
+        MessageSenderProvider sender,
+        MessageQueueProvider queues,
+        ServiceProvider owner)
+        : BotDriver(serviceProvider, plugins, dictionary, sender, queues), IDisposable
+    {
+        protected override TimeSpan MessageProcessingTimeout => TimeSpan.FromMilliseconds(50);
+
+        public static AuditTestDriver Create()
+        {
+            var services = Config([typeof(AuditPlugin)]);
+            var owner = services.BuildServiceProvider();
+            return new AuditTestDriver(
+                owner,
+                owner.GetServices<MarisaPluginBase>(),
+                owner.GetRequiredService<DictionaryProvider>(),
+                owner.GetRequiredService<MessageSenderProvider>(),
+                owner.GetRequiredService<MessageQueueProvider>(),
+                owner);
+        }
+
+        public Message CreateMessage(string text)
+        {
+            return new Message(
+                new MessageChain(new MessageDataId(123, 0), new MessageDataText(text)),
+                MessageSenderProvider)
+            {
+                Type = MessageType.GroupMessage,
+                Sender = new SenderInfo(114514, "sensitive sender name"),
+                GroupInfo = new GroupInfo(1919810, "sensitive group name", null)
+            };
+        }
+
+        public Task Process(Message message) => ProcMessageStep(message);
+
+        protected override Task RecvMessage() => Task.CompletedTask;
+
+        protected override Task SendMessage() => Task.CompletedTask;
+
+        public void Dispose() => owner.Dispose();
+    }
+}

--- a/Marisa.BotDriver/BotDriver.cs
+++ b/Marisa.BotDriver/BotDriver.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics;
+using System.Reflection;
 using Marisa.BotDriver.DI;
 using Marisa.BotDriver.DI.Message;
 using Marisa.BotDriver.Entity.Message;
@@ -25,6 +26,7 @@ public abstract class BotDriver(
     private readonly CancellationTokenSource _shutdown = new();
 
     protected CancellationToken ShutdownToken => _shutdown.Token;
+    protected virtual TimeSpan MessageProcessingTimeout => TimeSpan.FromMinutes(10);
 
     /// <summary>
     /// 配置依赖注入
@@ -80,39 +82,67 @@ public abstract class BotDriver(
 
     protected async Task ProcMessageStep(Message message)
     {
+        var audit = message.AuditContext;
+        var started = Stopwatch.GetTimestamp();
+        Logger.Info("event=message_received {0}", audit);
+
         try
         {
-            var res = await Policy.TimeoutAsync(TimeSpan.FromMinutes(10), TimeoutStrategy.Pessimistic).ExecuteAndCaptureAsync(async () =>
+            var res = await Policy.TimeoutAsync(MessageProcessingTimeout, TimeoutStrategy.Pessimistic).ExecuteAndCaptureAsync(async () =>
             {
-                Logger.Info("{0}", message.ToString());
                 var toInvoke = MessageDispatcher.Dispatch(message);
 
                 foreach (var (plugin, method, m2) in toInvoke)
                 {
+                    var handlerStarted = Stopwatch.GetTimestamp();
                     var state = await MessageDispatcher.Invoke(plugin, method, m2);
+                    Logger.Info(
+                        "event=handler_completed {0} plugin={1} handler={2} outcome={3} duration_ms={4:F1}",
+                        audit,
+                        plugin.GetType().FullName ?? plugin.GetType().Name,
+                        method.Name,
+                        state,
+                        Stopwatch.GetElapsedTime(handlerStarted).TotalMilliseconds);
 
                     if (state == MarisaPluginTaskState.CompletedTask) break;
                 }
             });
 
-            if (res.Outcome != OutcomeType.Failure) return;
+            if (res.Outcome != OutcomeType.Failure)
+            {
+                Logger.Info(
+                    "event=message_completed {0} duration_ms={1:F1}",
+                    audit,
+                    Stopwatch.GetElapsedTime(started).TotalMilliseconds);
+                return;
+            }
 
             if (res.FinalException is TimeoutRejectedException)
             {
                 message.Reply("Cancelled due to timeout (10min)");
-                Logger.Error("Handler timed out. Caused by message: {0}", message);
+                Logger.Error(
+                    "event=message_timeout {0} duration_ms={1:F1}",
+                    audit,
+                    Stopwatch.GetElapsedTime(started).TotalMilliseconds);
             }
             else
             {
-                // 分发/触发匹配阶段（不在 DependencyInjectInvoke 的 try/catch 内）抛出的异常：
-                // 记录而非抛回无人 await 的任务，否则会被静默丢弃
-                Logger.Error(res.FinalException, "Dispatch failed. Caused by message: {0}", message);
+                Logger.Error(
+                    "event=dispatch_failed {0} error_type={1} hresult={2} duration_ms={3:F1}",
+                    audit,
+                    res.FinalException?.GetType().FullName ?? "unknown",
+                    res.FinalException?.HResult ?? 0,
+                    Stopwatch.GetElapsedTime(started).TotalMilliseconds);
             }
         }
         catch (Exception e)
         {
-            // 兜底：本任务是即发即弃的，任何逃逸异常都必须在此消化，避免成为未观测异常
-            Logger.Error(e, "Unexpected error while processing message: {0}", message);
+            Logger.Error(
+                "event=message_failed {0} error_type={1} hresult={2} duration_ms={3:F1}",
+                audit,
+                e.GetType().FullName ?? e.GetType().Name,
+                e.HResult,
+                Stopwatch.GetElapsedTime(started).TotalMilliseconds);
         }
     }
 

--- a/Marisa.BotDriver/Entity/Message/Message.cs
+++ b/Marisa.BotDriver/Entity/Message/Message.cs
@@ -41,6 +41,10 @@ public record Message
 
     public MessageAuditContext AuditContext => _auditContext ??= MessageAuditContext.FromMessage(this);
 
+    internal MessageSenderProvider SenderProvider => _sender;
+
+    public MessageReplyTarget CaptureReplyTarget() => new(this);
+
     /// <summary>
     ///     消息在哪，群或者私聊
     /// </summary>

--- a/Marisa.BotDriver/Entity/Message/Message.cs
+++ b/Marisa.BotDriver/Entity/Message/Message.cs
@@ -7,6 +7,7 @@ namespace Marisa.BotDriver.Entity.Message;
 public record Message
 {
     private readonly MessageSenderProvider _sender;
+    private MessageAuditContext? _auditContext;
 
     public readonly MessageChain? MessageChain;
 
@@ -37,6 +38,8 @@ public record Message
 
     public MessageDataId MessageId =>
         (MessageChain!.Messages.FirstOrDefault(m => m.Type == MessageDataType.Id) as MessageDataId)!;
+
+    public MessageAuditContext AuditContext => _auditContext ??= MessageAuditContext.FromMessage(this);
 
     /// <summary>
     ///     消息在哪，群或者私聊
@@ -79,9 +82,7 @@ public record Message
 
     public override string ToString()
     {
-        return GroupInfo == null
-            ? $"[{Type}] {Sender.Name} ({Sender.Id}) => {MessageChain}"
-            : $"[{Type}] {Sender.Name} ({Sender.Id}) -> {GroupInfo?.Name ?? "Unknown"} ({GroupInfo?.Id ?? 0}) => {MessageChain}";
+        return AuditContext.ToString();
     }
 
     #region Reply

--- a/Marisa.BotDriver/Entity/Message/MessageAuditContext.cs
+++ b/Marisa.BotDriver/Entity/Message/MessageAuditContext.cs
@@ -1,0 +1,69 @@
+using System.Security.Cryptography;
+using System.Text;
+using Marisa.BotDriver.Entity.MessageData;
+
+namespace Marisa.BotDriver.Entity.Message;
+
+public sealed record MessageAuditContext(
+    string CorrelationId,
+    string MessageRef,
+    MessageType MessageType,
+    string LocationKind,
+    string SenderRef,
+    string LocationRef,
+    string SegmentTypes,
+    int TextLength)
+{
+    private static readonly byte[] PseudonymKey = RandomNumberGenerator.GetBytes(32);
+
+    public static MessageAuditContext FromMessage(Message message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+
+        var chain = message.MessageChain;
+        var messageId = chain?.Messages.OfType<MessageDataId>().FirstOrDefault()?.Id;
+        var locationId = message.Type == MessageType.GroupMessage
+            ? message.GroupInfo?.Id
+            : message.Sender.Id;
+
+        return new MessageAuditContext(
+            Convert.ToHexString(RandomNumberGenerator.GetBytes(8)),
+            messageId is null ? "none" : Pseudonymize("message", messageId.Value),
+            message.Type,
+            LocationKindOf(message.Type),
+            Pseudonymize("sender", message.Sender.Id),
+            locationId is null ? "none" : Pseudonymize($"location:{message.Type}", locationId.Value),
+            SummarizeSegments(chain),
+            chain?.Messages.OfType<MessageDataText>().Sum(x => x.Text.Length) ?? 0);
+    }
+
+    public static string Pseudonymize(string domain, long value)
+    {
+        using var hmac = new HMACSHA256(PseudonymKey);
+        var digest = hmac.ComputeHash(Encoding.UTF8.GetBytes($"{domain}:{value}"));
+        return Convert.ToHexString(digest.AsSpan(0, 8));
+    }
+
+    public static string SummarizeSegments(MessageChain? chain)
+    {
+        if (chain is null || chain.Messages.Count == 0) return "none";
+
+        return string.Join(',', chain.Messages
+            .GroupBy(x => x.Type)
+            .OrderBy(x => x.Key)
+            .Select(x => $"{x.Key}:{x.Count()}"));
+    }
+
+    public override string ToString() =>
+        $"correlation={CorrelationId} message_ref={MessageRef} type={MessageType} " +
+        $"location_kind={LocationKind} sender_ref={SenderRef} location_ref={LocationRef} " +
+        $"segments={SegmentTypes} text_length={TextLength}";
+
+    private static string LocationKindOf(MessageType type) => type switch
+    {
+        MessageType.GroupMessage => "group",
+        MessageType.TempMessage => "temp",
+        MessageType.FriendMessage or MessageType.StrangerMessage => "private",
+        _ => "unknown"
+    };
+}

--- a/Marisa.BotDriver/Entity/Message/MessageReplyTarget.cs
+++ b/Marisa.BotDriver/Entity/Message/MessageReplyTarget.cs
@@ -1,0 +1,41 @@
+using Marisa.BotDriver.DI.Message;
+using Marisa.BotDriver.Entity.MessageData;
+
+namespace Marisa.BotDriver.Entity.Message;
+
+public sealed class MessageReplyTarget
+{
+    private readonly MessageSenderProvider _sender;
+
+    internal MessageReplyTarget(Message message)
+    {
+        _sender = message.SenderProvider;
+        Type = message.Type;
+        Location = message.Location;
+        SenderId = message.Sender.Id;
+        CorrelationId = message.AuditContext.CorrelationId;
+    }
+
+    public MessageType Type { get; }
+
+    public long Location { get; }
+
+    public long SenderId { get; }
+
+    public string CorrelationId { get; }
+
+    public void Reply(string text, bool mentionSender = false)
+    {
+        if (mentionSender && Type == MessageType.GroupMessage)
+        {
+            _sender.Send(
+                new MessageChain(new MessageDataAt(SenderId), new MessageDataText(" " + text)),
+                Type,
+                Location,
+                null).Wait();
+            return;
+        }
+
+        _sender.Send(text, Type, Location, null).Wait();
+    }
+}

--- a/Marisa.BotDriver/Plugin/ExceptionDump.cs
+++ b/Marisa.BotDriver/Plugin/ExceptionDump.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Marisa.BotDriver.Entity.Message;
 using Marisa.Configuration;
 using NLog;
 
@@ -8,7 +9,7 @@ public static class ExceptionDump
 {
     private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-    public static string? Save(Exception exception, string? relatedMessage = null, string? source = null)
+    public static string? Save(Exception exception, MessageAuditContext auditContext, string? source = null)
     {
         try
         {
@@ -22,10 +23,8 @@ public static class ExceptionDump
             var payload = new ExceptionDumpPayload(
                 timestamp,
                 source ?? "unknown",
-                exception.GetType().FullName ?? exception.GetType().Name,
-                exception.Message,
-                exception.ToString(),
-                relatedMessage
+                auditContext,
+                ExceptionFrames(exception)
             );
 
             var json = JsonSerializer.Serialize(payload, new JsonSerializerOptions
@@ -38,17 +37,51 @@ public static class ExceptionDump
         }
         catch (Exception dumpException)
         {
-            Logger.Warn(dumpException, "Failed to persist exception dump");
+            Logger.Warn(
+                "event=exception_dump_failed correlation={0} error_type={1} hresult={2}",
+                auditContext.CorrelationId,
+                dumpException.GetType().FullName ?? dumpException.GetType().Name,
+                dumpException.HResult);
             return null;
         }
+    }
+
+    private static IReadOnlyList<ExceptionFrame> ExceptionFrames(Exception exception)
+    {
+        var frames = new List<ExceptionFrame>();
+        var seen = new HashSet<Exception>(ReferenceEqualityComparer.Instance);
+        var pending = new Queue<Exception>();
+        pending.Enqueue(exception);
+
+        while (pending.Count > 0 && frames.Count < 16)
+        {
+            var current = pending.Dequeue();
+            if (!seen.Add(current)) continue;
+
+            frames.Add(new ExceptionFrame(
+                current.GetType().FullName ?? current.GetType().Name,
+                current.HResult,
+                current.StackTrace));
+
+            if (current is AggregateException aggregate)
+            {
+                foreach (var inner in aggregate.InnerExceptions) pending.Enqueue(inner);
+            }
+            else if (current.InnerException is not null)
+            {
+                pending.Enqueue(current.InnerException);
+            }
+        }
+
+        return frames;
     }
 
     private sealed record ExceptionDumpPayload(
         DateTimeOffset TimestampUtc,
         string Source,
-        string ExceptionType,
-        string Message,
-        string Detail,
-        string? RelatedMessage
+        MessageAuditContext AuditContext,
+        IReadOnlyList<ExceptionFrame> Exceptions
     );
+
+    private sealed record ExceptionFrame(string Type, int HResult, string? StackTrace);
 }

--- a/Marisa.BotDriver/Plugin/MarisaPluginBase.cs
+++ b/Marisa.BotDriver/Plugin/MarisaPluginBase.cs
@@ -21,11 +21,13 @@ public class MarisaPluginBase
         var currentException = Unwrap(exception);
         var dumpPath = TrySaveDump(currentException);
 
-        log.Error($"{exception}\nCaused by message: {message}");
-        if (dumpPath is not null)
-        {
-            log.Error("Exception dump saved to {0}", dumpPath);
-        }
+        log.Error(
+            "event=plugin_exception {0} source={1} error_type={2} hresult={3} dump={4}",
+            message.AuditContext,
+            GetType().FullName ?? GetType().Name,
+            currentException.GetType().FullName ?? currentException.GetType().Name,
+            currentException.HResult,
+            dumpPath is null ? "none" : Path.GetFileName(dumpPath));
 
         if (currentException is MissingConfigurationException missingConfigurationException)
         {
@@ -33,7 +35,7 @@ public class MarisaPluginBase
             return Task.CompletedTask;
         }
 
-        message.Send(new MessageDataText("出现异常，已上报开发者"));
+        message.Send(new MessageDataText($"出现异常，已上报开发者（故障编号：{message.AuditContext.CorrelationId}）"));
 
         return Task.CompletedTask;
 
@@ -41,7 +43,7 @@ public class MarisaPluginBase
         {
             return currentException is MissingConfigurationException
                 ? null
-                : ExceptionDump.Save(currentException, message.ToString(), GetType().FullName);
+                : ExceptionDump.Save(currentException, message.AuditContext, GetType().FullName);
         }
 
         static Exception Unwrap(Exception exception)

--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -26,7 +26,6 @@ public class MaiScoreHubClient
         string JobId,
         string? BotFriendCode,
         string? AuthToken,
-        string? Message,
         string? Stage,
         string? FriendRequestSentAt,
         string? ErrorCode,
@@ -41,33 +40,28 @@ public class MaiScoreHubClient
         string Status,
         string? Stage,
         string? Token,
-        string? Message,
         string? BotFriendCode,
         string? FriendRequestSentAt,
         string? ErrorCode,
-        DateTimeOffset? DeadlineAt)
+        DateTimeOffset? DeadlineAt,
+        bool DeadlineExceeded)
     {
         public bool FriendRequestSent =>
             !string.IsNullOrEmpty(FriendRequestSentAt) || Stage == "wait_acceptance";
-
-        public bool DeadlineExceeded => IsDeadlineExceeded(ErrorCode, Message);
     }
 
     public sealed record ProfileResult(bool HasLxns, bool HasDivingFish);
 
-    public sealed record ExportResult(bool Success, int Exported, int Scores, string? Message);
+    public sealed record ExportResult(bool Success, int Exported, int Scores);
 
     public sealed record JobStartResult(string JobId, DateTimeOffset? DeadlineAt);
 
     public sealed record JobResult(
         string Status,
         string? Stage,
-        string? Error,
         string? ErrorCode,
-        DateTimeOffset? DeadlineAt)
-    {
-        public bool DeadlineExceeded => IsDeadlineExceeded(ErrorCode, Error);
-    }
+        DateTimeOffset? DeadlineAt,
+        bool DeadlineExceeded);
 
     private static string? S(JsonElement e, string k) =>
         e.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
@@ -105,7 +99,6 @@ public class MaiScoreHubClient
             jobId,
             bot,
             authToken,
-            S(root, "message"),
             stage,
             friendRequestSentAt,
             errorCode,
@@ -147,11 +140,11 @@ public class MaiScoreHubClient
             status,
             stage ?? S(root, "stage"),
             token,
-            error ?? S(root, "message"),
             botFriendCode ?? S(root, "botUserFriendCode"),
             friendRequestSentAt ?? S(root, "friendRequestSentAt"),
             errorCode ?? S(root, "errorCode"),
-            deadlineAt ?? D(root, "deadlineAt"));
+            deadlineAt ?? D(root, "deadlineAt"),
+            IsDeadlineExceeded(errorCode ?? S(root, "errorCode"), error ?? S(root, "message")));
     }
 
     /// <summary>
@@ -171,7 +164,7 @@ public class MaiScoreHubClient
 
         if (resp.StatusCode >= 400)
         {
-            throw new InvalidOperationException(S(root, "message") ?? S(root, "error") ?? $"HTTP {resp.StatusCode}");
+            throw new InvalidOperationException($"MSH create update job failed with HTTP {resp.StatusCode}");
         }
 
         var jobId = S(root, "jobId");
@@ -194,9 +187,9 @@ public class MaiScoreHubClient
         return new JobResult(
             S(root, "status") ?? "",
             S(root, "stage"),
-            S(root, "error"),
             S(root, "errorCode"),
-            D(root, "deadlineAt"));
+            D(root, "deadlineAt"),
+            IsDeadlineExceeded(S(root, "errorCode"), S(root, "error")));
     }
 
     /// <summary>GET /me（Bearer）— 看 MSH 里已配置了哪些查分器令牌。</summary>
@@ -210,20 +203,6 @@ public class MaiScoreHubClient
         bool B(string k) => root.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.True;
 
         return new ProfileResult(B("hasLxnsImportToken"), B("hasDivingFishImportToken"));
-    }
-
-    /// <summary>
-    ///     PATCH /me（Bearer）— 设置某查分器的导入令牌。抓分完成后向已配置令牌的查分器
-    ///     推送由本客户端显式触发；不改动 autoUpdate（那是 MSH 的定时自动更新开关，
-    ///     是否开启应由用户在网站上自行决定）。
-    /// </summary>
-    public async Task SetTokenAsync(string jwt, string prober, string token)
-    {
-        object body = prober == "lxns"
-            ? new { lxnsImportToken = token }
-            : new { divingFishImportToken = token };
-
-        await Authed("/me", jwt).PatchJsonAsync(body);
     }
 
     /// <summary>
@@ -243,8 +222,7 @@ public class MaiScoreHubClient
 
         if (resp.StatusCode >= 400)
         {
-            using var err = JsonDocument.Parse(json);
-            return new ExportResult(false, 0, 0, S(err.RootElement, "message") ?? S(err.RootElement, "error") ?? $"HTTP {resp.StatusCode}");
+            return new ExportResult(false, 0, 0);
         }
 
         string exportJobId;
@@ -255,7 +233,7 @@ public class MaiScoreHubClient
             exportJobId = S(root, "exportJobId") ?? "";
         }
 
-        if (exportJobId.Length == 0) return new ExportResult(false, 0, 0, "创建导出任务失败（响应中无任务号）");
+        if (exportJobId.Length == 0) return new ExportResult(false, 0, 0);
 
         // 队列繁忙时导出任务需要排队，容忍偶发的查询失败，最长等待 5 分钟
         var deadline = DateTime.UtcNow.AddMinutes(5);
@@ -272,7 +250,7 @@ public class MaiScoreHubClient
             }
             catch
             {
-                if (++failures >= 6) return new ExportResult(false, 0, 0, "查询导出任务状态失败");
+                if (++failures >= 6) return new ExportResult(false, 0, 0);
                 continue;
             }
 
@@ -280,7 +258,7 @@ public class MaiScoreHubClient
             if (TryParseExportJob(doc.RootElement, prober, out var result)) return result;
         }
 
-        return new ExportResult(false, 0, 0, "导出任务等待超时");
+        return new ExportResult(false, 0, 0);
     }
 
     /// <summary>任务达到终态时解析对应查分器的回执；job 既可能是响应根级也可能嵌套于 job 字段。</summary>
@@ -302,11 +280,11 @@ public class MaiScoreHubClient
             int I(string k) => pr.TryGetProperty(k, out var v) && v.ValueKind == JsonValueKind.Number && v.TryGetInt32(out var n) ? n : 0;
 
             var ok = S(pr, "status") == "success";
-            result = new ExportResult(ok, I("exported"), I("scores"), S(pr, "message"));
+            result = new ExportResult(ok, I("exported"), I("scores"));
             return true;
         }
 
-        result = new ExportResult(status == "completed", 0, 0, S(job, "error") ?? status);
+        result = new ExportResult(status == "completed", 0, 0);
         return true;
     }
 

--- a/Marisa.Plugin.Test/MaiScoreHubClientTest.cs
+++ b/Marisa.Plugin.Test/MaiScoreHubClientTest.cs
@@ -83,7 +83,6 @@ public class MaiScoreHubClientTest
         {
             Assert.That(result.DeadlineExceeded, Is.True);
             Assert.That(result.ErrorCode, Is.Null);
-            Assert.That(result.Message, Is.EqualTo("DXNet job deadline exceeded"));
         });
     }
 

--- a/Marisa.Plugin.Test/MaiSyncCredentialSafetyTest.cs
+++ b/Marisa.Plugin.Test/MaiSyncCredentialSafetyTest.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Flurl.Http;
+using Flurl.Http.Testing;
+using Marisa.BotDriver;
+using Marisa.BotDriver.DI.Message;
+using Marisa.BotDriver.Entity.Message;
+using Marisa.BotDriver.Entity.MessageData;
+using Marisa.BotDriver.Entity.MessageSender;
+using Marisa.Configuration;
+using Marisa.Database;
+using Marisa.Database.Entity.Plugin.MaiMaiDx;
+using NUnit.Framework;
+
+namespace Marisa.Plugin.Test;
+
+[NonParallelizable]
+public class MaiSyncCredentialSafetyTest
+{
+    private const long Qq = 114514;
+    private const string FriendCode = "123456789012345";
+    private const string Sentinel = "SECRET_SENTINEL";
+    private const string SettingsUrl = "https://maiscorehub.bakapiano.com/app/sync";
+
+    private string _sourceConfigPath = null!;
+    private string _tempRoot = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _sourceConfigPath = Path.Join(FindRepositoryRoot(), "Marisa.StartUp", "config.yaml");
+        _tempRoot = Path.Join(Path.GetTempPath(), "Marisa.Plugin.Test", Guid.NewGuid().ToString("N"));
+        ConfigurationManager.SetConfigFilePath(CreateTestConfig(_tempRoot));
+        BotDbContext.EnsureCreated();
+        ResetDispatcherCaches();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        ResetDispatcherCaches();
+        ConfigurationManager.SetConfigFilePath(_sourceConfigPath);
+        if (Directory.Exists(_tempRoot)) Directory.Delete(_tempRoot, true);
+    }
+
+    [TestCase(null)]
+    [TestCase(1919810)]
+    public async Task Legacy_Token_Command_Should_Be_Rejected_Without_Http_Or_Realm_Changes(long? groupId)
+    {
+        using (var realm = BotDbContext.OpenRealm())
+        {
+            realm.Write(() => realm.AddWithAutoId(new MaiMaiDxBind(Qq, 0)
+            {
+                FriendCode = FriendCode,
+                ServerName = "DivingFish"
+            }));
+        }
+
+        using var http = new HttpTest();
+        var driver = TestBackend.Create(typeof(MaiMaiDx.MaiMaiDx));
+        await driver.SetMessage(Qq, groupId, $"mai 导 999999999999999 水鱼 {Sentinel}");
+        driver.Finish();
+
+        await driver.ProcAll();
+        var replies = await driver.GetAllSend();
+
+        using var check = BotDbContext.OpenRealm();
+        var binding = check.All<MaiMaiDxBind>().Single(x => x.UId == Qq);
+        var replyText = string.Join('\n', replies.Select(x => x.MessageChain.Text));
+        Assert.Multiple(() =>
+        {
+            Assert.That(binding.FriendCode, Is.EqualTo(FriendCode));
+            Assert.That(http.CallLog, Is.Empty);
+            Assert.That(replyText, Does.Contain("不再接收聊天中的查分器凭据"));
+            Assert.That(replyText, Does.Contain(SettingsUrl));
+            Assert.That(replyText, Does.Not.Contain(Sentinel));
+            Assert.That(replyText, Does.Not.Contain("999999999999999"));
+        });
+    }
+
+    [Test]
+    public async Task Missing_Prober_Tokens_Should_Stop_Before_Crawl()
+    {
+        using var http = LoginResponses(hasLxns: false, hasDivingFish: false);
+        var (target, queue) = CreateReplyTarget();
+
+        await InvokeRunSync(target);
+
+        var replyText = DrainReplies(queue);
+        Assert.Multiple(() =>
+        {
+            Assert.That(replyText, Does.Contain(SettingsUrl));
+            Assert.That(replyText, Does.Contain("尚未配置查分器"));
+            Assert.That(replyText, Does.Not.Contain("JWT_SENTINEL"));
+            Assert.That(http.CallLog.Count, Is.EqualTo(3));
+            Assert.That(http.CallLog, Has.None.Matches<FlurlCall>(x =>
+                x.Request.Url.ToString().Contains("/me/dxnet-jobs", StringComparison.Ordinal)));
+        });
+    }
+
+    [Test]
+    public async Task Configured_Prober_Should_Crawl_Then_Export()
+    {
+        using var http = LoginResponses(hasLxns: true, hasDivingFish: false);
+        http.RespondWithJson(new
+        {
+            jobId = "crawl-job",
+            job = new { deadlineAt = DateTimeOffset.UtcNow.AddMinutes(5) }
+        }, 201);
+        http.RespondWithJson(new { status = "completed", stage = "update_score" });
+        http.RespondWithJson(new
+        {
+            status = "completed",
+            result = new { lxns = new { status = "success", exported = 2202, scores = 2202 } }
+        });
+        var (target, queue) = CreateReplyTarget();
+
+        await InvokeRunSync(target);
+
+        var calls = http.CallLog.Select(x => x.Request.Url.ToString()).ToList();
+        var replyText = DrainReplies(queue);
+        Assert.Multiple(() =>
+        {
+            Assert.That(calls.FindIndex(x => x.EndsWith("/me", StringComparison.Ordinal)),
+                Is.LessThan(calls.FindIndex(x => x.EndsWith("/me/dxnet-jobs", StringComparison.Ordinal))));
+            Assert.That(calls, Has.Some.EndsWith("/me/sync/latest/exports/lxns"));
+            Assert.That(replyText, Does.Contain("落雪 ✅ 导入 2202/2202 条"));
+            Assert.That(replyText, Does.Not.Contain("JWT_SENTINEL"));
+        });
+    }
+
+    private static HttpTest LoginResponses(bool hasLxns, bool hasDivingFish)
+    {
+        var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            jobId = "login-job",
+            authToken = "fallback-jwt",
+            deadlineAt = DateTimeOffset.UtcNow.AddMinutes(5)
+        });
+        http.RespondWithJson(new { status = "completed", token = "JWT_SENTINEL" });
+        http.RespondWithJson(new
+        {
+            hasLxnsImportToken = hasLxns,
+            hasDivingFishImportToken = hasDivingFish
+        });
+        return http;
+    }
+
+    private static async Task InvokeRunSync(MessageReplyTarget target)
+    {
+        var method = typeof(MaiMaiDx.MaiMaiDx).GetMethod("RunSync", BindingFlags.Static | BindingFlags.NonPublic)!;
+        var task = (Task)method.Invoke(null, [target, FriendCode, (Func<TimeSpan, int>)(_ => 0)])!;
+        await task;
+    }
+
+    private static (MessageReplyTarget Target, MessageQueueProvider Queue) CreateReplyTarget()
+    {
+        var queue = new MessageQueueProvider();
+        var sender = new MessageSenderProvider(queue);
+        var message = new Message(
+            new MessageChain(new MessageDataId(1, 0), new MessageDataText("mai 导")),
+            sender)
+        {
+            Sender = new SenderInfo(Qq, "tester"),
+            Type = MessageType.FriendMessage
+        };
+        return (message.CaptureReplyTarget(), queue);
+    }
+
+    private static string DrainReplies(MessageQueueProvider queue)
+    {
+        var replies = new List<string>();
+        while (queue.SendQueue.Reader.TryRead(out var reply)) replies.Add(reply.MessageChain.Text);
+        return string.Join('\n', replies);
+    }
+
+    private static void ResetDispatcherCaches()
+    {
+        foreach (var fieldName in new[] { "_plugins", "_commands", "_subCommands" })
+        {
+            typeof(MessageDispatcher).GetField(fieldName, BindingFlags.Static | BindingFlags.NonPublic)!
+                .SetValue(null, null);
+        }
+    }
+
+    private string CreateTestConfig(string tempRoot)
+    {
+        var escapedTempRoot = tempRoot.Replace('\\', '/');
+        var config = File.ReadAllText(_sourceConfigPath);
+        config = Regex.Replace(config, @"^tempPath:\s*.*$", $"tempPath:     {escapedTempRoot}", RegexOptions.Multiline);
+        config = Regex.Replace(config, @"^databasePath:\s*.*$", "databasePath: bot.db", RegexOptions.Multiline);
+        var configPath = Path.Join(tempRoot, "config.yaml");
+        Directory.CreateDirectory(tempRoot);
+        File.WriteAllText(configPath, config);
+        return configPath;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(Environment.CurrentDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Join(directory.FullName, "Marisa.sln"))) return directory.FullName;
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate repository root from current test directory.");
+    }
+}

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -226,19 +226,14 @@ public partial class MaiMaiDx
 
     #region 推分同步（导）
 
+    private const string MshSettingsUrl = "https://maiscorehub.bakapiano.com/app/sync";
+
     private const string UsageText =
         "用法：\n" +
         "mai 导 —— 同步成绩到查分器（首次使用会引导设置）\n" +
         "mai 导 <好友码> —— 绑定/换绑好友码\n" +
-        "mai 导 落雪 xxx 水鱼 yyy —— 设置查分器导入令牌（可只填其中一个）\n" +
-        "令牌获取方法：\n\n" +
-        "水鱼：首页-编辑个人资料-成绩导入Token\n\n" +
-        "落雪：账号详情-个人API密钥\n\n" +
-        "建议发送令牌后立即「撤回」消息。";
-
-    private static readonly Regex SyncTokenArg = new(
-        @"(?<=^|\s)(?<key>落雪|水鱼|lxns|diving-fish|divingfish|df)[:：\s]+(?<val>\S+)",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        $"查分器凭据请只在 MSH 网页配置：{MshSettingsUrl}\n" +
+        "请勿向机器人发送水鱼/落雪 token、API key 或账号密码。";
 
     /// <summary>正在后台同步的用户集合，防止同一用户并发发起多个 MSH 任务。</summary>
     private static readonly ConcurrentDictionary<long, byte> Syncing = new();
@@ -256,31 +251,23 @@ public partial class MaiMaiDx
             friendCode = realm.All<MaiMaiDxBind>().FirstOrDefault(x => x.UId == qq)?.FriendCode;
         }
 
-        var (fcArg, lxns, df, junk) = ParseSyncArgs(message.Command.ToString());
-        if (junk != null)
+        var (inputKind, fcArg) = ParseSyncInput(message.Command);
+        if (inputKind == SyncInputKind.Unsupported)
         {
-            // 解析失败的原文不回显：其中可能包含真实令牌，而 bot 发出的消息用户无法撤回
-            ReplyAt(message, $"有解析失败的参数（请确认令牌前后有空格分隔）。\n{UsageText}");
+            ReplyAt(message,
+                "「mai 导」不再接收聊天中的查分器凭据，本消息未进入凭据配置流程。" +
+                $"请前往 {MshSettingsUrl} 配置后重试。" +
+                "如果刚才发送了真实 token、API key 或密码，它已经经过 QQ/NapCat，请立即在对应服务撤销或轮换。\n" +
+                UsageText);
             return MarisaPluginTaskState.CompletedTask;
         }
 
-        var newTokens = lxns == null && df == null ? ((string? Lxns, string? DivingFish)?)null : (lxns, df);
-
-        if (newTokens != null && message.GroupInfo != null)
-        {
-            ReplyAt(message, "令牌解析成功。建议立即「撤回」含有令牌的消息。");
-        }
-
-        // 同步任务可能持续数分钟，期间拒绝新的指令；携带令牌的指令需明确告知未提交，避免用户误以为设置已生效
         if (Syncing.ContainsKey(qq))
         {
-            ReplyAt(message, newTokens == null
-                ? "已有一个传分任务在进行中，请在该任务结束后再次发送指令。"
-                : "已有一个传分任务在进行中，请在该任务结束后再次发送带令牌的指令。");
+            ReplyAt(message, "已有一个传分任务在进行中，请在该任务结束后再次发送指令。");
             return MarisaPluginTaskState.CompletedTask;
         }
 
-        // 消息中携带好友码：执行绑定/换绑
         if (fcArg != null)
         {
             PersistFriendCode(qq, fcArg);
@@ -289,123 +276,49 @@ public partial class MaiMaiDx
 
         if (!string.IsNullOrWhiteSpace(friendCode))
         {
-            StartSync(message, friendCode!, newTokens);
+            StartSync(message.CaptureReplyTarget(), friendCode!);
             return MarisaPluginTaskState.CompletedTask;
         }
 
-        // 首次使用：通过对话引导完成设置，先收集好友码，必要时再收集令牌。
-        // 实现为单个对话的状态机（ToBeContinued 表示继续当前对话）。注意不能在对话 handler 内
-        // 对同一 key 再次调用 AddDialogAsync：它会自旋等待 key 释放，而 key 要到 handler 返回
-        // 之后才会释放，二者互相等待形成死锁。
-        ReplyAt(message, newTokens == null
-            ? "「首次传分设置」先发送你的 maimai DX 好友码（NET-好友-你的好友号码，15 位数字）。\n" +
-              "发送请求后会有bot账号在NET里加好友，同意后自动传分到水鱼/落雪。"
-            : "令牌解析成功，还需要好友码：请发送你的 maimai DX 好友码（NET-好友-你的好友号码，15 位数字）。");
+        ReplyAt(message,
+            "「首次传分设置」请发送你的 maimai DX 好友码（NET-好友-你的好友号码，15 位数字）。\n" +
+            "发送请求后会有 bot 账号在 NET 里加好友；查分器凭据只在 MSH 网页配置，请勿发送给机器人。");
 
-        var pendingTokens = newTokens;
         var startedAt = DateTime.UtcNow;
-        string? fc = null;
         await DialogManager.AddDialogAsync((message.GroupInfo?.Id, qq), next =>
         {
-            // 闲置超过 10 分钟的引导对话视为已放弃，避免长期驻留——否则用户日后偶然发送的
-            // 一串数字会被误认为好友码。返回 Canceled 会移除对话，并把该消息正常转交其它插件处理
             if (DateTime.UtcNow - startedAt > TimeSpan.FromMinutes(10))
             {
                 return Task.FromResult(MarisaPluginTaskState.Canceled);
             }
 
-            var input = next.Command.Trim().ToString();
-
-            // 第一步：收集好友码
-            if (fc == null)
+            var (nextKind, friendCodeInput) = ParseSyncInput(next.Command);
+            if (nextKind != SyncInputKind.FriendCode || friendCodeInput == null)
             {
-                if (input.Length != 15 || !input.All(char.IsAsciiDigit))
-                {
-                    ReplyAt(next, "好友码应为 15 位数字，解析失败，已退出设置。可重新发送「mai 导」。");
-                    return Task.FromResult(MarisaPluginTaskState.Canceled);
-                }
-
-                fc = input;
-                PersistFriendCode(next.Sender.Id, fc);
-                startedAt = DateTime.UtcNow; // 刷新计时：超时语义为「闲置 10 分钟」，而非从对话创建起算
-
-                if (pendingTokens != null)
-                {
-                    StartSync(next, fc, pendingTokens);
-                    return Task.FromResult(MarisaPluginTaskState.CompletedTask);
-                }
-
                 ReplyAt(next,
-                    "好友码已绑定。接下来请发送查分器的【导入令牌】（不是账号密码），一行一个，可只填其中一个：\n" +
-                    "落雪 xxx\n" +
-                    "水鱼 yyy\n" +
-                    "令牌获取方法：\n\n" +
-                    "水鱼：首页-编辑个人资料-成绩导入Token\n\n" +
-                    "落雪：账号详情-个人API密钥\n\n" +
-                    "建议发送令牌后立即「撤回」消息。如果不需要设置令牌，请发送「跳过」。");
-                return Task.FromResult(MarisaPluginTaskState.ToBeContinued);
-            }
-
-            // 第二步：收集令牌（或跳过）
-            if (input is "跳过" or "skip")
-            {
-                StartSync(next, fc, null);
-                return Task.FromResult(MarisaPluginTaskState.CompletedTask);
-            }
-
-            var (fcExtra, lx, d, leftover) = ParseSyncArgs(input);
-            if (lx == null && d == null)
-            {
-                ReplyAt(next, "没有解析到令牌（格式：落雪 xxx / 水鱼 yyy），已退出设置。之后可随时发送「mai 导 落雪 xxx 水鱼 yyy」完成设置。");
+                    "好友码必须是 15 位数字，且不要发送 token、API key 或账号密码；本次设置已退出。" +
+                    $"查分器凭据请在 {MshSettingsUrl} 配置。");
                 return Task.FromResult(MarisaPluginTaskState.Canceled);
             }
 
-            if (leftover != null || fcExtra != null)
-            {
-                // 部分解析成功（如「水鱼yyy」缺少空格）时整体拒绝，避免用户误以为两个令牌都已设置；
-                // 原文不回显，其中可能包含真实令牌
-                ReplyAt(next, "部分参数解析失败（请确认令牌前后有空格分隔），已退出设置。可重新发送「mai 导 落雪 xxx 水鱼 yyy」。" +
-                              (next.GroupInfo != null ? "建议立即「撤回」含有令牌的消息。" : ""));
-                return Task.FromResult(MarisaPluginTaskState.Canceled);
-            }
-
-            if (next.GroupInfo != null)
-            {
-                ReplyAt(next, "令牌解析成功。建议立即「撤回」含有令牌的消息。");
-            }
-
-            StartSync(next, fc, (lx, d));
+            PersistFriendCode(next.Sender.Id, friendCodeInput);
+            StartSync(next.CaptureReplyTarget(), friendCodeInput);
             return Task.FromResult(MarisaPluginTaskState.CompletedTask);
         }, this);
 
         return MarisaPluginTaskState.CompletedTask;
 
-        // 解析「导」命令的参数：15 位纯数字视为好友码，「落雪/水鱼 xxx」视为对应查分器的导入令牌；
-        // 无法解析的部分经 Junk 返回，Junk 非空时应回复用法说明，而不是猜测用户意图
-        static (string? Fc, string? Lxns, string? Df, string? Junk) ParseSyncArgs(string args)
+        static (SyncInputKind Kind, string? FriendCode) ParseSyncInput(ReadOnlyMemory<char> input)
         {
-            string? lxnsTok = null, dfTok = null;
-
-            var rest = SyncTokenArg.Replace(args, m =>
+            var value = input.Span.Trim();
+            if (value.IsEmpty) return (SyncInputKind.Empty, null);
+            if (value.Length != 15) return (SyncInputKind.Unsupported, null);
+            foreach (var character in value)
             {
-                var val = m.Groups["val"].Value;
-                // 令牌值均为 ASCII；匹配到非 ASCII 值（如「落雪 水鱼 yyy」缺少令牌值）时整段视为解析失败
-                if (val.Any(c => c > 127)) return m.Value;
-
-                if (m.Groups["key"].Value.ToLowerInvariant() is "落雪" or "lxns") lxnsTok = val;
-                else dfTok = val;
-                return " ";
-            });
-
-            string? fcVal = null;
-            var junkWords = new List<string>();
-            foreach (var w in rest.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries))
-            {
-                if (fcVal == null && w.Length == 15 && w.All(char.IsAsciiDigit)) fcVal = w;
-                else junkWords.Add(w);
+                if (!char.IsAsciiDigit(character)) return (SyncInputKind.Unsupported, null);
             }
 
-            return (fcVal, lxnsTok, dfTok, junkWords.Count == 0 ? null : string.Join(' ', junkWords));
+            return (SyncInputKind.FriendCode, value.ToString());
         }
 
         // 仅持久化好友码；令牌不落库，仅经手转交 MSH
@@ -429,7 +342,13 @@ public partial class MaiMaiDx
         }
     }
 
-    /// <summary>用 @ 用户代替引用回复：传分消息常落在已被撤回的令牌消息上，引用会显示「原消息已被撤回」。</summary>
+    private enum SyncInputKind
+    {
+        Empty,
+        FriendCode,
+        Unsupported
+    }
+
     private static void ReplyAt(Message message, string text)
     {
         if (message.GroupInfo == null)
@@ -442,13 +361,13 @@ public partial class MaiMaiDx
         }
     }
 
-    private static void StartSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
+    private static void ReplyAt(MessageReplyTarget target, string text) => target.Reply(text, true);
+
+    private static void StartSync(MessageReplyTarget target, string friendCode)
     {
-        if (!Syncing.TryAdd(message.Sender.Id, 0))
+        if (!Syncing.TryAdd(target.SenderId, 0))
         {
-            ReplyAt(message, newTokens == null
-                ? "已有一个传分任务在进行中，请在该任务结束后再次发送指令。"
-                : "已有一个传分任务在进行中，请在该任务结束后再次发送带令牌的指令。");
+            ReplyAt(target, "已有一个传分任务在进行中，请在该任务结束后再次发送指令。");
             return;
         }
 
@@ -456,43 +375,39 @@ public partial class MaiMaiDx
         {
             try
             {
-                await RunSync(message, friendCode, newTokens);
+                await RunSync(target, friendCode);
             }
             catch (Exception e)
             {
-                ReplyAt(message, $"同步失败：{e.Message}。{RetryHint(newTokens)}");
+                LogSyncFailure(target, "run_sync", e);
+                ReplyAt(target, $"同步暂时失败，请稍后重试「mai 导」（故障编号：{target.CorrelationId}）。");
             }
             finally
             {
-                Syncing.TryRemove(message.Sender.Id, out _);
+                Syncing.TryRemove(target.SenderId, out _);
             }
         });
     }
 
-    /// <summary>失败后的重试提示。令牌不落库，携带令牌的同步失败后需要用户重发令牌。</summary>
-    private static string RetryHint((string? Lxns, string? DivingFish)? newTokens) => newTokens == null
-        ? "重试「mai 导」即可。"
-        : "请重新发送「mai 导 落雪/水鱼 xxx」（失败时令牌可能未被保存）。";
-
-    /// <summary>轮询退避：前 1 分钟每 5 秒（保证状态切换灵敏），随后拉长到 10、20 秒，减轻 MSH 单实例负担。</summary>
     private static int PollDelayMs(TimeSpan waited) =>
         waited < TimeSpan.FromMinutes(1) ? 5000 :
         waited < TimeSpan.FromMinutes(3) ? 10000 : 20000;
 
-    /// <summary>跑一次完整同步：登录 → 轮询 → （可选设令牌）→ 推到所有已配置的查分器。</summary>
-    private static async Task RunSync(Message message, string friendCode, (string? Lxns, string? DivingFish)? newTokens)
+    private static async Task RunSync(
+        MessageReplyTarget target,
+        string friendCode,
+        Func<TimeSpan, int>? pollDelay = null)
     {
         var msh = new MaiScoreHubClient();
+        var delay = pollDelay ?? PollDelayMs;
 
-        var retryHint = RetryHint(newTokens);
-
-        ReplyAt(message, "正在发送请求…");
+        ReplyAt(target, "正在发送请求…");
 
         var login = await msh.LoginRequestAsync(friendCode);
         var announced = false;
         if (login.FriendRequestSent && !string.IsNullOrEmpty(login.BotFriendCode))
         {
-            ReplyAt(message, $"Bot 账号（好友码{login.BotFriendCode}）已发出好友申请，请尽快到 NET 同意。若任务随后超时，按提示重试即可。");
+            ReplyAt(target, $"Bot 账号（好友码{login.BotFriendCode}）已发出好友申请，请尽快到 NET 同意。若任务随后超时，按提示重试即可。");
             announced = true;
         }
 
@@ -504,7 +419,7 @@ public partial class MaiMaiDx
         var queuedNotified = false;
         while (DateTime.UtcNow < deadline)
         {
-            await Task.Delay(PollDelayMs(DateTime.UtcNow - waitStart));
+            await Task.Delay(delay(DateTime.UtcNow - waitStart));
 
             try
             {
@@ -514,7 +429,8 @@ public partial class MaiMaiDx
             catch (Exception e)
             {
                 if (++pollFailures < 6) continue;
-                ReplyAt(message, $"同步中断：连续多次查询任务状态失败（{e.Message}）。稍后{retryHint}");
+                LogSyncFailure(target, "poll_login", e);
+                ReplyAt(target, $"同步中断：连续多次查询 MSH 登录状态失败。稍后重试「mai 导」即可（故障编号：{target.CorrelationId}）。");
                 return;
             }
 
@@ -526,59 +442,69 @@ public partial class MaiMaiDx
             {
                 if (status.DeadlineExceeded)
                 {
-                    ReplyAt(message, sawAcceptance
-                        ? $"同步失败：MSH 好友验证任务已超过服务端截止时间，好友申请虽已发出，但未能及时确认好友关系。稍后{retryHint}"
-                        : $"同步失败：MSH 未能在服务端截止前发出好友申请（服务排队超时，与你是否同意无关）。稍后{retryHint}");
+                    ReplyAt(target, sawAcceptance
+                        ? "同步失败：MSH 好友验证任务已超过服务端截止时间，好友申请虽已发出，但未能及时确认好友关系。稍后重试「mai 导」即可。"
+                        : "同步失败：MSH 未能在服务端截止前发出好友申请（服务排队超时，与你是否同意无关）。稍后重试「mai 导」即可。");
                 }
                 else
                 {
-                    ReplyAt(message, $"同步失败：{status.Message ?? status.Status}。{retryHint}");
+                    ReplyAt(target, $"MSH 登录任务失败，请稍后重试「mai 导」（故障编号：{target.CorrelationId}）。");
                 }
                 return;
             }
 
             if (!announced && status.Stage == "wait_acceptance" && !string.IsNullOrEmpty(status.BotFriendCode))
             {
-                ReplyAt(message, $"Bot 账号（好友码{status.BotFriendCode}）已发出好友申请，请尽快到 NET 同意。若任务随后超时，按提示重试即可。");
+                ReplyAt(target, $"Bot 账号（好友码{status.BotFriendCode}）已发出好友申请，请尽快到 NET 同意。若任务随后超时，按提示重试即可。");
                 announced = true;
             }
 
-            // 老用户（已是好友）不会触发好友申请提示，任务也常卡在 send_request 排队；等待超过 30 秒仍无进展时
-            // 一次性告知请求已被受理，避免整段静默后只见超时
             if (!announced && !queuedNotified && DateTime.UtcNow - waitStart > TimeSpan.FromSeconds(30))
             {
-                ReplyAt(message, "同步请求已受理，正在等待处理（繁忙时可能需要排队几分钟），请稍候。");
+                ReplyAt(target, "同步请求已受理，正在等待处理（繁忙时可能需要排队几分钟），请稍候。");
                 queuedNotified = true;
             }
         }
 
         if (status == null || (!status.Done && string.IsNullOrEmpty(status.Token)))
         {
-            ReplyAt(message, sawAcceptance
-                ? $"等待超时（可能未及时同意好友申请）。同意后{retryHint}"
-                : $"等待超时（服务繁忙，好友申请仍在排队、未能及时处理，与你是否同意无关）。稍后{retryHint}");
+            ReplyAt(target, sawAcceptance
+                ? "等待超时（可能未及时同意好友申请）。同意后重试「mai 导」即可。"
+                : "等待超时（服务繁忙，好友申请仍在排队、未能及时处理，与你是否同意无关）。稍后重试「mai 导」即可。");
             return;
         }
 
-        // JWT 随登录任务完成（好友关系确认）下发；创建登录任务时的 authToken 仅作回退
         var jwt = !string.IsNullOrEmpty(status.Token) ? status.Token! : login.AuthToken;
         if (string.IsNullOrEmpty(jwt))
         {
-            ReplyAt(message, "登录完成，但未获取到登录凭据（MSH 的 token 下发方式可能已变更）。请向开发者反馈。");
+            ReplyAt(target, $"MSH 登录完成但未返回临时凭据，请向开发者反馈（故障编号：{target.CorrelationId}）。");
             return;
         }
 
-        // 一拿到 JWT 即把令牌存入 MSH：抓分等待可能超时，提前提交可避免本次令牌白费、被迫重发令牌
-        if (newTokens is { } t)
+        MaiScoreHubClient.ProfileResult profile;
+        try
         {
-            if (!string.IsNullOrWhiteSpace(t.Lxns)) await msh.SetTokenAsync(jwt, "lxns", t.Lxns!);
-            if (!string.IsNullOrWhiteSpace(t.DivingFish)) await msh.SetTokenAsync(jwt, "diving-fish", t.DivingFish!);
-            retryHint = "重试「mai 导」即可。"; // 令牌已存入 MSH，后续失败无需再带令牌重发
+            profile = await msh.GetProfileAsync(jwt);
+        }
+        catch (Exception e)
+        {
+            LogSyncFailure(target, "get_profile", e);
+            ReplyAt(target, $"无法读取 MSH 查分器配置，请稍后重试「mai 导」（故障编号：{target.CorrelationId}）。");
+            return;
         }
 
-        // 第二阶段：创建独立的抓分任务并等待完成。登录任务不再包含抓分，把登录任务号作为
-        // 好友关系凭证传入可立即开始抓分。抓分阶段单独计时：第一阶段需等待好友申请送达并被
-        // 接受，繁忙时可能已耗去大部分时间，共用截止时间会使抓分预算所剩无几
+        var targets = new List<string>();
+        if (profile.HasLxns) targets.Add("lxns");
+        if (profile.HasDivingFish) targets.Add("diving-fish");
+
+        if (targets.Count == 0)
+        {
+            ReplyAt(target,
+                $"你的 MSH 账号尚未配置查分器。请在浏览器打开 {MshSettingsUrl}，登录并配置后重新发送「mai 导」。" +
+                "请勿把 token、API key 或账号密码发送给机器人。");
+            return;
+        }
+
         MaiScoreHubClient.JobStartResult crawl;
         try
         {
@@ -586,7 +512,8 @@ public partial class MaiMaiDx
         }
         catch (Exception e)
         {
-            ReplyAt(message, $"同步失败：创建抓分任务未成功（{e.Message}）。{retryHint}");
+            LogSyncFailure(target, "create_crawl", e);
+            ReplyAt(target, $"创建 MSH 抓分任务失败，请稍后重试「mai 导」（故障编号：{target.CorrelationId}）。");
             return;
         }
 
@@ -597,7 +524,7 @@ public partial class MaiMaiDx
         var crawlDone = false;
         while (DateTime.UtcNow < deadline)
         {
-            await Task.Delay(PollDelayMs(DateTime.UtcNow - crawlStart));
+            await Task.Delay(delay(DateTime.UtcNow - crawlStart));
 
             MaiScoreHubClient.JobResult job;
             try
@@ -608,7 +535,8 @@ public partial class MaiMaiDx
             catch (Exception e)
             {
                 if (++pollFailures < 6) continue;
-                ReplyAt(message, $"同步中断：连续多次查询任务状态失败（{e.Message}）。稍后{retryHint}");
+                LogSyncFailure(target, "poll_crawl", e);
+                ReplyAt(target, $"同步中断：连续多次查询 MSH 抓分状态失败。稍后重试「mai 导」即可（故障编号：{target.CorrelationId}）。");
                 return;
             }
 
@@ -620,29 +548,16 @@ public partial class MaiMaiDx
 
             if (job.Status is "failed" or "canceled")
             {
-                ReplyAt(message, job.DeadlineExceeded
-                    ? $"同步失败：MSH 未能在服务端截止前完成成绩抓取，本次任务已结束。稍后{retryHint}"
-                    : $"同步失败：{job.Error ?? job.Status}。{retryHint}");
+                ReplyAt(target, job.DeadlineExceeded
+                    ? "同步失败：MSH 未能在服务端截止前完成成绩抓取，本次任务已结束。稍后重试「mai 导」即可。"
+                    : $"MSH 抓分任务失败，请稍后重试「mai 导」（故障编号：{target.CorrelationId}）。");
                 return;
             }
         }
 
         if (!crawlDone)
         {
-            ReplyAt(message, $"等待超时（服务繁忙，成绩抓取未在限定时间内完成）。稍后{retryHint}");
-            return;
-        }
-
-        // 查询 MSH 中已配置的查分器
-        var profile = await msh.GetProfileAsync(jwt);
-
-        var targets = new List<string>();
-        if (profile.HasLxns) targets.Add("lxns");
-        if (profile.HasDivingFish) targets.Add("diving-fish");
-
-        if (targets.Count == 0)
-        {
-            ReplyAt(message, "成绩已抓取，但尚未配置任何查分器令牌。发送「mai 导 落雪 xxx 水鱼 yyy」完成设置（可只填其中一个，建议发送令牌后立即「撤回」消息）。");
+            ReplyAt(target, "等待超时（服务繁忙，成绩抓取未在限定时间内完成）。稍后重试「mai 导」即可。");
             return;
         }
 
@@ -652,18 +567,30 @@ public partial class MaiMaiDx
             var name = p == "lxns" ? "落雪" : "水鱼";
             try
             {
-                // 导出为异步任务，ExportAsync 内部轮询至终态后返回该查分器的回执
                 var r = await msh.ExportAsync(jwt, p);
 
-                sb.AppendLine(r.Success ? $"{name} ✅ 导入 {r.Exported}/{r.Scores} 条" : $"{name} ❌ {r.Message ?? "失败"}");
+                sb.AppendLine(r.Success
+                    ? $"{name} ✅ 导入 {r.Exported}/{r.Scores} 条"
+                    : $"{name} ❌ 导出失败，请检查 MSH 中的查分器凭据");
             }
             catch (Exception e)
             {
-                sb.AppendLine($"{name} ❌ {e.Message}");
+                LogSyncFailure(target, $"export_{p}", e);
+                sb.AppendLine($"{name} ❌ 导出失败（故障编号：{target.CorrelationId}）");
             }
         }
 
-        ReplyAt(message, sb.ToString().TrimEnd());
+        ReplyAt(target, sb.ToString().TrimEnd());
+    }
+
+    private static void LogSyncFailure(MessageReplyTarget target, string operation, Exception exception)
+    {
+        NLog.LogManager.GetCurrentClassLogger().Error(
+            "event=msh_sync_failed correlation={0} operation={1} error_type={2} hresult={3}",
+            target.CorrelationId,
+            operation,
+            exception.GetType().FullName ?? exception.GetType().Name,
+            exception.HResult);
     }
 
     #endregion


### PR DESCRIPTION
## 背景

#110 收紧了 OAuth callback 与授权消息的日志边界，但当时明确保留了一项既有风险：`mai 导` 允许用户在 QQ 中发送长期水鱼 Import-Token 或落雪 Personal Token/API key。

消息撤回无法删除 QQ/NapCat、Bot 控制台与文件日志、exception dump、外部日志采集或备份中的副本。插件级正则脱敏也来不及保护首次日志，因为 `BotDriver` 在 dispatch 前就会记录完整 `Message`。

MSH 已提供受登录保护的 [`/app/sync`](https://maiscorehub.bakapiano.com/app/sync) 页面，可直接配置两类查分器凭据。因此本 PR 将长期凭据的正常路径收缩为“用户浏览器 → MSH”，QQ 与 MarisaBot 不再承接凭据。

## 修改

### 默认无正文的消息审计

- 入站消息只记录随机 correlation ID、HMAC 伪名、消息/位置类型、segment 类型与文本长度；不记录正文、昵称、原始 QQ/群号或正文 hash。
- `Message.ToString()` 改为安全审计表示，避免后续误用重新暴露正文。
- handler 完成、timeout、dispatch failure 与兜底异常统一记录安全元数据、异常类型和 HResult。
- 插件异常日志不再插值 `Message` 或原始 `Exception`；用户只收到稳定文案和 correlation ID。
- exception dump 删除 `Message`、`Detail`、`RelatedMessage` 与异常 message，仅保存审计上下文、异常类型链、HResult 和 stack trace。
- 保留 `MessageChain.FromSensitiveText` 的真实发送载荷，但不再依赖它保护普通入站消息。

### NapCat 日志与鉴权

- 出站日志只记录目标伪名和 segment 结构，不记录消息正文。
- 未实现 event 不再记录完整 OneBot JSON；action failure 不再把完整响应 JSON放入异常。
- 连接日志删除 URI userinfo、query 与 fragment。
- `napCat.token` 只通过 NapCat 支持的 `Authorization: Bearer` header 发送，不再同时追加为 `access_token` query。

### `mai 导` 凭据流程

- 删除 `mai 导 落雪 xxx 水鱼 yyy`、token 正则、dialog 第二阶段、闭包传递及 `MaiScoreHubClient.SetTokenAsync`。
- 命令参数采用严格允许列表：仅接受空参数或单个 15 位好友码；其他输入在 Realm 写入和 MSH 调用前整体拒绝，且不复制或回显后缀。
- 旧用法会提示该值未进入凭据配置流程；如果内容是真实凭据，要求立即在对应服务撤销或轮换。
- 首次 dialog 只收好友码，并明确禁止发送 token、API key 或账号密码。
- 获得 MSH JWT 后先调用 `GET /me`；没有已配置目标时直接引导到 MSH `/app/sync`，不创建抓分任务。
- 后台同步只捕获不含 `Message`/`MessageChain`/`Command` 的最小回复目标。
- MSH 登录、轮询、抓分和导出错误不再向 QQ透传外部 `message`、response body、URL 或 job ID，只返回本地稳定文案和 correlation ID。

## 兼容性

- `mai 导`：继续使用已绑定好友码同步。
- `mai 导 <15 位好友码>`：继续绑定/换绑并同步。
- 已在 MSH 配置水鱼或落雪的用户：继续抓分并导出到已配置目标。
- 尚未配置查分器的用户：登录 MSH 网页配置后重新执行 `mai 导`。
- 曾通过 QQ发送有效凭据的用户：应按可能泄露处理并轮换；本次修改无法证明历史平台日志或备份已删除。

## 测试与验证

Windows / .NET 8 真实验证：

- `Marisa.BotDriver.Test`：26/26 通过。
- 日志、异常、dump、timeout、NapCat query/response sentinel 安全用例：10/10 通过。
- `MaiSyncCredentialSafetyTest` + `MaiScoreHubClientTest`：9/9 通过。
- `Marisa.StartUp.Test`：1/1 通过。
- Plugin build：6 个项目，0 error，0 warning。
- Startup build：8 个项目，0 error，0 warning；npm/Vite 构建通过。
- `git diff --check upstream/master...HEAD`：通过。

全量 `Marisa.Plugin.Test` 在同一无本地密钥/外部缓存环境中做了基线对照：

- `upstream/master`：488 passed / 12 failed / 2 skipped；
- 本 PR：492 passed / 12 failed / 2 skipped；
- 失败集合完全一致，新增 4 条测试全部通过。既有失败来自 Louis/Osu 缺失外部配置、资源/Realm 测试数据及旧 Dialog 夹具，不经过本 PR 路径。

## 建议重点 Review

1. `MessageAuditContext` 是否只包含允许的元数据，且 HMAC 域分隔正确；
2. exception dump 是否仍可能通过 stack 之外的字段携带动态秘密；
3. NapCat Authorization header 兼容性与 endpoint 日志脱敏；
4. 旧 token 命令是否在任何 Realm/MSH 副作用前拒绝；
5. MSH profile gate 是否确实早于 crawl/export；
6. `MessageReplyTarget` 是否避免后台任务延长原始消息正文生命周期。

---

初始安全方案由 **ChatGPT** 提供；方案复核、实现与验证由 **Codex（GPT-5）** 完成。

PR Body 由 **Codex（GPT-5）** 撰写。
