### PR TITLE
fix(maimai): 修复 MSH 登录请求失败

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/MaiScoreHubClient.cs
@@ -3,6 +3,14 @@ using Flurl.Http;
 
 namespace Marisa.Plugin.Shared.MaiMaiDx;
 
+public sealed class MaiScoreHubApiException(int statusCode, string? errorCode, string message) : Exception(message)
+{
+    public int StatusCode { get; } = statusCode;
+    public string? ErrorCode { get; } = errorCode;
+    public bool IsTransientLoginFailure =>
+        errorCode is "cabinet_bot_unavailable" or "bot_assignment_busy" || statusCode == 503;
+}
+
 /// <summary>
 ///     通过 maimai-score-hub 创建 DXNet 抓分任务，并将结果导出到用户配置的查分器。
 /// </summary>
@@ -78,13 +86,16 @@ public class MaiScoreHubClient
     /// <summary>POST /auth/login-requests — 用好友码发起登录任务（Bot 向用户发好友申请）。</summary>
     public async Task<LoginRequestResult> LoginRequestAsync(string friendCode)
     {
-        var json = await Req("/auth/login-requests")
-            .PostJsonAsync(new { friendCode, method = "bot_sends_request" })
-            .ReceiveString();
+        var response = await Req("/auth/login-requests")
+            .AllowAnyHttpStatus()
+            .PostJsonAsync(new { friendCode, method = "bot_sends_request" });
+        var json = await response.GetStringAsync();
+        if (response.StatusCode >= 400) throw LoginRequestError(response.StatusCode, json);
 
         using var doc = JsonDocument.Parse(json);
         var root  = doc.RootElement;
         var jobId = S(root, "jobId") ?? "";
+        if (jobId.Length == 0) throw new InvalidOperationException("MSH 登录响应缺少任务编号");
 
         // Bot 好友码可能位于根级（botFriendCode）或嵌套任务对象（botUserFriendCode，任务被
         // 调度前为空），两处都取
@@ -110,6 +121,31 @@ public class MaiScoreHubClient
             friendRequestSentAt,
             errorCode,
             deadlineAt);
+
+        static MaiScoreHubApiException LoginRequestError(int statusCode, string body)
+        {
+            string? errorCode = null;
+            string? serverMessage = null;
+            try
+            {
+                using var error = JsonDocument.Parse(body);
+                errorCode = S(error.RootElement, "code");
+                serverMessage = S(error.RootElement, "message") ?? S(error.RootElement, "error");
+            }
+            catch (JsonException)
+            {
+            }
+
+            var message = errorCode switch
+            {
+                "cabinet_bot_unavailable" => "MSH 当前没有可用的 Bot 账号",
+                "bot_assignment_busy" => "MSH 正在分配 Bot 账号",
+                _ when serverMessage == "Validation failed" => "MSH 拒绝了登录请求（参数验证失败）",
+                _ when !string.IsNullOrWhiteSpace(serverMessage) => $"MSH 拒绝了登录请求：{serverMessage}",
+                _ => $"MSH 登录请求失败（HTTP {statusCode}）"
+            };
+            return new MaiScoreHubApiException(statusCode, errorCode, message);
+        }
     }
 
     /// <summary>

--- a/Marisa.Plugin.Test/MaiScoreHubClientTest.cs
+++ b/Marisa.Plugin.Test/MaiScoreHubClientTest.cs
@@ -1,8 +1,14 @@
 using System;
+using System.Reflection;
 using System.Threading.Tasks;
 using Flurl.Http.Testing;
+using Marisa.BotDriver.DI.Message;
+using Marisa.BotDriver.Entity.Message;
+using Marisa.BotDriver.Entity.MessageData;
+using Marisa.BotDriver.Entity.MessageSender;
 using Marisa.Plugin.Shared.MaiMaiDx;
 using NUnit.Framework;
+using MaiMaiDxPlugin = Marisa.Plugin.MaiMaiDx.MaiMaiDx;
 
 namespace Marisa.Plugin.Test;
 
@@ -59,6 +65,102 @@ public class MaiScoreHubClientTest
         var result = await new MaiScoreHubClient().LoginRequestAsync(FriendCode);
 
         Assert.That(result.FriendRequestSent, Is.True);
