### PR TITLE
feat(maimai): 完成表支持多谱面难度筛选

### DIFF
--- a/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
+++ b/Marisa.Plugin.Shared/MaiMaiDx/PlateData.cs
@@ -87,7 +87,7 @@ public static class PlateData
     /// <summary>默认阈值（"将"=SSS）。用户未指定阈值时自动应用。</summary>
     public static readonly Threshold DefaultThreshold = new(Dimension.Achievement, 12, "SSS");
 
-    public enum ErrorKind { NotPlateCommand, EmptyQuery, UnsupportedPlate, UnknownSelector, ConflictingSelector }
+    public enum ErrorKind { NotPlateCommand, EmptyQuery, UnsupportedPlate, UnknownSelector, ConflictingSelector, InvalidDifficulty }
 
     public sealed record ParseError(ErrorKind Kind, string? Detail = null);
 
@@ -625,7 +625,7 @@ public static class PlateData
     /// <summary>
     ///     难度别名表。**故意不收单字**（绿/黄/红/紫/白），因为这些字跟代字（紫=MURASAKi、白=MiLK）
     ///     或者用户预期的别名会冲突。要写中文必须双字"绿谱/黄谱/红谱/紫谱/白谱"
-    ///     （单字色名仅 <see cref="TryStripDifficultyAffix"/> 在句首/句尾剥离时接受）。
+    ///     单字色名仅在句首/句尾剥离或「红-白谱」这类闭区间中接受。
     ///     Re:MASTER 是合法的 difficulty（用户显式指定时才走），但不是所有歌都有该难度。
     /// </summary>
     public static readonly Dictionary<string, int> DifficultyAliasMap = new(StringComparer.OrdinalIgnoreCase)
@@ -641,8 +641,7 @@ public static class PlateData
         DifficultyAliasMap.Select(kv => (kv.Key, kv.Value))
             .OrderByDescending(t => t.Key.Length).ToArray();
 
-    /// <summary>单字色名（仅句首/句尾剥离接受）。不进 <see cref="DifficultyAliasMap"/>：完成表的
-    /// anywhere 匹配下单字与版本代字冲突（紫=MURASAKi、白=MiLK）。</summary>
+    /// <summary>单字色名不进 <see cref="DifficultyAliasMap"/>，避免与版本代字冲突。</summary>
     private static readonly (char Color, int LevelIdx)[] SingleColorEntries =
         [('绿', 0), ('黄', 1), ('红', 2), ('紫', 3), ('白', 4)];
 
@@ -821,25 +820,16 @@ public static class PlateData
             ? (parsePart[..thresholdAt] + parsePart[(thresholdAt + thresholdLen)..]).Trim()
             : parsePart;
 
-        // 2. 难度 token（可选，同样 anywhere + rightmost + 同样的 ASCII letter 边界规则）。
-        //    缺省时回落到 DefaultLevelIdxes ([3, 4] = MASTER + Re:MASTER)；显式给一个就是单元素。
-        IReadOnlyList<int> levelIdxes = DefaultLevelIdxes;
-        int diffAt = -1, diffLen = 0;
-        foreach (var (token, idx) in DifficultyEntriesLongestFirst)
+        // 2. 难度集合：在原字符串上从左到右扫描一次，避免删除旧 token 后拼出新 token。
+        //    列表内是 OR；区间为低到高的闭区间。任意显式集合都覆盖默认难度。
+        if (!TryExtractDifficulties(afterThreshold, out var explicitLevelIdxes, out var selectorPart, out var difficultyError))
         {
-            var pos = FindBoundedRightmost(afterThreshold, token);
-            if (pos >= 0)
-            {
-                levelIdxes = [idx];
-                diffAt     = pos;
-                diffLen    = token.Length;
-                break;
-            }
+            error = difficultyError;
+            return false;
         }
 
-        var selectorPart = diffAt >= 0
-            ? (afterThreshold[..diffAt] + afterThreshold[(diffAt + diffLen)..]).Trim()
-            : afterThreshold;
+        var difficultyExplicit = explicitLevelIdxes.Count > 0;
+        IReadOnlyList<int> levelIdxes = difficultyExplicit ? explicitLevelIdxes : DefaultLevelIdxes;
 
         if (selectorPart.Length == 0 && selectors.Count == 0)
         {
@@ -977,7 +967,7 @@ public static class PlateData
             return false;
         }
 