+    }
+
+    [Test]
+    public void LoginRequest_CapacityFailure_IsStructuredAndRetryable()
+    {
+        using var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            statusCode = 400,
+            code = "cabinet_bot_unavailable",
+            message = "Bot friend capacity is exhausted"
+        }, 400);
+
+        var error = Assert.ThrowsAsync<MaiScoreHubApiException>(async () =>
+            await new MaiScoreHubClient().LoginRequestAsync(FriendCode));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(error!.StatusCode, Is.EqualTo(400));
+            Assert.That(error.ErrorCode, Is.EqualTo("cabinet_bot_unavailable"));
+            Assert.That(error.IsTransientLoginFailure, Is.True);
+            Assert.That(error.Message, Is.EqualTo("MSH 当前没有可用的 Bot 账号"));
+        });
+    }
+
+    [Test]
+    public void LoginRequest_ValidationFailure_IsNotRetryable()
+    {
+        using var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            statusCode = 400,
+            message = "Validation failed"
+        }, 400);
+
+        var error = Assert.ThrowsAsync<MaiScoreHubApiException>(async () =>
+            await new MaiScoreHubClient().LoginRequestAsync(FriendCode));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(error!.IsTransientLoginFailure, Is.False);
+            Assert.That(error.Message, Is.EqualTo("MSH 拒绝了登录请求（参数验证失败）"));
+        });
+    }
+
+    [Test]
+    public void LoginRequest_AssignmentBusy_IsRetryable()
+    {
+        using var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            statusCode = 503,
+            code = "bot_assignment_busy",
+            message = "Bot assignment is busy; retry after 5 seconds"
+        }, 503);
+
+        var error = Assert.ThrowsAsync<MaiScoreHubApiException>(async () =>
+            await new MaiScoreHubClient().LoginRequestAsync(FriendCode));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(error!.StatusCode, Is.EqualTo(503));
+            Assert.That(error.IsTransientLoginFailure, Is.True);
+            Assert.That(error.Message, Is.EqualTo("MSH 正在分配 Bot 账号"));
+        });
+    }
+
+    [Test]
+    public void Sync_RetriesTransientLoginFailure()
+    {
+        using var http = new HttpTest();
+        http.RespondWithJson(new
+        {
+            statusCode = 400,
+            code = "cabinet_bot_unavailable",
+            message = "Bot friend capacity is exhausted"
+        }, 400);
+        http.RespondWithJson(new
+        {
+            statusCode = 400,
+            message = "Validation failed"
+        }, 400);
+
+        var queue = new MessageQueueProvider();
+        var sender = new MessageSenderProvider(queue);
+        var message = new Message(new MessageChain(new MessageDataText("mai sync")), sender)
+        {
+            Type = MessageType.FriendMessage,
+            Sender = new SenderInfo(1001, "tester")
+        };
+        var runSync = typeof(MaiMaiDxPlugin).GetMethod("RunSync", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var task = (Task)runSync.Invoke(null, [message, FriendCode, null])!;
+
+        var error = Assert.ThrowsAsync<MaiScoreHubApiException>(async () => await task);
+
+        Assert.That(error!.Message, Is.EqualTo("MSH 拒绝了登录请求（参数验证失败）"));
     }
 
     [Test]

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -226,6 +226,9 @@ public partial class MaiMaiDx
 
     #region 推分同步（导）
 
+    private const int LoginRequestMaxAttempts = 4;
+    private const int LoginRequestRetryDelayMs = 5000;
+
     private const string UsageText =
         "用法：\n" +
         "mai 导 —— 同步成绩到查分器（首次使用会引导设置）\n" +
@@ -488,7 +491,7 @@ public partial class MaiMaiDx
 
         ReplyAt(message, "正在发送请求…");
 
-        var login = await msh.LoginRequestAsync(friendCode);
+        var login = await CreateLoginRequest();
         var announced = false;
         if (login.FriendRequestSent && !string.IsNullOrEmpty(login.BotFriendCode))
         {
@@ -664,6 +667,21 @@ public partial class MaiMaiDx
         }
 
         ReplyAt(message, sb.ToString().TrimEnd());
+
+        async Task<MaiScoreHubClient.LoginRequestResult> CreateLoginRequest()
+        {
+            for (var attempt = 1;; attempt++)
+            {
+                try
+                {
+                    return await msh.LoginRequestAsync(friendCode);
+                }
+                catch (MaiScoreHubApiException e) when (e.IsTransientLoginFailure && attempt < LoginRequestMaxAttempts)
+                {
+                    await Task.Delay(LoginRequestRetryDelayMs);
+                }
+            }
+        }
     }
 
     #endregion


### PR DESCRIPTION
## 概要

- 解析 MSH 登录接口的结构化错误，避免直接向用户返回原始 Flurl 400 异常
- 对 Bot 容量不足、分配繁忙及 HTTP 503 等临时失败最多重试 4 次，每次间隔 5 秒
- 参数验证失败等确定性错误立即返回，并保留可读的失败原因
- 补充登录错误分类及同步重试测试

## 验证

- MaiScoreHubClientTest：9/9 通过
- Marisa.Plugin 构建：0 error、0 warning
- 使用真实好友流程完成端到端同步：落雪 2202/2202，水鱼 2202/2202