-        if (diffAt < 0)
+        if (!difficultyExplicit)
         {
             if (selectors.Any(s => s is Selector.Level or Selector.Constant))
             {
@@ -1009,6 +999,204 @@ public static class PlateData
 
         query = new Query(selectors, threshold, levelIdxes);
         return true;
+
+        bool TryExtractDifficulties(
+            string source,
+            out IReadOnlyList<int> explicitLevels,
+            out string remaining,
+            out ParseError? parseError)
+        {
+            var levels = new SortedSet<int>();
+            var spans = new List<(int Start, int Length)>();
+
+            for (var at = 0; at < source.Length;)
+            {
+                if (TryMatchDifficultyRange(source, at, out var rangeLength, out var from, out var to))
+                {
+                    var rangeText = source.Substring(at, rangeLength);
+                    if (from > to)
+                    {
+                        explicitLevels = [];
+                        remaining = source;
+                        parseError = new(ErrorKind.InvalidDifficulty,
+                            $"{rangeText}（区间应从低难度写到高难度）");
+                        return false;
+                    }
+
+                    for (var levelIdx = from; levelIdx <= to; levelIdx++) levels.Add(levelIdx);
+                    spans.Add((at, rangeLength));
+                    at += rangeLength;
+                    continue;
+                }
+
+                if (TryMatchDifficultyToken(source, at, out var tokenLength, out var level, out _))
+                {
+                    levels.Add(level);
+                    spans.Add((at, tokenLength));
+                    at += tokenLength;
+                    continue;
+                }
+
+                at++;
+            }
+
+            if (spans.Count == 0)
+            {
+                explicitLevels = [];
+                remaining = source;
+                parseError = null;
+                return true;
+            }
+
+            var remove = new bool[source.Length];
+            foreach (var span in spans) MarkRemoved(span.Start, span.Length);
+
+            var leading = source[..spans[0].Start].TrimEnd();
+            if (EndsWithDifficultyConnector(leading))
+            {
+                explicitLevels = [];
+                remaining = source;
+                parseError = InvalidConnectorError();
+                return false;
+            }
+
+            for (var i = 1; i < spans.Count; i++)
+            {
+                var previousEnd = spans[i - 1].Start + spans[i - 1].Length;
+                var gapLength = spans[i].Start - previousEnd;
+                var gap = source.Substring(previousEnd, gapLength);
+                var trimmedGap = gap.Trim();
+
+                if (trimmedGap.Length == 0 || IsDifficultyListConnector(trimmedGap))
+                {
+                    MarkRemoved(previousEnd, gapLength);
+                    continue;
+                }
+
+                if (trimmedGap == "+" ||
+                    StartsWithDifficultyConnector(trimmedGap) || EndsWithDifficultyConnector(trimmedGap))
+                {
+                    explicitLevels = [];
+                    remaining = source;
+                    parseError = InvalidConnectorError();
+                    return false;
+                }
+            }
+
+            var last = spans[^1];
+            var trailing = source[(last.Start + last.Length)..].TrimStart();
+            if (StartsWithDifficultyConnector(trailing))
+            {
+                explicitLevels = [];
+                remaining = source;
+                parseError = InvalidConnectorError();
+                return false;
+            }
+
+            var builder = new System.Text.StringBuilder(source.Length);
+            for (var i = 0; i < source.Length; i++)
+            {
+                if (!remove[i]) builder.Append(source[i]);
+            }
+
+            explicitLevels = levels.ToArray();
+            remaining = builder.ToString().Trim();
+            parseError = null;
+            return true;
+
+            void MarkRemoved(int start, int length)
+            {
+                for (var i = start; i < start + length; i++) remove[i] = true;
+            }
+        }
+
+        bool TryMatchDifficultyRange(
+            string source,
+            int start,
+            out int length,
+            out int from,
+            out int to)
+        {
+            length = 0;
+            from = -1;
+            to = -1;
+
+            var leftLength = 0;
+            if (!TryMatchDifficultyToken(source, start, out leftLength, out from, out _))
+            {
+                var color = SingleColorEntries.FirstOrDefault(entry => entry.Color == source[start]);
+                if (color == default) return false;
+                leftLength = 1;
+                from = color.LevelIdx;
+            }
+
+            var hyphenAt = SkipWhitespace(source, start + leftLength);
+            if (hyphenAt >= source.Length || source[hyphenAt] is not ('-' or '－')) return false;
+
+            var rightAt = SkipWhitespace(source, hyphenAt + 1);
+            if (!TryMatchDifficultyToken(source, rightAt, out var rightLength, out to, out var rightToken)) return false;
+
+            // 单字色名只允许中文缩写区间「红-紫谱」；列表项仍必须是完整 token。
+            if (leftLength == 1 && (rightToken.Length != 2 || rightToken[1] != '谱')) return false;
+
+            length = rightAt + rightLength - start;
+            return true;
+        }
+
+        bool TryMatchDifficultyToken(
+            string source,
+            int start,
+            out int length,
+            out int levelIdx,
+            out string token)
+        {
+            foreach (var entry in DifficultyEntriesLongestFirst)
+            {
+                if (start + entry.Token.Length > source.Length) continue;
+                if (!source.AsSpan(start, entry.Token.Length)
+                        .Equals(entry.Token.AsSpan(), StringComparison.OrdinalIgnoreCase)) continue;
+
+                if (entry.Token.Any(IsAsciiLetter))
+                {
+                    var before = start > 0 ? source[start - 1] : '\0';
+                    var after = start + entry.Token.Length < source.Length
+                        ? source[start + entry.Token.Length]
+                        : '\0';
+                    if (IsAsciiLetter(before) || IsAsciiLetter(after)) continue;
+                }
+
+                length = entry.Token.Length;
+                levelIdx = entry.LevelIdx;
+                token = entry.Token;
+                return true;
+            }
+
+            length = 0;
+            levelIdx = -1;
+            token = string.Empty;
+            return false;
+        }
+
+        int SkipWhitespace(string source, int start)
+        {
+            while (start < source.Length && char.IsWhiteSpace(source[start])) start++;
+            return start;
+        }
+
+        bool IsDifficultyListConnector(string value) => value is "/" or "／" or "、" or "或";
+
+        bool StartsWithDifficultyConnector(string value) =>
+            value.StartsWith('/') || value.StartsWith('／') || value.StartsWith('、') ||
+            value.StartsWith('或') || value.StartsWith('-') || value.StartsWith('－') ||
+            value.StartsWith(',') || value.StartsWith('，');
+
+        bool EndsWithDifficultyConnector(string value) =>
+            value.EndsWith('/') || value.EndsWith('／') || value.EndsWith('、') ||
+            value.EndsWith('或') || value.EndsWith('-') || value.EndsWith('－') ||
+            value.EndsWith(',') || value.EndsWith('，');
+
+        ParseError InvalidConnectorError() =>
+            new(ErrorKind.InvalidDifficulty, "连接符两侧必须是谱面难度");
 
         bool TryExtractKnownName(string input, out int start, out int length, out Selector? selector)
         {

--- a/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
+++ b/Marisa.Plugin.Test/MaiMaiDxPlateDataTest.cs
@@ -223,6 +223,8 @@ public class MaiMaiDxPlateDataTest
             Check($"{name}神完成表", name, "AP", PlateData.DefaultLevelIdxes);
             Check($"MST{name}完成表", name, "SSS", [3]);
             Check($"{name}MST完成表", name, "SSS", [3]);
+            Check($"红谱/紫谱 {name}完成表", name, "SSS", [2, 3]);
+            Check($"{name} EXP/Re:MASTER完成表", name, "SSS", [2, 4]);
         }
 
         Assert.That(failures, Is.Empty, string.Join(Environment.NewLine, failures));
@@ -643,6 +645,217 @@ public class MaiMaiDxPlateDataTest
     public void RemasterDifficultyParsing(string raw, int expectedLevelIdx)
     {
         Assert.That(MustParse(raw).LevelIdxes, Is.EquivalentTo(new[] {expectedLevelIdx}));
+    }
+
+    [TestCase("真代13红谱/紫谱理论值完成表")]
+    [TestCase("红谱/紫谱理论值真代13完成表")]
+    [TestCase("理论值13真代红谱/紫谱完成表")]
+    public void MultiDifficulty_UserCommandParsesExactQuery(string raw)
+    {
+        var q = MustParse(raw);
+
+        Assert.That(q.Selectors, Has.Exactly(2).Items);
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("真"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13"));
+        Assert.That(q.Threshold.Dim, Is.EqualTo(PlateData.Dimension.Fc));
+        Assert.That(q.Threshold.Level, Is.EqualTo(4));
+        Assert.That(q.Threshold.DisplayName, Is.EqualTo("AP+"));
+        Assert.That(q.LevelIdxes, Is.EqualTo(new[] {2, 3}), "difficulty OR set must be canonical and sorted");
+    }
+
+    [TestCase("真13+红谱/紫谱完成表")]
+    [TestCase("真红谱/紫谱13+完成表")]
+    public void MultiDifficulty_LevelPlusIsNotTreatedAsAListConnector(string raw)
+    {
+        var q = MustParse(raw);
+
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("真"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Level>().Single().Label, Is.EqualTo("13+"));
+        Assert.That(q.LevelIdxes, Is.EqualTo(new[] {2, 3}));
+    }
+
+    [TestCase("真红谱/紫谱完成表",     new[] {2, 3})]
+    [TestCase("真红谱或紫谱完成表",    new[] {2, 3})]
+    [TestCase("真红谱、紫谱完成表",    new[] {2, 3})]
+    [TestCase("真红谱／紫谱完成表",    new[] {2, 3})]
+    [TestCase("真红谱 紫谱完成表",     new[] {2, 3})]
+    [TestCase("真红谱紫谱完成表",      new[] {2, 3})]
+    [TestCase("真EXP/MST完成表",       new[] {2, 3})]
+    [TestCase("真exp 或 mst完成表",    new[] {2, 3})]
+    [TestCase("真EXPERT/紫谱/ReMAS完成表", new[] {2, 3, 4})]
+    public void MultiDifficulty_ListsAcceptSupportedConnectorsAndAliases(string raw, int[] expected)
+    {
+        Assert.That(MustParse(raw).LevelIdxes, Is.EqualTo(expected));
+    }
+
+    [TestCase("真红-紫谱完成表",          new[] {2, 3})]
+    [TestCase("真红-白谱完成表",          new[] {2, 3, 4})]
+    [TestCase("真红谱-白谱完成表",        new[] {2, 3, 4})]
+    [TestCase("真红谱 - 白谱完成表",      new[] {2, 3, 4})]
+    [TestCase("真EXP-MST完成表",           new[] {2, 3})]
+    [TestCase("真红谱－白谱完成表",        new[] {2, 3, 4})]
+    [TestCase("真黄-紫谱/白谱完成表",      new[] {1, 2, 3, 4})]
+    [TestCase("真绿-白谱完成表",           new[] {0, 1, 2, 3, 4})]
+    public void MultiDifficulty_RangesAreInclusiveAndComposeWithLists(string raw, int[] expected)
+    {
+        Assert.That(MustParse(raw).LevelIdxes, Is.EqualTo(expected));
+    }
+
+    [TestCase("真紫谱/红谱完成表",                  new[] {2, 3})]
+    [TestCase("真白谱/红谱/MST/BSC完成表",          new[] {0, 2, 3, 4})]
+    [TestCase("真MST/MASTER/紫谱/EXP/EXPERT完成表", new[] {2, 3})]
+    [TestCase("真Re:MASTER/白谱/ReMAS完成表",       new[] {4})]
+    public void MultiDifficulty_IsSortedAndDeduplicatesAliases(string raw, int[] expected)
+    {
+        Assert.That(MustParse(raw).LevelIdxes, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void MultiDifficulty_LongestMatchProtectsRemaster()
+    {
+        var q = MustParse("真Re:MASTER/MASTER完成表");
+
+        Assert.That(q.LevelIdxes, Is.EqualTo(new[] {3, 4}));
+        Assert.That(q.Selectors, Has.Exactly(1).InstanceOf<PlateData.Selector.Plate>());
+    }
+
+    [TestCase("真M红谱ST完成表", "MST")]
+    [TestCase("真EX红谱PERT完成表", "EXPERT")]
+    public void MultiDifficulty_RemovalDoesNotSynthesizeAnotherDifficultyToken(string raw, string remainder)
+    {
+        var q = MustParse(raw);
+
+        Assert.That(q.LevelIdxes, Is.EqualTo(new[] {2}));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("真"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Charter>().Single().Name, Is.EqualTo(remainder));
+    }
+
+    [Test]
+    public void MultiDifficulty_AdjacentAsciiWordsAreNotSplitIntoDifficultyTokens()
+    {
+        var q = MustParse("真EXPERTMASTER完成表");
+
+        Assert.That(q.LevelIdxes, Is.EqualTo(new[] {3}), "plate default must remain when no bounded token exists");
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("真"));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Charter>().Single().Name, Is.EqualTo("EXPERTMASTER"));
+    }
+
+    [TestCase("真红谱/紫谱完成表",       new[] {2, 3})]
+    [TestCase("13红谱/紫谱完成表",      new[] {2, 3})]
+    [TestCase("14.6红谱/紫谱完成表",    new[] {2, 3})]
+    [TestCase("宴会场红谱/白谱完成表",  new[] {2, 4})]
+    [TestCase("复活曲红谱/白谱完成表",  new[] {2, 4})]
+    [TestCase("舞绿谱/白谱完成表",      new[] {0, 4})]
+    [TestCase("霸者红谱/紫谱完成表",    new[] {2, 3})]
+    public void MultiDifficulty_ExplicitSetOverridesEveryImplicitDefault(string raw, int[] expected)
+    {
+        Assert.That(MustParse(raw).LevelIdxes, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void MultiDifficulty_PreservesSelectorAndSpecialThresholdInteractions()
+    {
+        var level = MustParse("13红谱/紫谱完成表");
+        Assert.That(level.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Level>());
+
+        var constant = MustParse("14.6红谱/紫谱完成表");
+        Assert.That(constant.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Constant>());
+
+        var banquet = MustParse("宴会场红谱/白谱完成表");
+        Assert.That(banquet.Selectors.OfType<PlateData.Selector.Genre>().Single().FullName, Is.EqualTo("宴会場"));
+
+        var revival = MustParse("复活曲红谱/白谱完成表");
+        Assert.That(revival.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Revival>());
+
+        var finale = MustParse("舞绿谱/白谱完成表");
+        Assert.That(finale.Selectors.OfType<PlateData.Selector.Plate>().Single().Scope,
+            Is.EqualTo(PlateData.PlateScope.FinaleAndEarlier));
+
+        var allClear = MustParse("霸者红谱/紫谱完成表");
+        Assert.That(allClear.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo("霸者"));
+        Assert.That(allClear.Threshold.DisplayName, Is.EqualTo("A"));
+    }
+
+    [TestCase("真完成表",      new[] {3})]
+    [TestCase("13完成表",      new[] {0, 1, 2, 3, 4})]
+    [TestCase("14.6完成表",    new[] {0, 1, 2, 3, 4})]
+    [TestCase("宴会场完成表",  new[] {0, 1, 2, 3, 4})]
+    [TestCase("复活曲完成表",  new[] {3, 4})]
+    [TestCase("舞完成表",      new[] {3, 4})]
+    [TestCase("霸者完成表",    new[] {3, 4})]
+    public void MultiDifficulty_FeatureLeavesExistingDefaultsUnchanged(string raw, int[] expected)
+    {
+        Assert.That(MustParse(raw).LevelIdxes, Is.EqualTo(expected));
+    }
+
+    [TestCase("真白谱-红谱完成表")]
+    [TestCase("真MST-EXP完成表")]
+    [TestCase("真红谱/完成表")]
+    [TestCase("真/红谱完成表")]
+    [TestCase("真红谱或完成表")]
+    [TestCase("真红谱、完成表")]
+    [TestCase("真红谱－完成表")]
+    [TestCase("真红谱//紫谱完成表")]
+    [TestCase("真红谱/或紫谱完成表")]
+    [TestCase("真红谱--紫谱完成表")]
+    [TestCase("真红谱-紫谱-白谱完成表")]
+    [TestCase("真红谱+紫谱完成表")]
+    [TestCase("真红谱,紫谱完成表")]
+    [TestCase("真红谱，紫谱完成表")]
+    [TestCase("真红/紫谱完成表")]
+    [TestCase("真红谱/紫完成表")]
+    [TestCase("真红谱/UNKNOWN完成表")]
+    public void MultiDifficulty_RejectsDescendingDanglingAndMalformedExpressions(string raw)
+    {
+        var error = MustFail(raw);
+
+        Assert.That(error.Kind, Is.EqualTo(PlateData.ErrorKind.InvalidDifficulty));
+        Assert.That(error.Detail, Is.Not.Null.And.Not.Empty);
+    }
+
+    [Test]
+    public void MultiDifficulty_ValidExpressionStillRequiresAScopeSelector()
+    {
+        Assert.That(MustFail("红谱/紫谱完成表").Kind, Is.EqualTo(PlateData.ErrorKind.UnknownSelector));
+    }
+
+    [TestCase("紫红谱完成表", "紫", 2)]
+    [TestCase("紫白谱完成表", "紫", 4)]
+    [TestCase("白红谱完成表", "白", 2)]
+    [TestCase("白紫谱完成表", "白", 3)]
+    public void MultiDifficulty_ConcatenatedPlateKanjiAndDifficultyKeepLegacyMeaning(
+        string raw, string plateKanji, int expectedLevelIdx)
+    {
+        var q = MustParse(raw);
+
+        Assert.That(q.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Plate>());
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Plate>().Single().Kanji, Is.EqualTo(plateKanji));
+        Assert.That(q.LevelIdxes, Is.EqualTo(new[] {expectedLevelIdx}));
+    }
+
+    [TestCase("真绿完成表", "绿")]
+    [TestCase("真黄完成表", "黄")]
+    [TestCase("真红完成表", "红")]
+    public void MultiDifficulty_BareColorsOutsideRangesRemainCharterText(string raw, string charter)
+    {
+        var q = MustParse(raw);
+
+        Assert.That(q.LevelIdxes, Is.EqualTo(new[] {3}));
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Charter>().Single().Name, Is.EqualTo(charter));
+    }
+
+    [TestCase("红谱/白谱 SAMBA MASTER 佐藤完成表", "SAMBA MASTER 佐藤", new[] {2, 4})]
+    [TestCase("ちょむP <advanced mix> EXP/MST完成表", "ちょむP <advanced mix>", new[] {2, 3})]
+    public void MultiDifficulty_ExternalExpressionDoesNotSplitReservedWordsInsideKnownNames(
+        string raw, string expectedArtist, int[] expectedLevelIdxes)
+    {
+        var (charters, artists) = LoadKnownNames();
+        var ok = PlateData.TryParse(raw, charters, artists, out var q, out var error);
+
+        Assert.That(ok, Is.True, $"parse failed for '{raw}': {error?.Kind}/{error?.Detail}");
+        Assert.That(q!.Selectors.Single(), Is.InstanceOf<PlateData.Selector.Artist>());
+        Assert.That(q.Selectors.OfType<PlateData.Selector.Artist>().Single().Name, Is.EqualTo(expectedArtist));
+        Assert.That(q.LevelIdxes, Is.EqualTo(expectedLevelIdxes));
     }
 
     // ──────────────────────────────────────────────────────────────────────

--- a/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
+++ b/Marisa.Plugin/MaiMaiDx/MaiMaiDx.MessageHandler.cs
@@ -1399,10 +1399,10 @@ public partial class MaiMaiDx
     private const string PlateUsage =
         "完成表用于查看指定范围内，还有哪些谱面没有达到目标成绩。\n" +
         "\n" +
-        "用法：mai <范围><目标成绩><难度>完成表\n" +
-        "范围、目标成绩、难度的顺序不固定。\n" +
+        "用法：mai <范围><目标成绩><谱面难度>完成表\n" +
+        "范围、目标成绩、谱面难度的顺序不固定。\n" +
         "\n" +
-        "范围必须填写，可以组合多个条件；组合时只保留同时满足所有条件的谱面。\n" +
+        "范围必须填写；多个范围条件需同时满足，多个谱面难度满足任一即可。\n" +
         "  · 版本代字：舞 / 真 / 超 / 橙 / 暁 / 熊 / 華 / 鏡 / 彩 等，可加“代”，如 熊代\n" +
         "  · 谱师：例如 翠楼屋。合作名义也会匹配，如 サファ太 vs 翠楼屋\n" +
         "  · 类别：术力口 / V家 / 东方 / 击中 / 流行 / 动漫 / 其他 / 宴会场 / 舞萌 / 复活曲\n" +
@@ -1416,10 +1416,11 @@ public partial class MaiMaiDx
         "  · 舞舞=FDX，也可以直接写 SSS+ / SS / FC+ / AP+ / FDX+ 等\n" +
         "  · DX 分星档：一星到五星，或 1星到5星\n" +
         "\n" +
-        "难度不写时，普通版本代字默认只查紫谱；舞和其他范围默认查紫谱 + 白谱。\n" +
-        "只查宴会场时默认查全难度。可以显式指定：\n" +
-        "  · 绿谱 / 黄谱 / 红谱 / 紫谱 / 白谱\n" +
-        "  · 或英文缩写 BSC / ADV / EXP / MST\n" +
+        "谱面难度不写时，普通版本代字默认只查紫谱；舞和其他范围默认查紫谱和白谱。\n" +
+        "指定等级或定数时，或只查宴会场时，默认查全难度。可显式指定一个或多个谱面难度：\n" +
+        "  · 单项：绿谱 / 黄谱 / 红谱 / 紫谱 / 白谱，或 BSC / ADV / EXP / MST / Re:MASTER\n" +
+        "  · 多项：用 / 连接，如 红谱/紫谱、EXP/MST；也支持“或”“、”，中文可直接连写，如 红谱紫谱\n" +
+        "  · 区间：用 - 表示从低到高并包含两端，如 红谱-白谱、EXP-MST\n" +
         "\n" +
         "示例：\n" +
         "  mai 真完成表\n" +
@@ -1430,14 +1431,14 @@ public partial class MaiMaiDx
         "  mai HIMEHINA神完成表\n" +
         "  mai 14+大将完成表\n" +
         "  mai 13.5神完成表\n" +
-        "  mai 紫谱将真完成表\n" +
+        "  mai 真代13红谱/紫谱理论值完成表\n" +
         "  mai 镜代V家将完成表\n" +
         "  mai 14+四星完成表";
 
     public static MarisaPluginTrigger.PluginTrigger PlateTrigger => (message, _) =>
         message.Command.EndsWith(PlateData.CommandSuffix);
 
-    [MarisaPluginDoc("查询版本/谱师/类别/作曲家/难度/定数的完成表")]
+    [MarisaPluginDoc("按版本/谱师/类别/作曲家/等级/定数筛选完成表，支持多谱面难度")]
     [MarisaPluginTrigger(typeof(MaiMaiDx), nameof(PlateTrigger))]
     private async Task<MarisaPluginTaskState> Plate(Message message)
     {
@@ -1486,15 +1487,16 @@ public partial class MaiMaiDx
         static string FormatError(PlateData.ParseError err) => err.Kind switch
         {
             PlateData.ErrorKind.UnsupportedPlate     => $"不支持该版本：{err.Detail}",
-            PlateData.ErrorKind.UnknownSelector      => $"无法识别版本/谱师/类别/作曲家/难度/定数：{err.Detail}",
-            PlateData.ErrorKind.EmptyQuery           => "'完成表' 前面要写一个版本代字 / 谱师名 / 类别 / 作曲家名 / 难度 / 定数",
+            PlateData.ErrorKind.InvalidDifficulty    => $"谱面难度格式错误：{err.Detail}",
+            PlateData.ErrorKind.UnknownSelector      => $"无法识别版本/谱师/类别/作曲家/等级/定数：{err.Detail}",
+            PlateData.ErrorKind.EmptyQuery           => "'完成表' 前面要写一个版本代字 / 谱师名 / 类别 / 作曲家名 / 等级 / 定数",
             PlateData.ErrorKind.ConflictingSelector  => $"{err.Detail}只能指定一次",
             _                                        => "命令格式错误",
         };
 
         List<(double Constant, int LevelIdx, MaiMaiSong Song)> SelectCharts(PlateData.Query q)
         {
-            // 默认难度由解析层决定；用户显式给难度（红谱/EXPERT/...）则单元素 list 限定。
+            // 默认难度由解析层决定；用户显式给出一个或多个谱面难度时，按解析得到的集合限定。
             var levelIdxes = q.LevelIdxes;
             // 带「复活曲」selector 时，版本牌放行复活曲（用于「真复活曲」= 首发自该版本的复活曲）。
             var includeRevival = q.Selectors.Any(s => s is PlateData.Selector.Revival);


### PR DESCRIPTION
## 背景

完成表已经支持版本、等级、定数、谱师、类别、作曲家等条件组合，但显式谱面难度一次只能指定一个。

例如：

- `真代13红谱理论值完成表` 可以查看真代 13 级红谱；
- `真代13紫谱理论值完成表` 可以查看真代 13 级紫谱；
- 但无法在一次请求中查看“红谱或紫谱”。

底层 `Query.LevelIdxes`、选谱逻辑和渲染数据本身已经支持多个难度，限制来自解析器只抽取一个显式难度 token。

## 变更

- 显式谱面难度改为集合：集合内部取 OR，与版本、等级、定数等范围条件继续取 AND。
- 支持难度列表：
  - `/`、`／`、`、`、`或`；
  - 中文完整难度词可直接相邻；
  - 空格分隔；
  - 英文全名及既有缩写。
- 支持从低到高、包含两端的连续难度区间，例如 `红谱-白谱`、`红-白谱`、`EXP-MST`。
- 多个难度自动按难度顺序归一化并去重。
- 新增谱面难度格式错误，明确拦截降序区间、悬空或重复连接符、未知列表项等输入。
- 更新完成表帮助文案和命令说明。

## 行为对照

| 指令 | 结果 |
|------|------|
| `真代13红谱/紫谱理论值完成表` | 真代 ∩ 等级 13 ∩ 红谱或紫谱，目标 AP+ |
| `真红谱或紫谱完成表` | 红谱、紫谱，默认目标 SSS |
| `真红谱紫谱完成表` | 中文完整难度词直接相邻，等价于 `红谱/紫谱` |
| `真EXP/MST完成表` | EXPERT、MASTER |
| `真EXPERT/紫谱/ReMAS完成表` | EXPERT、MASTER、Re:MASTER |
| `真红谱/白谱完成表` | 只选 EXPERT、Re:MASTER，不包含 MASTER |
| `真红谱-白谱完成表` | EXPERT 至 Re:MASTER 的闭区间，包含 MASTER |
| `真白谱-红谱完成表` | 报错：区间必须从低难度写到高难度 |
| `红谱/紫谱完成表` | 报错：完成表仍必须提供范围条件 |

## 兼容性与实现

- 未显式指定谱面难度时，现有默认规则不变：
  - 普通版本代字默认 MASTER；
  - 舞、复活曲及一般范围默认 MASTER + Re:MASTER；
  - 含等级或定数、以及只查宴会场时默认全难度。
- 原有单难度写法和全部中英文别名保持不变。
- 显式难度集合继续覆盖版本、等级、定数、宴会场等隐式默认。
- 保留已知谱师和作曲家优先作为整体识别的机制，名称内部的 `MASTER`、`EXP`、`/` 等内容不会被拆成难度列表。
- 保留 `紫红谱`、`紫白谱`、`白红谱`、`白紫谱` 的既有语义：首字仍是版本代字，后面的完整难度词仍是单难度。
- 列表连接符只在两侧均为合法谱面难度时消费，不会全局删除名称中的 `/`、`或` 等字符。
- 难度扫描直接基于原字符串的非重叠片段完成，不会在删除一个 token 后重新识别拼接出的新 token。
- `Re:MASTER`、`ADVANCED`、`EXPERT` 等重叠别名继续使用最长匹配和 ASCII 边界。
- 不支持共享“谱”后缀的 `红紫谱`、省略单项“谱”的 `红/紫谱`，也不使用与 `13+`、`SSS+` 冲突的 `+` 作为列表连接符。
- 查询模型、选谱器及前端数据结构无需调整；本 PR 复用既有多 `LevelIdxes` 筛选和渲染路径。

## 验证

- `MaiMaiDxPlateDataTest`：379/379 通过。
- 独立解析矩阵：2,935/2,935 通过，覆盖 17 个难度别名、1,445 个有序别名对与连接符组合、289 个别名区间、120 个五难度排列及 1,000 个固定种子字段乱序输入。
- 当前曲库 1,038 个运行时有效谱师/作曲家名称分别验证两种外接多难度表达式：2,076/2,076 通过，其中包含 22 个自身带难度 token 的名称。
- 当前仓库固定 `SongInfo.json`（1,362 首）选谱正负控：
  - 真代 ∩ 等级 13 ∩ EXPERT/MASTER：25 张谱面、23 首歌；
  - 同范围 BASIC/ADVANCED：0 张谱面；
  - 宴会场 BASIC/ADVANCED：68 张谱面；
  - 宴会场 EXPERT/MASTER：0 张谱面。
- `DispatcherTest`：33/33 通过。
- 完整 `Marisa.BotDriver.Test`：45/45 通过。
- 完整 Mai 测试：506 通过、2 失败、1 跳过；失败项为 `All_Song_Should_Have_Cover`、`Score_Should_Be_Fetched(920759985)`，堆栈未进入本次解析改动。
- `Marisa.Plugin` build：成功，0 error；干净重建另有 2 个既有 CS9124 warning，文件不在本 PR diff。
- `Marisa.StartUp` build：成功，0 error，包含 Vite 构建；独立 Vite 构建处理 819 modules。
- 文件编码、换行及 `git diff --check` 检查通过。

---

本 PR 的代码实现、测试与验证由 **OpenAI Codex** 完成。

PR Body 由 **OpenAI Codex** 撰写。
